### PR TITLE
Use module.region to get AWS region instead of get_aws_connection_info

### DIFF
--- a/plugins/modules/aws_ses_identity.py
+++ b/plugins/modules/aws_ses_identity.py
@@ -218,8 +218,9 @@ notification_attributes:
             type: bool
 '''
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 import time
 
@@ -530,7 +531,7 @@ def main():
     state = module.params.get("state")
 
     if state == 'present':
-        region = get_aws_connection_info(module, boto3=True)[0]
+        region = module.region
         account_id = get_account_id(module)
         validate_params_for_identity_present(module)
         create_or_update_identity(connection, module, region, account_id)

--- a/plugins/modules/efs_info.py
+++ b/plugins/modules/efs_info.py
@@ -177,10 +177,11 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 
 class EFSConnection(object):
@@ -196,7 +197,7 @@ class EFSConnection(object):
         except Exception as e:
             module.fail_json(msg="Failed to connect to AWS: %s" % to_native(e))
 
-        self.region = get_aws_connection_info(module, boto3=True)[0]
+        self.region = module.region
 
     @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def list_file_systems(self, **kwargs):

--- a/plugins/modules/elasticache_info.py
+++ b/plugins/modules/elasticache_info.py
@@ -223,12 +223,10 @@ elasticache_clusters:
         Environment: test
 '''
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (get_aws_connection_info,
-                                                                     camel_dict_to_snake_dict,
-                                                                     AWSRetry,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 
 try:
@@ -272,7 +270,7 @@ def get_aws_account_id(module):
 
 
 def get_elasticache_clusters(client, module):
-    region = get_aws_connection_info(module, boto3=True)[0]
+    region = module.region
     try:
         clusters = describe_cache_clusters_with_backoff(client, cluster_id=module.params.get('name'))
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:


### PR DESCRIPTION
##### SUMMARY

Simplify the calls and remove the get_aws_connection_info imports

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_ses_identity
efs_info
elasticache_info

##### ADDITIONAL INFORMATION
