### PR TITLE
Use `coverage<5` in integration tests.

### DIFF
--- a/tests/integration/targets/aws_acm/tasks/main.yml
+++ b/tests/integration/targets/aws_acm/tasks/main.yml
@@ -20,7 +20,7 @@
       name:
         - 'botocore<1.13.0,>=1.12.211'
         - boto3
-        - coverage
+        - coverage<5
         - jinja2
         - pyyaml
         - 'pyopenssl>=0.15'

--- a/tests/integration/targets/aws_eks_cluster/tasks/main.yml
+++ b/tests/integration/targets/aws_eks_cluster/tasks/main.yml
@@ -14,7 +14,7 @@
     name:
       - 'botocore<1.10.1'
       - boto3
-      - coverage
+      - coverage<5
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
@@ -33,7 +33,7 @@
     name:
       - 'botocore>1.10.1,<1.12.38'
       - boto3
-      - coverage
+      - coverage<5
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/version_fail_wrapper.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/version_fail_wrapper.yml
@@ -16,7 +16,7 @@
     name:
       - 'botocore<1.10.16'
       - boto3
-      - coverage
+      - coverage<5
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -12,7 +12,7 @@
     name:
       - 'botocore<1.8.4'
       - boto3
-      - coverage
+      - coverage<5
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
@@ -35,7 +35,7 @@
     name:
       - 'botocore>=1.12.60'
       - boto3
-      - coverage
+      - coverage<5
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -13,7 +13,7 @@
       - 'botocore<1.10.30'
       - boto3
       - boto
-      - coverage
+      - coverage<5
       - cryptography
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -29,7 +29,7 @@
       - 'botocore>=1.10.30'
       - boto3
       - boto
-      - coverage
+      - coverage<5
       - cryptography
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"


### PR DESCRIPTION
##### SUMMARY

Coverage versions 5 and later are not supported by ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
