### PR TITLE
Change github url in galaxy.yml from git@ to https://

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ license_file: COPYING
 tags: null
 dependencies:
   amazon.aws: '>=0.1.0'
-repository: git@github.com:ansible-collections/community.aws.git
+repository: https://github.com/ansible-collections/community.amazon.git
 documentation: https://github.com/ansible-collections/community.aws/tree/master/docs
 homepage: https://github.com/ansible-collections/community.aws
 issues: https://github.com/ansible-collections/community.aws/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
Change github url in galaxy.yml from git@ to https://

Galaxy needs to be able to resolve and refer to this url.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
galaxy.yml