### PR TITLE
Fix error in collection name introduced in #17

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ license_file: COPYING
 tags: null
 dependencies:
   amazon.aws: '>=0.1.0'
-repository: https://github.com/ansible-collections/community.amazon.git
+repository: https://github.com/ansible-collections/community.aws.git
 documentation: https://github.com/ansible-collections/community.aws/tree/master/docs
 homepage: https://github.com/ansible-collections/community.aws
 issues: https://github.com/ansible-collections/community.aws/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
Bad copy-pasta while resolving a local merge conflict led to the wrong collection name in galaxy.yml.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
Oops!