### PR TITLE
Add _get_boto_client and STS token management.

### DIFF
--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -24,14 +24,17 @@ options:
     description: The STS access key to use when connecting via session-manager.
     vars:
     - name: ansible_aws_ssm_access_key_id
+    version_added: 1.3.0
   secret_access_key:
     description: The STS secret key to use when connecting via session-manager.
     vars:
     - name: ansible_aws_ssm_secret_access_key
+    version_added: 1.3.0
   session_token:
     description: The STS session token to use when connecting via session-manager.
     vars:
     - name: ansible_aws_ssm_session_token
+    version_added: 1.3.0
   instance_id:
     description: The EC2 instance ID.
     vars:

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -20,6 +20,18 @@ requirements:
 - The control machine must have the aws session manager plugin installed.
 - The remote EC2 linux instance must have the curl installed.
 options:
+  access_key_id:
+    description: The STS access key to use when connecting via session-manager.
+    vars:
+    - name: ansible_aws_ssm_access_key_id
+  secret_access_key:
+    description: The STS secret key to use when connecting via session-manager.
+    vars:
+    - name: ansible_aws_ssm_secret_access_key
+  session_token:
+    description: The STS session token to use when connecting via session-manager.
+    vars:
+    - name: ansible_aws_ssm_session_token
   instance_id:
     description: The EC2 instance ID.
     vars:
@@ -289,8 +301,7 @@ class Connection(ConnectionBase):
         profile_name = ''
         region_name = self.get_option('region')
         ssm_parameters = dict()
-
-        client = boto3.client('ssm', region_name=region_name)
+        client = self._get_boto_client('ssm', region_name=region_name)
         self._client = client
         response = client.start_session(Target=self.instance_id, Parameters=ssm_parameters)
         self._session_id = response['SessionId']
@@ -483,8 +494,26 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method):
         ''' Generate URL for get_object / put_object '''
-        client = boto3.client('s3')
+        client = self._get_boto_client('s3')
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
+
+    def _get_boto_client(self, service, region_name=None):
+        ''' Gets a boto3 client based on the STS token '''
+
+        aws_access_key_id = self.get_option('access_key_id')
+        aws_secret_access_key = self.get_option('secret_access_key')
+        aws_session_token = self.get_option('session_token')
+        if aws_access_key_id is None or aws_secret_access_key is None or aws_session_token is None:
+            aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", None)
+            aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+            aws_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
+        client = boto3.client(
+            service,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            region_name=region_name)
+        return client
 
     @_ssm_retry
     def _file_transport_command(self, in_path, out_path, ssm_action):
@@ -504,7 +533,7 @@ class Connection(ConnectionBase):
             get_command = "curl '%s' -o '%s'" % (
                 self._get_url('get_object', self.get_option('bucket_name'), s3_path, 'GET'), out_path)
 
-        client = boto3.client('s3')
+        client = self._get_boto_client('s3')
         if ssm_action == 'get':
             (returncode, stdout, stderr) = self.exec_command(put_command, in_data=None, sudoable=False)
             with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb') as data:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #24 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add the following parameters to aws_ssm.py connection plugin:
* ansible_aws_ssm_access_key_id
* ansible_aws_ssm_secret_access_key
* ansible_aws_ssm_session_token
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
This implements some basic STS token management, that can be passed as parameters to the task when the aws_ssm connection plugin is involved, the parameters are scoped to the plugin namespace.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
If you have a role that you allowed to assume in a target account, you would need to assume such role in the target account before invoking the task; this example comes from an invocation by using ansible APIs, where even assuming the role in the target account, the connection plugin was still executing under the controller-node account session.
```paste below
flavioel/.virtualenvs/ansible_ssm/lib/python3.6/site-packages/botocore/client.py\", line 626, in _make_api_call\n    raise error_class(parsed_response, operation_name)\nbotocore.errorfactor
y.TargetNotConnected: An error occurred (TargetNotConnected) when calling the StartSession operation: i-01234567890123456 is not connected.\n",
```
By implementing the changes in this PR I am able to pass an STS token as a parameter to the task, letting it execute under the target account context.

This change also allows for backward compatibility as if nothing is specified (no OS environment variables, no parameters) the boto3 client will automatically select the `default` profile configured on the controller.