### PR TITLE
kinesis_stream: Don't mark kstreams `changed` when no encryption actions taken

### DIFF
--- a/changelogs/fragments/23-kinesis_stream-changed.yml
+++ b/changelogs/fragments/23-kinesis_stream-changed.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- kinesis_stream - now returns tags consistently (https://github.com/ansible-collections/community.aws/pull/27).
+- kinesis_stream - now returns changed more accurately (https://github.com/ansible-collections/community.aws/pull/27).
+- kinesis_stream - return values are now the same format when working with both encrypted and un-encrypted streams (https://github.com/ansible-collections/community.aws/pull/27).
+- kinesis_stream - check_mode is now based on the live settings rather than comparisons with a hard coded/fake stream definition (https://github.com/ansible-collections/community.aws/pull/27).

--- a/changelogs/fragments/27-kinesis_stream-do-not-mark-as-changed-no-enc-actions.yaml
+++ b/changelogs/fragments/27-kinesis_stream-do-not-mark-as-changed-no-enc-actions.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - kinesis_stream - fixed issue where streams get marked as changed even if no encryption actions were necessary (https://github.com/ansible/ansible/issues/65928).

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -1229,27 +1229,32 @@ def start_stream_encryption(client, stream_name, encryption_type='', key_id='',
         find_stream(client, stream_name, check_mode=check_mode)
     )
     if stream_found:
-        success, err_msg = (
-            stream_encryption_action(
-                client, stream_name, action='start_encryption', encryption_type=encryption_type, key_id=key_id, check_mode=check_mode
+        if (current_stream.get("EncryptionType") == encryption_type and current_stream.get("KeyId") == key_id):
+            changed = False
+            success = True
+            err_msg = 'Kinesis Stream {0} encryption already configured.'.format(stream_name)
+        else:
+            success, err_msg = (
+                stream_encryption_action(
+                    client, stream_name, action='start_encryption', encryption_type=encryption_type, key_id=key_id, check_mode=check_mode
+                )
             )
-        )
-        if success:
-            changed = True
-            if wait:
-                success, err_msg, results = (
-                    wait_for_status(
-                        client, stream_name, 'ACTIVE', wait_timeout,
-                        check_mode=check_mode
+            if success:
+                changed = True
+                if wait:
+                    success, err_msg, results = (
+                        wait_for_status(
+                            client, stream_name, 'ACTIVE', wait_timeout,
+                            check_mode=check_mode
+                        )
                     )
-                )
-                err_msg = 'Kinesis Stream {0} encryption started successfully.'.format(stream_name)
-                if not success:
-                    return success, True, err_msg, results
-            else:
-                err_msg = (
-                    'Kinesis Stream {0} is in the process of starting encryption.'.format(stream_name)
-                )
+                    err_msg = 'Kinesis Stream {0} encryption started successfully.'.format(stream_name)
+                    if not success:
+                        return success, True, err_msg, results
+                else:
+                    err_msg = (
+                        'Kinesis Stream {0} is in the process of starting encryption.'.format(stream_name)
+                    )
     else:
         success = True
         changed = False
@@ -1301,11 +1306,7 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
                     client, stream_name, action='stop_encryption', key_id=key_id, encryption_type=encryption_type, check_mode=check_mode
                 )
             )
-        elif current_stream.get('EncryptionType') == 'NONE':
-            success = True
-
-        if success:
-            changed = True
+            changed = success
             if wait:
                 success, err_msg, results = (
                     wait_for_status(
@@ -1313,13 +1314,16 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
                         check_mode=check_mode
                     )
                 )
-                err_msg = 'Kinesis Stream {0} encryption stopped successfully.'.format(stream_name)
                 if not success:
                     return success, True, err_msg, results
+                err_msg = 'Kinesis Stream {0} encryption stopped successfully.'.format(stream_name)
             else:
                 err_msg = (
                     'Stream {0} is in the process of stopping encryption.'.format(stream_name)
                 )
+        elif current_stream.get('EncryptionType') == 'NONE':
+            success = True
+            err_msg = 'Kinesis Stream {0} encryption already stopped.'.format(stream_name)
     else:
         success = True
         changed = False

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -657,7 +657,6 @@ def update_shard_count(client, stream_name, number_of_shards=1, check_mode=False
     return success, err_msg
 
 
-
 def update(client, current_stream, stream_name, number_of_shards=1, retention_period=None,
            tags=None, wait=False, wait_timeout=300, check_mode=False):
     """Update an Amazon Kinesis Stream.
@@ -1184,7 +1183,6 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
 
         results = camel_dict_to_snake_dict(results)
         results['tags'] = current_tags
-
 
     return success, changed, err_msg, results
 

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -657,6 +657,7 @@ def update_shard_count(client, stream_name, number_of_shards=1, check_mode=False
     return success, err_msg
 
 
+
 def update(client, current_stream, stream_name, number_of_shards=1, retention_period=None,
            tags=None, wait=False, wait_timeout=300, check_mode=False):
     """Update an Amazon Kinesis Stream.
@@ -1089,6 +1090,19 @@ def start_stream_encryption(client, stream_name, encryption_type='', key_id='',
         changed = False
         err_msg = 'Kinesis Stream {0} does not exist'.format(stream_name)
 
+    if success:
+        stream_found, stream_msg, results = (
+            find_stream(client, stream_name)
+        )
+        tag_success, tag_msg, current_tags = (
+            get_tags(client, stream_name)
+        )
+        if not current_tags:
+            current_tags = dict()
+
+        results = camel_dict_to_snake_dict(results)
+        results['tags'] = current_tags
+
     return success, changed, err_msg, results
 
 
@@ -1112,7 +1126,7 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
     Basic Usage:
         >>> client = boto3.client('kinesis')
         >>> stream_name = 'test-stream'
-        >>> start_stream_encryption(client, stream_name,encryption_type, key_id)
+        >>> stop_stream_encryption(client, stream_name,encryption_type, key_id)
 
     Returns:
         Tuple (bool, bool, str, dict)
@@ -1157,6 +1171,20 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
         success = True
         changed = False
         err_msg = 'Stream {0} does not exist.'.format(stream_name)
+
+    if success:
+        stream_found, stream_msg, results = (
+            find_stream(client, stream_name)
+        )
+        tag_success, tag_msg, current_tags = (
+            get_tags(client, stream_name)
+        )
+        if not current_tags:
+            current_tags = dict()
+
+        results = camel_dict_to_snake_dict(results)
+        results['tags'] = current_tags
+
 
     return success, changed, err_msg, results
 

--- a/tests/integration/targets/kinesis_stream/defaults/main.yml
+++ b/tests/integration/targets/kinesis_stream/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+run_kms_tests: True
 kinesis_stream_name: '{{ resource_prefix }}'
 
 kms_cmk_alias_1: '{{ resource_prefix }}-1'

--- a/tests/integration/targets/kinesis_stream/tasks/main.yml
+++ b/tests/integration/targets/kinesis_stream/tasks/main.yml
@@ -552,8 +552,6 @@
         that:
         - result is success
         - result is not changed
-      # XXX BUG (Enc_idemp)
-      ignore_errors: yes
     # Merge this into the main assertion when the main return keys are
     # snake_cased
     - name: 'Assert expected return values'

--- a/tests/integration/targets/kinesis_stream/tasks/main.yml
+++ b/tests/integration/targets/kinesis_stream/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 # ============================================================
-# Known issues:
-#
-# - (Tag_snake) tag keys get snake_cased in return values
-# - (Tag_changed) changing tags doesn't return changed
-# - (Enc_snake) return values don't get snake_cased when updating encryption
-# - (Enc_disable) disabling encryption Requires key and type be set
-# - (Enc_idemp) Updating encryption settings isn't idempotent
-#
-# ============================================================
 - name: 'Setup AWS Module Defaults'
   module_defaults:
     group/aws:

--- a/tests/integration/targets/kinesis_stream/tasks/main.yml
+++ b/tests/integration/targets/kinesis_stream/tasks/main.yml
@@ -2,9 +2,6 @@
 # ============================================================
 # Known issues:
 #
-# - (CM) check_mode returns changed (always?)
-# - (CM_snake) check_mode returns keys and values that don't directly
-#   map to those from non-check_mode
 # - (Tag_snake) tag keys get snake_cased in return values
 # - (Tag_changed) changing tags doesn't return changed
 # - (Enc_snake) return values don't get snake_cased when updating encryption
@@ -114,8 +111,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Create a basic Kinesis stream - Idempotency'
     kinesis_stream:
@@ -178,8 +173,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Increase the retention period - Idempotency'
     kinesis_stream:
@@ -240,8 +233,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Decrease the retention period - Idempotency'
     kinesis_stream:
@@ -292,8 +283,6 @@
       that:
       - result is changed
       - result.tags == kinesis_stream_tags_1
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Set some tags - Idempotency (CHECK_MODE)'
     check_mode: yes
@@ -306,8 +295,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Set some tags - Idempotency'
     kinesis_stream:
@@ -382,8 +369,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Change some tags - Idempotency'
     kinesis_stream:
@@ -462,8 +447,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Change the number of shards - Idempotency'
     kinesis_stream:
@@ -535,6 +518,7 @@
       kinesis_stream:
         name: '{{ kinesis_stream_name }}'
         encryption_state: 'disabled'
+      register: result
     - name: 'Assert state is not changed when encryption_state not changed (CHECK_MODE)'
       ignore_errors: yes
       assert:
@@ -547,6 +531,7 @@
       kinesis_stream:
         name: '{{ kinesis_stream_name }}'
         encryption_state: 'disabled'
+      register: result
     - name: 'Assert state is not changed when encryption_state not changed (CHECK_MODE)'
       assert:
         that:
@@ -581,6 +566,7 @@
         encryption_state: 'enabled'
         encryption_type: 'KMS'
         key_id: '{{ kms_cmk_id_1 }}'
+      register: result
     - name: 'Assert that state is changed when enabling encryption'
       assert:
         that:
@@ -594,6 +580,7 @@
         encryption_state: 'enabled'
         encryption_type: 'KMS'
         key_id: '{{ kms_cmk_id_2 }}'
+      register: result
     - name: 'Assert state is changed when stream encryption key is changed (CHECK_MODE)'
       assert:
         that:
@@ -606,6 +593,7 @@
         encryption_state: 'enabled'
         encryption_type: 'KMS'
         key_id: '{{ kms_cmk_id_2 }}'
+      register: result
     - name: 'Assert state is changed when stream encryption key is changed'
       assert:
         that:
@@ -674,8 +662,6 @@
       that:
       - result is success
       - result is not changed
-    # XXX BUG (CM)
-    ignore_errors: yes
 
   - name: 'Delete stream - Idempotency'
     module_defaults: { kinesis_stream: {} }

--- a/tests/integration/targets/kinesis_stream/tasks/test_encryption.yml
+++ b/tests/integration/targets/kinesis_stream/tasks/test_encryption.yml
@@ -11,6 +11,9 @@
 # Disable (check_mode)
 # Disable
 #
+# Known issue:
+# - key_id needs to be in the same form as is already set to return changed=False
+#
 - name: 'Enable encryption using {{ key_type }} (CHECK_MODE)'
   check_mode: yes
   kinesis_stream:
@@ -37,11 +40,6 @@
     that:
     - result is success
     - result is changed
-# Merge this into the main assertion when the main return keys are
-# snake_cased
-- name: 'Assert expected return values'
-  assert:
-    that:
     - result.encryption_type == 'KMS'
     - result.key_id in kms_cmk_1
     - result.open_shards_count == 1
@@ -49,17 +47,50 @@
     - result.stream_arn == kinesis_stream_arn
     - result.stream_name == kinesis_stream_name
     - result.stream_status == 'ACTIVE'
-    #- result.tags == kinesis_stream_tags_2
-  # XXX BUG (Enc_snake)
-  ignore_errors: yes
-# Merge this into the main assertion when the tag keys are no longer
-# snake_cased
-- name: 'Assert tags return as expected (tags2)'
+    - result.tags == kinesis_stream_tags_2
+
+- name: 'Re-Enable encryption using {{ key_type }} (CHECK_MODE)'
+  kinesis_stream:
+    name: '{{ kinesis_stream_name }}'
+    encryption_state: 'enabled'
+    encryption_type: 'KMS'
+    key_id: '{{ kinesis_key }}'
+  check_mode: True
+  register: result
+- name: 'Assert that state is not changed when enabling encryption'
   assert:
     that:
+    - result is success
+    - result is not changed
+    - result.encryption_type == 'KMS'
+    - result.key_id in kms_cmk_1
+    - result.open_shards_count == 1
+    - result.retention_period_hours == 48
+    - result.stream_arn == kinesis_stream_arn
+    - result.stream_name == kinesis_stream_name
+    - result.stream_status == 'ACTIVE'
     - result.tags == kinesis_stream_tags_2
-  # XXX BUG (Tag_snake)
-  ignore_errors: yes
+
+- name: 'Re-Enable encryption using {{ key_type }}'
+  kinesis_stream:
+    name: '{{ kinesis_stream_name }}'
+    encryption_state: 'enabled'
+    encryption_type: 'KMS'
+    key_id: '{{ kinesis_key }}'
+  register: result
+- name: 'Assert that state is not changed when enabling encryption'
+  assert:
+    that:
+    - result is success
+    - result is not changed
+    - result.encryption_type == 'KMS'
+    - result.key_id in kms_cmk_1
+    - result.open_shards_count == 1
+    - result.retention_period_hours == 48
+    - result.stream_arn == kinesis_stream_arn
+    - result.stream_name == kinesis_stream_name
+    - result.stream_status == 'ACTIVE'
+    - result.tags == kinesis_stream_tags_2
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and ID (CHECK_MODE)'
   check_mode: yes
@@ -69,11 +100,12 @@
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_id }}'
   register: result
-- name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
+- name: 'Assert state is not changed when comparing {{ key_id }} and ID (CHECK_MODE)'
   assert:
     that:
     - result is success
     - result is not changed
+  ignore_errors: yes
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and ID'
   kinesis_stream:
@@ -82,16 +114,15 @@
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_id }}'
   register: result
-- name: 'Assert that state is changed when enabling encryption'
+- name: 'Assert that state is not changed when comparing {{ key_type }} and ID'
   assert:
     that:
-    - result is success
     - result is not changed
-# Merge this into the main assertion when the main return keys are
-# snake_cased
+  ignore_errors: yes
 - name: 'Assert expected return values'
   assert:
     that:
+    - result is success
     - result.encryption_type == 'KMS'
     - result.key_id in kms_cmk_1
     - result.open_shards_count == 1
@@ -99,17 +130,7 @@
     - result.stream_arn == kinesis_stream_arn
     - result.stream_name == kinesis_stream_name
     - result.stream_status == 'ACTIVE'
-    #- result.tags == kinesis_stream_tags_2
-  # XXX BUG (Enc_snake)
-  ignore_errors: yes
-# Merge this into the main assertion when the tag keys are no longer
-# snake_cased
-- name: 'Assert tags return as expected (tags2)'
-  assert:
-    that:
     - result.tags == kinesis_stream_tags_2
-  # XXX BUG (Tag_snake)
-  ignore_errors: yes
 
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and Alias (CHECK_MODE)'
@@ -120,12 +141,11 @@
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_alias }}'
   register: result
-- name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
+- name: 'Assert state is not changed when comparing {{ key_type }} and Alias (CHECK_MODE)'
   assert:
     that:
     - result is success
     - result is not changed
-  # XXX BUG (Enc_Idemp)
   ignore_errors: yes
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and Alias'
@@ -135,18 +155,15 @@
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_alias }}'
   register: result
-- name: 'Assert that state is changed when enabling encryption'
+- name: 'Assert that state is not changed when comparing {{ key_type }} and Alias'
   assert:
     that:
-    - result is success
     - result is not changed
-  # XXX BUG (Enc_Idemp)
   ignore_errors: yes
-# Merge this into the main assertion when the main return keys are
-# snake_cased
 - name: 'Assert expected return values'
   assert:
     that:
+    - result is success
     - result.encryption_type == 'KMS'
     - result.key_id in kms_cmk_1
     - result.open_shards_count == 1
@@ -154,17 +171,7 @@
     - result.stream_arn == kinesis_stream_arn
     - result.stream_name == kinesis_stream_name
     - result.stream_status == 'ACTIVE'
-    #- result.tags == kinesis_stream_tags_2
-  # XXX BUG (Enc_snake)
-  ignore_errors: yes
-# Merge this into the main assertion when the tag keys are no longer
-# snake_cased
-- name: 'Assert tags return as expected (tags2)'
-  assert:
-    that:
     - result.tags == kinesis_stream_tags_2
-  # XXX BUG (Tag_snake)
-  ignore_errors: yes
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and ARN (CHECK_MODE)'
   check_mode: yes
@@ -174,12 +181,11 @@
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_arn }}'
   register: result
-- name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
+- name: 'Assert state is not changed when comparing {{ key_type }} and ARN (CHECK_MODE)'
   assert:
     that:
     - result is success
     - result is not changed
-  # XXX BUG (Enc_Idemp)
   ignore_errors: yes
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and ARN'
@@ -189,17 +195,15 @@
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_arn }}'
   register: result
-- name: 'Assert that state is changed when enabling encryption'
+- name: 'Assert that state is not changed when comparing {{ key_type }} and ARN'
   assert:
     that:
-    - result is success
     - result is not changed
   ignore_errors: yes
-# Merge this into the main assertion when the main return keys are
-# snake_cased
 - name: 'Assert expected return values'
   assert:
     that:
+    - result is success
     - result.encryption_type == 'KMS'
     - result.key_id in kms_cmk_1
     - result.open_shards_count == 1
@@ -207,27 +211,17 @@
     - result.stream_arn == kinesis_stream_arn
     - result.stream_name == kinesis_stream_name
     - result.stream_status == 'ACTIVE'
-    #- result.tags == kinesis_stream_tags_2
-  # XXX BUG (Enc_snake)
-  ignore_errors: yes
-# Merge this into the main assertion when the tag keys are no longer
-# snake_cased
-- name: 'Assert tags return as expected (tags2)'
-  assert:
-    that:
     - result.tags == kinesis_stream_tags_2
-  # XXX BUG (Tag_snake)
-  ignore_errors: yes
 
 - name: 'Disable encryption (CHECK_MODE)'
   kinesis_stream:
     name: '{{ kinesis_stream_name }}'
     encryption_state: 'disabled'
-    # XXX BUG (Enc_Disable)
     encryption_type: 'KMS'
     # XXX Oddity of Kinesis - This needs to match the existing setting
     key_id: '{{ kinesis_key_arn }}'
   register: result
+  check_mode: yes
 - name: 'Assert state is changed when disabling encryption (CHECK_MODE)'
   assert:
     that:
@@ -238,12 +232,11 @@
   kinesis_stream:
     name: '{{ kinesis_stream_name }}'
     encryption_state: 'disabled'
-    # XXX BUG (Enc_Disable)
     encryption_type: 'KMS'
     # XXX Oddity of Kinesis - This needs to match the existing setting
     key_id: '{{ kinesis_key_arn }}'
   register: result
-- name: 'Assert state is not changed when disabling encryption'
+- name: 'Assert state is changed when disabling encryption'
   assert:
     that:
     - result is success
@@ -254,12 +247,4 @@
     - result.stream_arn == kinesis_stream_arn
     - result.stream_name == kinesis_stream_name
     - result.stream_status == 'ACTIVE'
-    #- result.tags == kinesis_stream_tags_2
-# Merge this into the main assertion when the tag keys are no longer
-# snake_cased
-- name: 'Assert tags return as expected (tags2)'
-  assert:
-    that:
     - result.tags == kinesis_stream_tags_2
-  # XXX BUG (Tag_snake)
-  ignore_errors: yes

--- a/tests/integration/targets/kinesis_stream/tasks/test_encryption.yml
+++ b/tests/integration/targets/kinesis_stream/tasks/test_encryption.yml
@@ -18,6 +18,7 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key }}'
+  register: result
 - name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
   assert:
     that:
@@ -30,6 +31,7 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key }}'
+  register: result
 - name: 'Assert that state is changed when enabling encryption'
   assert:
     that:
@@ -66,13 +68,12 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_id }}'
+  register: result
 - name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
   assert:
     that:
     - result is success
     - result is not changed
-  # XXX BUG (Enc_Idemp)
-  ignore_errors: yes
 
 - name: 'Test encryption idempotency comparing {{ key_type }} and ID'
   kinesis_stream:
@@ -80,13 +81,12 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_id }}'
+  register: result
 - name: 'Assert that state is changed when enabling encryption'
   assert:
     that:
     - result is success
     - result is not changed
-  # XXX BUG (Enc_Idemp)
-  ignore_errors: yes
 # Merge this into the main assertion when the main return keys are
 # snake_cased
 - name: 'Assert expected return values'
@@ -119,6 +119,7 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_alias }}'
+  register: result
 - name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
   assert:
     that:
@@ -133,6 +134,7 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_alias }}'
+  register: result
 - name: 'Assert that state is changed when enabling encryption'
   assert:
     that:
@@ -171,6 +173,7 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_arn }}'
+  register: result
 - name: 'Assert state is changed when enabling encryption (CHECK_MODE)'
   assert:
     that:
@@ -185,12 +188,12 @@
     encryption_state: 'enabled'
     encryption_type: 'KMS'
     key_id: '{{ kinesis_key_arn }}'
+  register: result
 - name: 'Assert that state is changed when enabling encryption'
   assert:
     that:
     - result is success
     - result is not changed
-  # XXX BUG (Enc_Idemp)
   ignore_errors: yes
 # Merge this into the main assertion when the main return keys are
 # snake_cased
@@ -224,9 +227,8 @@
     encryption_type: 'KMS'
     # XXX Oddity of Kinesis - This needs to match the existing setting
     key_id: '{{ kinesis_key_arn }}'
+  register: result
 - name: 'Assert state is changed when disabling encryption (CHECK_MODE)'
-  # XXX BUG (CM)
-  ignore_errors: yes
   assert:
     that:
     - result is success
@@ -240,7 +242,8 @@
     encryption_type: 'KMS'
     # XXX Oddity of Kinesis - This needs to match the existing setting
     key_id: '{{ kinesis_key_arn }}'
-- name: 'Assert state is not changed when disabling encryption (CHECK_MODE)'
+  register: result
+- name: 'Assert state is not changed when disabling encryption'
   assert:
     that:
     - result is success


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/65928

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/65928.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kinesis_stream

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Do a few extra conditional checks when running to avoid reporting changes if the stream already matches the desired configuration.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [localhost] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "aws_access_key": null, 
            "aws_config": null, 
            "aws_secret_key": null, 
            "debug_botocore_endpoint_logs": false, 
            "ec2_url": null, 
            "encryption_state": "disabled", 
            "encryption_type": "KMS", 
            "key_id": "alias/aws/kinesis", 
            "name": "tyler-test", 
            "profile": null, 
            "region": null, 
            "retention_period": 24, 
            "security_token": null, 
            "shards": 1, 
            "state": "present", 
            "tags": null, 
            "validate_certs": true, 
            "wait": true, 
            "wait_timeout": 300
        }
    }, 
    "msg": "Kinesis Stream tyler-test encryption already stopped.", 
    "success": true

```
