### PR TITLE
fix: don't create aws_kms keys when in check mode

### DIFF
--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -828,12 +828,14 @@ def create_key(connection, module):
         result = connection.create_key(**params)['KeyMetadata']
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to create initial key")
+
     key = get_key_details(connection, module, result['KeyId'])
     update_alias(connection, module, key, module.params['alias'])
     update_key_rotation(connection, module, key, module.params.get('enable_key_rotation'))
 
     ensure_enabled_disabled(connection, module, key, module.params.get('enabled'))
     update_grants(connection, module, key, module.params.get('grants'), False)
+
     # make results consistent with kms_facts
     result = get_key_details(connection, module, key['key_id'])
     result['changed'] = True

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -836,6 +836,7 @@ def create_key(connection, module):
     update_grants(connection, module, key, module.params.get('grants'), False)
     # make results consistent with kms_facts
     result = get_key_details(connection, module, key['key_id'])
+    result['changed'] = True
     return result
 
 

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -816,13 +816,14 @@ def create_key(connection, module):
                   Tags=ansible_dict_to_boto3_tag_list(module.params['tags'], tag_name_key_name='TagKey', tag_value_key_name='TagValue'),
                   KeyUsage='ENCRYPT_DECRYPT',
                   Origin='AWS_KMS')
+
+    if module.check_mode:
+        return {'changed': True}
+
     if module.params.get('description'):
         params['Description'] = module.params['description']
     if module.params.get('policy'):
         params['Policy'] = module.params['policy']
-
-    if module.check_mode:
-        return {'changed': True}
 
     try:
         result = connection.create_key(**params)['KeyMetadata']

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -822,7 +822,7 @@ def create_key(connection, module):
         params['Policy'] = module.params['policy']
 
     if module.check_mode:
-        return {'changed': True }
+        return {'changed': True}
 
     try:
         result = connection.create_key(**params)['KeyMetadata']

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -40,6 +40,7 @@
           Hello: World
         state: present
         enabled: yes
+      register: create_kms_check
 
     - name: find facts about the check mode key
       aws_kms_info:
@@ -47,10 +48,11 @@
           alias: "{{ resource_prefix }}-kms-check"
       register: check_key
 
-    - name: ensure that the check mode key wasn't created
+    - name: ensure that check mode worked as expected
       assert:
         that:
           - check_key["keys"]|length == 0
+          - create_kms_check is changed
 
     - name: create a key
       aws_kms:
@@ -90,7 +92,11 @@
       aws_kms:
         alias: "{{ resource_prefix }}-kms"
         state: absent
+      register: delete_kms_check
 
+    - assert:
+        that:
+          - delete_kms_check is changed
 
     - name: find facts about the key
       aws_kms_info:

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -32,6 +32,26 @@
         filters:
           alias: "{{ resource_prefix }}-kms"
 
+    - name: create a key in check mode
+      check_mode: yes
+      aws_kms:
+        alias: "{{ resource_prefix }}-kms-check"
+        tags:
+          Hello: World
+        state: present
+        enabled: yes
+
+    - name: find facts about the check mode key
+      aws_kms_info:
+        filters:
+          alias: "{{ resource_prefix }}-kms-check"
+      register: check_key
+
+    - name: ensure that the check mode key wasn't created
+      assert:
+        that:
+          - check_key["keys"]|length == 0
+
     - name: create a key
       aws_kms:
         alias: "{{ resource_prefix }}-kms"
@@ -65,6 +85,13 @@
           - create_kms.tags['Hello'] == 'World'
           - create_kms.enable_key_rotation == true
 
+    - name: delete the key in check mode
+      check_mode: yes
+      aws_kms:
+        alias: "{{ resource_prefix }}-kms"
+        state: absent
+
+
     - name: find facts about the key
       aws_kms_info:
         filters:
@@ -76,6 +103,7 @@
         that:
           - new_key["keys"]|length == 1
           - new_key["keys"][0]["enable_key_rotation"] == true
+          - new_key["keys"][0]["key_state"] != PendingDeletion
 
     - name: Update Policy on key to match AWS Console generate policy
       aws_kms:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/68019

https://github.com/ansible/ansible/issues/68019
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_kms

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When running aws_kms for key creation in check mode, check mode is ignored and the key is actually created. This commit solves this. See issue description for more details.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
(venv) tyler@func-platform:~/Repos/ansible-fork$ ansible-playbook tyler-test.yml --check
TASK [Create KMS key] *********************************************************************************************************************************************************************************************
task path: /home/tyler/Repos/ansible-fork/tyler-test.yml:5
changed: [localhost] => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "alias": "test-kms-key", 
            "aws_access_key": null, 
            "aws_config": null, 
            "aws_secret_key": null, 
            "debug_botocore_endpoint_logs": false, 
            "description": null, 
            "ec2_url": null, 
            "enable_key_rotation": null, 
            "enabled": true, 
            "grants": [], 
            "key_id": null, 
            "policy": null, 
            "policy_clean_invalid_entries": true, 
            "policy_grant_types": null, 
            "policy_mode": "grant", 
            "policy_role_arn": null, 
            "policy_role_name": null, 
            "profile": null, 
            "purge_grants": false, 
            "purge_tags": false, 
            "region": null, 
            "security_token": null, 
            "state": "present", 
            "tags": {}, 
            "validate_certs": true
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

(venv) tyler@func-platform:~/Repos/ansible-fork$ aws kms list-aliases | grep test-kms-key
(venv) tyler@func-platform:~/Repos/ansible-fork$ 
```