### PR TITLE
fix: Cloudfront distribution now uses provided origin_access_identity

### DIFF
--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1685,10 +1685,15 @@ class CloudFrontValidationManager(object):
             self.module.fail_json_aws(e, msg="Error validating distribution origins")
 
     def validate_s3_origin_configuration(self, client, existing_config, origin):
-        if origin['s3_origin_access_identity_enabled'] and existing_config.get('s3_origin_config', {}).get('origin_access_identity'):
-            return existing_config['s3_origin_config']['origin_access_identity']
         if not origin['s3_origin_access_identity_enabled']:
             return None
+
+        if origin.get('s3_origin_config', {}).get('origin_access_identity'):
+            return origin['s3_origin_config']['origin_access_identity']
+
+        if existing_config.get('s3_origin_config', {}).get('origin_access_identity'):
+            return existing_config['s3_origin_config']['origin_access_identity']
+
         try:
             comment = "access-identity-by-ansible-%s-%s" % (origin.get('domain_name'), self.__default_datetime_string)
             caller_reference = "%s-%s" % (origin.get('domain_name'), self.__default_datetime_string)

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -414,14 +414,14 @@
     cloudfront_distribution:
       distribution_id: "{{ distribution_id }}"
       origins:
-        - id: "{{ targetBucket }}"
-          domain_name: "{{ targetBucket }}.s3.amazonaws.com"
+        - id: "{{ resource_prefix }}"
+          domain_name: "{{ resource_prefix }}.s3.amazonaws.com"
           s3_origin_access_identity_enabled: true
           s3_origin_config:
             origin_access_identity: origin-access-identity/cloudfront/ANYTHING
     register: update_distribution_with_specific_access_identity
 
-  - name: check that custom origin with origin access identity fails
+  - name: check that custom origin uses the provided origin_access_identity
     assert:
       that:
         - update_distribution_with_specific_access_identity.changed

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -410,6 +410,23 @@
       that:
         - update_origin_to_s3_with_origin_access_and_with_custom_origin_config.failed
 
+  - name: Update distribution to use specific access identity
+    cloudfront_distribution_fixed:
+      distribution_id: "{{ distribution_id }}"
+      origins:
+        - id: "{{ targetBucket }}"
+          domain_name: "{{ targetBucket }}.s3.amazonaws.com"
+          s3_origin_access_identity_enabled: true
+          s3_origin_config:
+            origin_access_identity: origin-access-identity/cloudfront/ANYTHING
+    register: update_distribution_with_specific_access_identity
+
+  - name: check that custom origin with origin access identity fails
+    assert:
+      that:
+        - update_distribution_with_specific_access_identity.changed
+        - update_distribution_with_specific_access_identity.origins.items[0].s3_origin_config.origin_access_identity == 'origin-access-identity/cloudfront/ANYTHING'
+
   always:
   # TEARDOWN STARTS HERE
   - name: delete the s3 bucket

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -411,7 +411,7 @@
         - update_origin_to_s3_with_origin_access_and_with_custom_origin_config.failed
 
   - name: Update distribution to use specific access identity
-    cloudfront_distribution_fixed:
+    cloudfront_distribution:
       distribution_id: "{{ distribution_id }}"
       origins:
         - id: "{{ targetBucket }}"


### PR DESCRIPTION
##### SUMMARY

- This PR was originally opened at https://github.com/ansible/ansible/pull/68845

- Currently, a new access-identity is created even though the parameters specify a given access-identity ID in `origin.s3_origin_config.origin_access_identity`. 

- It will instead a new access-identity instead of using the provided `origin-access-identity/cloudfront/ANYTHING`

- This PR adds the retrieval of `origin.s3_origin_config.origin_access_identity` when applicable

```
- name: Create associated Cloudfront distribution
  cloudfront_distribution_fixed:
    # <other parameters omitted, see below for full parameters
    origins:
      - id: "{{ targetBucket }}"
        domain_name: "{{ targetBucket }}.s3.amazonaws.com"
        s3_origin_access_identity_enabled: true
        s3_origin_config:
          origin_access_identity: origin-access-identity/cloudfront/ANYTHING
```
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- [cloudfront_distribution](lib/ansible/modules/cloud/amazon/cloudfront_distribution.py)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

###### Call parameters

```yaml
# https://docs.ansible.com/ansible/latest/modules/cloudfront_distribution_module.html
# NOTE: "region" must be "us-east-1" as per https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-invalid-viewer-certificate/
- name: Create associated Cloudfront distribution
  cloudfront_distribution_fixed:
    alias: "{{ targetBucket }}"
    aws_access_key: "{{ VAULT_AWS_ACCESS_KEY }}"
    aws_secret_key: "{{ VAULT_AWS_SECRET_KEY }}"
    caller_reference: "{{ targetBucket }}"
    comment: "{{ targetBucket }} distribution created by Ansible"
      allowed_methods:
        items:
          - GET
          - HEAD
          - OPTIONS
        cached_methods:
          - GET
          - HEAD
      compress: true
      forwarded_values:
        cookies:
          forward: none
        headers:
          - Access-Control-Request-Headers
          - Access-Control-Request-Method
          - Origin
        query_string: false
      target_origin_id: "{{ targetBucket }}"
      trusted_signers:
        enabled: true
        items:
          - self
      viewer_protocol_policy: redirect-to-https
    ipv6_enabled: yes
    origins:
      - id: "{{ targetBucket }}"
        domain_name: "{{ targetBucket }}.s3.amazonaws.com"
        s3_origin_access_identity_enabled: true
        s3_origin_config:
          origin_access_identity: origin-access-identity/cloudfront/ANYTHING
    region: us-east-1
    state: present
    viewer_certificate:
      acm_certificate_arn: "{{ aws_certificate_arn }}"
      certificate_source: acm
      minimum_protocol_version: TLSv1.1_2016
      ssl_support_method: sni-only
  register: distribution_data
```

###### Output (with fix)

```yaml
TASK [../roles/deployments/setup_s3 : Create associated Cloudfront distribution] ************************************************************************************************************************************
Friday 10 April 2020  16:50:23 +0200 (0:00:00.034)       0:00:46.841 ********** 
changed: [REDACTED] => {
    "active_trusted_signers": {
        "enabled": true, 
        "items": [
            {
                "aws_account_number": "self", 
                "key_pair_ids": {
                    "items": [
                        "REDACTED", 
                        "REDACTED"
                    ], 
                    "quantity": 2
                }
            }
        ], 
        "quantity": 1
    }, 
    "alias_icp_recordals": [
        {
            "cname": "REDACTED", 
            "icp_recordal_status": "APPROVED"
        }
    ], 
    "aliases": {
        "items": [
            "REDACTED"
        ], 
        "quantity": 1
    }, 
    "arn": "arn:aws:cloudfront::REDACTED:distribution/REDACTED", 
    "cache_behaviors": {
        "quantity": 0
    }, 
    "caller_reference": "REDACTED", 
    "changed": true, 
    "comment": "REDACTED distribution created by Ansible", 
    "custom_error_responses": {
        "quantity": 0
    }, 
    "default_cache_behavior": {
        "allowed_methods": {
            "cached_methods": {
                "items": [
                    "HEAD", 
                    "GET"
                ], 
                "quantity": 2
            }, 
            "items": [
                "HEAD", 
                "GET", 
                "OPTIONS"
            ], 
            "quantity": 3
        }, 
        "compress": true, 
        "default_ttl": 86400, 
        "field_level_encryption_id": "", 
        "forwarded_values": {
            "cookies": {
                "forward": "none"
            }, 
            "headers": {
                "items": [
                    "Origin", 
                    "Access-Control-Request-Method", 
                    "Access-Control-Request-Headers"
                ], 
                "quantity": 3
            }, 
            "query_string": false, 
            "query_string_cache_keys": {
                "quantity": 0
            }
        }, 
        "lambda_function_associations": {
            "quantity": 0
        }, 
        "max_ttl": 31536000, 
        "min_ttl": 0, 
        "smooth_streaming": false, 
        "target_origin_id": "REDACTED", 
        "trusted_signers": {
            "enabled": true, 
            "items": [
                "self"
            ], 
            "quantity": 1
        }, 
        "viewer_protocol_policy": "redirect-to-https"
    }, 
    "default_root_object": "", 
    "domain_name": "REDACTED.cloudfront.net", 
    "enabled": true, 
    "http_version": "http2", 
    "id": "REDACTED", 
    "in_progress_invalidation_batches": 0, 
    "is_ipv6_enabled": true, 
    "last_modified_time": "2020-04-10T14:50:31.744000+00:00", 
    "logging": {
        "bucket": "", 
        "enabled": false, 
        "include_cookies": false, 
        "prefix": ""
    }, 
    "origin_groups": {
        "quantity": 0
    }, 
    "origins": {
        "items": [
            {
                "custom_headers": {
                    "quantity": 0
                }, 
                "domain_name": "REDACTED", 
                "id": "REDACTED", 
                "origin_path": "", 
                "s3_origin_config": {
                    "origin_access_identity": "origin-access-identity/cloudfront/ANYTHING"
                }
            }
        ], 
        "quantity": 1
    }, 
    "price_class": "PriceClass_All", 
    "restrictions": {
        "geo_restriction": {
            "quantity": 0, 
            "restriction_type": "none"
        }
    }, 
    "status": "InProgress", 
    "viewer_certificate": {
        "acm_certificate_arn": "arn:aws:acm:us-east-1:REDACTED:certificate/REDACTED", 
        "certificate": "arn:aws:acm:us-east-1:REDACTED:certificate/REDACTED", 
        "certificate_source": "acm", 
        "minimum_protocol_version": "TLSv1.1_2016", 
        "ssl_support_method": "sni-only"
    }, 
    "web_acl_id": ""
}
```