### PR TITLE
aws_kms: Fix policy arg to actually work with JSON strings that is needs

### DIFF
--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -234,7 +234,7 @@ EXAMPLES = '''
 - name: Example using lookup for policy json
   aws_kms:
     alias: my-kms-key
-    policy: "{{ lookup('template', 'kms_iam_policy_template.json.js') }}"
+    policy: "{{ lookup('template', 'kms_iam_policy_template.json.j2') }}"
     state: present
 '''
 

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -166,7 +166,7 @@ options:
     description:
       - policy to apply to the KMS key. Provide a valid JSON string.
       - See U(https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
-    type: str
+    type: json
 author:
   - Ted Timmons (@tedder)
   - Will Thames (@willthames)

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -164,7 +164,7 @@ options:
             type: dict
   policy:
     description:
-      - policy to apply to the KMS key. Provide a valid JSON string.
+      - policy to apply to the KMS key.
       - See U(https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
     type: json
 author:

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -228,7 +228,7 @@ EXAMPLES = '''
 - name: Update IAM policy on an existing KMS key
   aws_kms:
     alias: my-kms-key
-    policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [{ "Sid": "AllowIAMAccess", "Effect": "Allow", "Principal": { "AWS": "arn:aws:iam::123:root" },"Action": "kms:*", "Resource": "*" } ]}'
+    policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present
 
 - name: Example using lookup for policy json

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -164,7 +164,7 @@ options:
             type: dict
   policy:
     description:
-      - policy to apply to the KMS key
+      - policy to apply to the KMS key. Provide a valid JSON string.
       - See U(https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
     type: str
 author:
@@ -224,6 +224,18 @@ EXAMPLES = '''
         operations:
           - Decrypt
           - RetireGrant
+
+- name: Update IAM policy on an existing KMS key
+  aws_kms:
+    alias: my-kms-key
+    policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [{ "Sid": "AllowIAMAccess", "Effect": "Allow", "Principal": { "AWS": "arn:aws:iam::123:root" },"Action": "kms:*", "Resource": "*" } ]}'
+    state: present
+
+- name: Example using lookup for policy json
+  aws_kms:
+    alias: my-kms-key
+    policy: "{{ lookup('template', 'kms_iam_policy_template.json.js') }}"
+    state: present
 '''
 
 RETURN = '''
@@ -1017,7 +1029,7 @@ def main():
         tags=dict(type='dict', default={}),
         purge_tags=dict(type='bool', default=False),
         grants=dict(type='list', default=[]),
-        policy=dict(),
+        policy=dict(type='json'),
         purge_grants=dict(type='bool', default=False),
         state=dict(default='present', choices=['present', 'absent']),
         enable_key_rotation=(dict(type='bool'))


### PR DESCRIPTION
##### SUMMARY
It was impossible for me to pass in a string into the `policy` arg of the `aws_kms` module as it always parsed the string as dict and then wrapped it into a string somehow, so it always failed to parse the contents as JSON within the module as all quotes would have been changed to single quotes.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
aws_kms module
