### PR TITLE
Fix docs issues in aws_s3_bucket_info and ec2_vpc_vpn

### DIFF
--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -47,7 +47,7 @@ buckets:
   description: "List of buckets"
   returned: always
   sample:
-    - creation_date: 2017-07-06 15:05:12 +00:00
+    - creation_date: '2017-07-06 15:05:12 +00:00'
       name: my_bucket
   type: list
 '''

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -288,7 +288,7 @@ vgw_telemetry:
     vgw_telemetry: [{
                      'outside_ip_address': 'string',
                      'status': 'up',
-                     'last_status_change': datetime(2015, 1, 1),
+                     'last_status_change': 'datetime(2015, 1, 1)',
                      'status_message': 'string',
                      'accepted_route_count': 123
                     }]


### PR DESCRIPTION
##### SUMMARY
Fixes #40, fixes #41. With these fixes, `ansible-doc --json` should no longer crash on these modules.

The value for `ec2_vpc_vpn` is probably not correct, but at least it is a lot better than the current one (which is totally not JSON).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_s3_bucket_info
ec2_vpc_vpn
