### PR TITLE
Add direct_connect_gateway_id to virtual_interface

### DIFF
--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.CreatePrivateVirtualInterface_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.CreatePrivateVirtualInterface_1.json
@@ -1,0 +1,52 @@
+{
+  "status_code": 200,
+  "data": {
+    "ownerAccount": "123412341234",
+    "virtualInterfaceId": "dxvif-aaaaaaaa",
+    "location": "EqSe2",
+    "connectionId": "dxcon-aaaaaaaa",
+    "virtualInterfaceType": "private",
+    "virtualInterfaceName": "aaaaaaaa",
+    "vlan": 2,
+    "asn": 123,
+    "amazonSideAsn": 64512,
+    "authKey": "aaaabbbb",
+    "amazonAddress": "169.254.0.2/30",
+    "customerAddress": "169.254.0.1/30",
+    "addressFamily": "ipv4",
+    "virtualInterfaceState": "down",
+    "customerRouterConfig": "",
+    "mtu": 1500,
+    "jumboFrameCapable": true,
+    "virtualGatewayId": "",
+    "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "routeFilterPrefixes": [],
+    "bgpPeers": [
+      {
+        "bgpPeerId": "dxpeer-aaaaaaa",
+        "asn": 123,
+        "authKey": "aaaabbbb",
+        "addressFamily": "ipv4",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "bgpPeerState": "available",
+        "bgpStatus": "down",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+      }
+    ],
+    "region": "us-west-2",
+    "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+    "tags": [],
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    }
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,18 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.DescribeVirtualInterfaces_2.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.DescribeVirtualInterfaces_2.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.DescribeVirtualInterfaces_3.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_private_vi/directconnect.DescribeVirtualInterfaces_3.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.CreatePublicVirtualInterface_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.CreatePublicVirtualInterface_1.json
@@ -1,0 +1,52 @@
+{
+  "status_code": 200,
+  "data": {
+    "ownerAccount": "123412341234",
+    "virtualInterfaceId": "dxvif-aaaaaaaa",
+    "location": "EqSe2",
+    "connectionId": "dxcon-aaaaaaaa",
+    "virtualInterfaceType": "private",
+    "virtualInterfaceName": "aaaaaaaa",
+    "vlan": 2,
+    "asn": 123,
+    "amazonSideAsn": 64512,
+    "authKey": "aaaabbbb",
+    "amazonAddress": "169.254.0.2/30",
+    "customerAddress": "169.254.0.1/30",
+    "addressFamily": "ipv4",
+    "virtualInterfaceState": "down",
+    "customerRouterConfig": "",
+    "mtu": 1500,
+    "jumboFrameCapable": true,
+    "virtualGatewayId": "",
+    "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "routeFilterPrefixes": [],
+    "bgpPeers": [
+      {
+        "bgpPeerId": "dxpeer-aaaaaaa",
+        "asn": 123,
+        "authKey": "aaaabbbb",
+        "addressFamily": "ipv4",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "bgpPeerState": "available",
+        "bgpStatus": "down",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+      }
+    ],
+    "region": "us-west-2",
+    "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+    "tags": [],
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    }
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,18 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.DescribeVirtualInterfaces_2.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.DescribeVirtualInterfaces_2.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.DescribeVirtualInterfaces_3.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/create_public_vi/directconnect.DescribeVirtualInterfaces_3.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/delete_vi/directconnect.DeleteVirtualInterface_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/delete_vi/directconnect.DeleteVirtualInterface_1.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    }
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/delete_vi/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/delete_vi/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_by_connection_id/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_by_connection_id/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_by_name/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_by_name/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_by_vi_id/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_by_vi_id/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,56 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_returns_missing_for_vi_id/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_returns_missing_for_vi_id/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,18 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+    ]
+  }
+}

--- a/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_returns_multiple/directconnect.DescribeVirtualInterfaces_1.json
+++ b/tests/unit/modules/placebo_recordings/aws_direct_connect_virtual_interface/find_unique_vi_returns_multiple/directconnect.DescribeVirtualInterfaces_1.json
@@ -1,0 +1,94 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 27 Jun 2017 16:29:00 GMT",
+        "content-length": "18"
+      },
+      "RequestId": "b9e352dd-5b55-11e7-9750-d97c605bdcae",
+      "HTTPStatusCode": 200
+    },
+    "virtualInterfaces": [
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-aaaaaaaa",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      },
+      {
+        "ownerAccount": "123412341234",
+        "virtualInterfaceId": "dxvif-bbbbbbbb",
+        "location": "EqSe2",
+        "connectionId": "dxcon-aaaaaaaa",
+        "virtualInterfaceType": "private",
+        "virtualInterfaceName": "bbbbbbbb",
+        "vlan": 2,
+        "asn": 123,
+        "amazonSideAsn": 64512,
+        "authKey": "aaaabbbb",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualInterfaceState": "down",
+        "customerRouterConfig": "",
+        "mtu": 1500,
+        "jumboFrameCapable": true,
+        "virtualGatewayId": "",
+        "directConnectGatewayId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "routeFilterPrefixes": [],
+        "bgpPeers": [
+          {
+            "bgpPeerId": "dxpeer-aaaaaaa",
+            "asn": 123,
+            "authKey": "aaaabbbb",
+            "addressFamily": "ipv4",
+            "amazonAddress": "169.254.0.2/30",
+            "customerAddress": "169.254.0.1/30",
+            "bgpPeerState": "available",
+            "bgpStatus": "down",
+            "awsDeviceV2": "EqSe2-aaaaaaaaaaaa"
+          }
+        ],
+        "region": "us-west-2",
+        "awsDeviceV2": "EqSe2-aaaaaaaaaaaa",
+        "tags": []
+      }
+    ]
+  }
+}

--- a/tests/unit/modules/test_aws_direct_connect_virtual_interface.py
+++ b/tests/unit/modules/test_aws_direct_connect_virtual_interface.py
@@ -1,0 +1,223 @@
+# (c) 2017 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
+from ansible_collections.community.aws.plugins.modules import aws_direct_connect_virtual_interface
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception("FAIL")
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+def test_find_unique_vi_by_connection_id(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    vi_id = aws_direct_connect_virtual_interface.find_unique_vi(client, "dxcon-aaaaaaaa", None, None)
+    assert vi_id == "dxvif-aaaaaaaa"
+
+
+def test_find_unique_vi_by_vi_id(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    vi_id = aws_direct_connect_virtual_interface.find_unique_vi(client,
+                                                                None,
+                                                                "dxvif-aaaaaaaaa",
+                                                                None)
+    assert vi_id == "dxvif-aaaaaaaa"
+
+
+def test_find_unique_vi_by_name(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    vi_id = aws_direct_connect_virtual_interface.find_unique_vi(client, None, None, "aaaaaaaa")
+    assert vi_id == "dxvif-aaaaaaaa"
+
+
+def test_find_unique_vi_returns_multiple(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    module = FakeModule(state="present",
+                        id_to_associate="dxcon-aaaaaaaa",
+                        public=False,
+                        name=None)
+    try:
+        aws_direct_connect_virtual_interface.ensure_state(
+            client,
+            module
+        )
+    except Exception:
+        assert "Multiple virtual interfaces were found" in module.exit_kwargs["msg"]
+
+
+def test_find_unique_vi_returns_missing_for_vi_id(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    module = FakeModule(state="present",
+                        id_to_associate=None,
+                        public=False,
+                        name=None,
+                        virtual_interface_id="dxvif-aaaaaaaa")
+    try:
+        aws_direct_connect_virtual_interface.ensure_state(
+            client,
+            module
+        )
+    except Exception:
+        assert "The virtual interface dxvif-aaaaaaaa does not exist" in module.exit_kwargs["msg"]
+
+
+def test_construct_public_vi():
+    module = FakeModule(state="present",
+                        id_to_associate=None,
+                        public=True,
+                        name="aaaaaaaa",
+                        vlan=1,
+                        bgp_asn=123,
+                        authentication_key="aaaa",
+                        customer_address="169.254.0.1/30",
+                        amazon_address="169.254.0.2/30",
+                        address_type="ipv4",
+                        cidr=["10.88.0.0/30"],
+                        virtual_gateway_id="xxxx",
+                        direct_connect_gateway_id="yyyy")
+    vi = aws_direct_connect_virtual_interface.assemble_params_for_creating_vi(module.params)
+    assert vi == {
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 1,
+        "asn": 123,
+        "authKey": "aaaa",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "routeFilterPrefixes": [{"cidr": "10.88.0.0/30"}]
+    }
+
+
+def test_construct_private_vi_with_virtual_gateway_id():
+    module = FakeModule(state="present",
+                        id_to_associate=None,
+                        public=False,
+                        name="aaaaaaaa",
+                        vlan=1,
+                        bgp_asn=123,
+                        authentication_key="aaaa",
+                        customer_address="169.254.0.1/30",
+                        amazon_address="169.254.0.2/30",
+                        address_type="ipv4",
+                        cidr=["10.88.0.0/30"],
+                        virtual_gateway_id="xxxx",
+                        direct_connect_gateway_id="yyyy")
+    vi = aws_direct_connect_virtual_interface.assemble_params_for_creating_vi(module.params)
+    print(vi)
+    assert vi == {
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 1,
+        "asn": 123,
+        "authKey": "aaaa",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "virtualGatewayId": "xxxx"
+    }
+
+
+def test_construct_private_vi_with_direct_connect_gateway_id():
+    module = FakeModule(state="present",
+                        id_to_associate=None,
+                        public=False,
+                        name="aaaaaaaa",
+                        vlan=1,
+                        bgp_asn=123,
+                        authentication_key="aaaa",
+                        customer_address="169.254.0.1/30",
+                        amazon_address="169.254.0.2/30",
+                        address_type="ipv4",
+                        cidr=["10.88.0.0/30"],
+                        virtual_gateway_id=None,
+                        direct_connect_gateway_id="yyyy")
+    vi = aws_direct_connect_virtual_interface.assemble_params_for_creating_vi(module.params)
+    print(vi)
+    assert vi == {
+        "virtualInterfaceName": "aaaaaaaa",
+        "vlan": 1,
+        "asn": 123,
+        "authKey": "aaaa",
+        "amazonAddress": "169.254.0.2/30",
+        "customerAddress": "169.254.0.1/30",
+        "addressFamily": "ipv4",
+        "directConnectGatewayId": "yyyy"
+    }
+
+
+# def test_create_public_vi(placeboify, maybe_sleep):
+#     client = placeboify.client("directconnect")
+#     module = FakeModule(state="present",
+#                         id_to_associate='dxcon-aaaaaaaa',
+#                         virtual_interface_id=None,
+#                         public=True,
+#                         name="aaaaaaaa",
+#                         vlan=1,
+#                         bgp_asn=123,
+#                         authentication_key="aaaa",
+#                         customer_address="169.254.0.1/30",
+#                         amazon_address="169.254.0.2/30",
+#                         address_type="ipv4",
+#                         cidr=["10.88.0.0/30"],
+#                         virtual_gateway_id="xxxx",
+#                         direct_connect_gateway_id="yyyy")
+#     changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
+#     assert changed is True
+#     assert latest_state is not None
+#
+#
+# def test_create_private_vi(placeboify, maybe_sleep):
+#     client = placeboify.client("directconnect")
+#     module = FakeModule(state="present",
+#                         id_to_associate='dxcon-aaaaaaaa',
+#                         virtual_interface_id=None,
+#                         public=False,
+#                         name="aaaaaaaa",
+#                         vlan=1,
+#                         bgp_asn=123,
+#                         authentication_key="aaaa",
+#                         customer_address="169.254.0.1/30",
+#                         amazon_address="169.254.0.2/30",
+#                         address_type="ipv4",
+#                         cidr=["10.88.0.0/30"],
+#                         virtual_gateway_id="xxxx",
+#                         direct_connect_gateway_id="yyyy")
+#     changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
+#     assert changed is True
+#     assert latest_state is not None
+
+
+def test_delete_vi(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    module = FakeModule(state="absent",
+                        id_to_associate='dxcon-aaaaaaaa',
+                        virtual_interface_id='dxvif-aaaaaaaa',
+                        public=False,
+                        name="aaaaaaaa",
+                        vlan=1,
+                        bgp_asn=123,
+                        authentication_key="aaaa",
+                        customer_address="169.254.0.1/30",
+                        amazon_address="169.254.0.2/30",
+                        address_type="ipv4",
+                        cidr=["10.88.0.0/30"],
+                        virtual_gateway_id=None,
+                        direct_connect_gateway_id="yyyy")
+    changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
+    assert changed is True
+    assert latest_state == {}

--- a/tests/unit/modules/test_aws_direct_connect_virtual_interface.py
+++ b/tests/unit/modules/test_aws_direct_connect_virtual_interface.py
@@ -159,46 +159,46 @@ def test_construct_private_vi_with_direct_connect_gateway_id():
     }
 
 
-# def test_create_public_vi(placeboify, maybe_sleep):
-#     client = placeboify.client("directconnect")
-#     module = FakeModule(state="present",
-#                         id_to_associate='dxcon-aaaaaaaa',
-#                         virtual_interface_id=None,
-#                         public=True,
-#                         name="aaaaaaaa",
-#                         vlan=1,
-#                         bgp_asn=123,
-#                         authentication_key="aaaa",
-#                         customer_address="169.254.0.1/30",
-#                         amazon_address="169.254.0.2/30",
-#                         address_type="ipv4",
-#                         cidr=["10.88.0.0/30"],
-#                         virtual_gateway_id="xxxx",
-#                         direct_connect_gateway_id="yyyy")
-#     changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
-#     assert changed is True
-#     assert latest_state is not None
-#
-#
-# def test_create_private_vi(placeboify, maybe_sleep):
-#     client = placeboify.client("directconnect")
-#     module = FakeModule(state="present",
-#                         id_to_associate='dxcon-aaaaaaaa',
-#                         virtual_interface_id=None,
-#                         public=False,
-#                         name="aaaaaaaa",
-#                         vlan=1,
-#                         bgp_asn=123,
-#                         authentication_key="aaaa",
-#                         customer_address="169.254.0.1/30",
-#                         amazon_address="169.254.0.2/30",
-#                         address_type="ipv4",
-#                         cidr=["10.88.0.0/30"],
-#                         virtual_gateway_id="xxxx",
-#                         direct_connect_gateway_id="yyyy")
-#     changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
-#     assert changed is True
-#     assert latest_state is not None
+def test_create_public_vi(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    module = FakeModule(state="present",
+                        id_to_associate='dxcon-aaaaaaaa',
+                        virtual_interface_id=None,
+                        public=True,
+                        name="aaaaaaaa",
+                        vlan=1,
+                        bgp_asn=123,
+                        authentication_key="aaaa",
+                        customer_address="169.254.0.1/30",
+                        amazon_address="169.254.0.2/30",
+                        address_type="ipv4",
+                        cidr=["10.88.0.0/30"],
+                        virtual_gateway_id="xxxx",
+                        direct_connect_gateway_id="yyyy")
+    changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
+    assert changed is True
+    assert latest_state is not None
+
+
+def test_create_private_vi(placeboify, maybe_sleep):
+    client = placeboify.client("directconnect")
+    module = FakeModule(state="present",
+                        id_to_associate='dxcon-aaaaaaaa',
+                        virtual_interface_id=None,
+                        public=False,
+                        name="aaaaaaaa",
+                        vlan=1,
+                        bgp_asn=123,
+                        authentication_key="aaaa",
+                        customer_address="169.254.0.1/30",
+                        amazon_address="169.254.0.2/30",
+                        address_type="ipv4",
+                        cidr=["10.88.0.0/30"],
+                        virtual_gateway_id="xxxx",
+                        direct_connect_gateway_id="yyyy")
+    changed, latest_state = aws_direct_connect_virtual_interface.ensure_state(client, module)
+    assert changed is True
+    assert latest_state is not None
 
 
 def test_delete_vi(placeboify, maybe_sleep):

--- a/tests/unit/modules/test_aws_direct_connect_virtual_interface.py
+++ b/tests/unit/modules/test_aws_direct_connect_virtual_interface.py
@@ -119,7 +119,6 @@ def test_construct_private_vi_with_virtual_gateway_id():
                         virtual_gateway_id="xxxx",
                         direct_connect_gateway_id="yyyy")
     vi = aws_direct_connect_virtual_interface.assemble_params_for_creating_vi(module.params)
-    print(vi)
     assert vi == {
         "virtualInterfaceName": "aaaaaaaa",
         "vlan": 1,


### PR DESCRIPTION
##### SUMMARY
This adds `direct_connect_gateway_id` to `aws_direct_connect_virtual_interface`.
This field is only applicable in private VIF cases (`public=False`) and is
mutually exclusive to `virtual_gateway_id`.

The initial PR for the existing ansible/ansible repo was here, https://github.com/ansible/ansible/pull/48711.  It is very similar, but lacked return documentation and had a bug that allowed `direct_connect_gateway_id` for `public=True` VIFs, which is not supported by AWS.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_direct_connect_virtual_interface

##### ADDITIONAL INFORMATION
