### PR TITLE
Adds module aws_direct_connect_confirm_connection

### DIFF
--- a/plugins/modules/aws_direct_connect_confirm_connection.py
+++ b/plugins/modules/aws_direct_connect_confirm_connection.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
 module: aws_direct_connect_confirm_connection
 short_description: Confirms the creation of a hosted DirectConnect connection.
 description:
-  - Confirms the creation of a hosted DirectConnect, which requires approval before it can be used.  
+  - Confirms the creation of a hosted DirectConnect, which requires approval before it can be used.
   - DirectConnect connections that require approval would be in the 'ordering'.
   - After confirmation, they will move to the 'pending' state and finally the 'available' state.
 author: "Matt Traynham (@mtraynham)"

--- a/plugins/modules/aws_direct_connect_confirm_connection.py
+++ b/plugins/modules/aws_direct_connect_confirm_connection.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: aws_direct_connect_confirm_connection
+short_description: Confirms the creation of a hosted DirectConnect connection.
+description:
+  - Confirms the creation of a hosted DirectConnect, which requires approval before it can be used.  
+  - DirectConnect connections that require approval would be in the 'ordering'.
+  - After confirmation, they will move to the 'pending' state and finally the 'available' state.
+author: "Matt Traynham (@mtraynham)"
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+
+requirements:
+  - boto3
+  - botocore
+options:
+  name:
+    description:
+      - The name of the Direct Connect connection.
+      - One of I(connection_id) or I(name) must be specified.
+    type: str
+  connection_id:
+    description:
+      - The ID of the Direct Connect connection.
+      - One of I(connection_id) or I(name) must be specified.
+    type: str
+'''
+
+EXAMPLES = '''
+
+# confirm a Direct Connect by name
+- name: confirm the connection id
+  aws_direct_connect_confirm_connection:
+    name: my_host_direct_connect
+
+# confirm a Direct Connect by connection_id
+- name: confirm the connection id
+  aws_direct_connect_confirm_connection:
+    connection_id: dxcon-xxxxxxxx
+'''
+
+RETURN = '''
+
+connection_state:
+  description: The state of the connection.
+  returned: always
+  type: str
+  sample: pending
+'''
+
+import traceback
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import DirectConnectError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict, AWSRetry)
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except Exception:
+    pass
+    # handled by imported AnsibleAWSModule
+
+retry_params = {"tries": 10, "delay": 5, "backoff": 1.2, "catch_extra_error_codes": ["DirectConnectClientException"]}
+
+
+def find_connection_id(client, connection_id=None, connection_name=None):
+    params = {}
+    if connection_id:
+        params['connectionId'] = connection_id
+    try:
+        response = AWSRetry.backoff(**retry_params)(client.describe_connections)(**params)
+    except (BotoCoreError, ClientError) as e:
+        if connection_id:
+            msg = "Failed to describe DirectConnect ID {0}".format(connection_id)
+        else:
+            msg = "Failed to describe DirectConnect connections"
+        raise DirectConnectError(msg=msg,
+                                 last_traceback=traceback.format_exc(),
+                                 exception=e)
+
+    match = []
+    if len(response.get('connections', [])) == 1 and connection_id:
+        if response['connections'][0]['connectionState'] != 'deleted':
+            match.append(response['connections'][0]['connectionId'])
+
+    for conn in response.get('connections', []):
+        if connection_name == conn['connectionName'] and conn['connectionState'] != 'deleted':
+            match.append(conn['connectionId'])
+
+    if len(match) == 1:
+        return match[0]
+    else:
+        raise DirectConnectError(msg="Could not find a valid DirectConnect connection")
+
+
+def get_connection_state(client, connection_id):
+    try:
+        response = AWSRetry.backoff(**retry_params)(client.describe_connections)(connectionId=connection_id)
+        return response['connections'][0]['connectionState']
+    except (BotoCoreError, ClientError, IndexError) as e:
+        raise DirectConnectError(msg="Failed to describe DirectConnect connection {0} state".format(connection_id),
+                                 last_traceback=traceback.format_exc(),
+                                 exception=e)
+
+
+def main():
+    argument_spec = dict(
+        connection_id=dict(),
+        name=dict()
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              mutually_exclusive=[['connection_id', 'name']],
+                              required_one_of=[['connection_id', 'name']])
+    client = module.client('directconnect')
+
+    connection_id = module.params['connection_id']
+    connection_name = module.params['name']
+
+    changed = False
+    connection_state = None
+    try:
+        connection_id = find_connection_id(client,
+                                           connection_id,
+                                           connection_name)
+        connection_state = get_connection_state(client, connection_id)
+        if connection_state == 'ordering':
+            client.confirm_connection(connectionId=connection_id)
+            changed = True
+            connection_state = get_connection_state(client, connection_id)
+    except DirectConnectError as e:
+        if e.last_traceback:
+            module.fail_json(msg=e.msg, exception=e.last_traceback, **camel_dict_to_snake_dict(e.exception.response))
+        else:
+            module.fail_json(msg=e.msg)
+
+    module.exit_json(changed=changed, connection_state=connection_state)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/modules/test_aws_direct_connect_confirm_connection.py
+++ b/tests/unit/modules/test_aws_direct_connect_confirm_connection.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import pytest
 from ansible_collections.community.aws.tests.unit.compat.mock import MagicMock, patch, call
 from ansible_collections.community.aws.tests.unit.modules.utils import (AnsibleExitJson,
                                                                         AnsibleFailJson,
@@ -14,19 +13,19 @@ try:
 except ImportError:
     pass
 
-
+@patch('ansible_collections.amazon.aws.plugins.module_utils.core.HAS_BOTO3', new=True)
+@patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
 class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
-    def test_missing_required_parameters(self):
+    def test_missing_required_parameters(self, *args):
         set_module_args({})
-        with pytest.raises(AnsibleFailJson) as context:
+        with self.assertRaises(AnsibleFailJson) as exec_info:
             aws_direct_connect_confirm_connection.main()
 
-        result = context.value.args[0]
+        result = exec_info.exception.args[0]
         assert result["failed"] is True
         assert "name" in result["msg"]
         assert "connection_id" in result["msg"]
 
-    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
     def test_get_by_connection_id(self, mock_client):
         mock_client.return_value.describe_connections.return_value = {
             "connections": [
@@ -44,10 +43,10 @@ class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
         set_module_args({
             "connection_id": "dxcon-fgq9rgot"
         })
-        with pytest.raises(AnsibleExitJson) as context:
+        with self.assertRaises(AnsibleExitJson) as exec_info:
             aws_direct_connect_confirm_connection.main()
 
-        result = context.value.args[0]
+        result = exec_info.exception.args[0]
         assert result["changed"] is False
         assert result["connection_state"] == "requested"
         mock_client.return_value.describe_connections.assert_has_calls([
@@ -55,7 +54,6 @@ class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
         ])
         mock_client.return_value.confirm_connection.assert_not_called()
 
-    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
     def test_get_by_name(self, mock_client):
         mock_client.return_value.describe_connections.return_value = {
             "connections": [
@@ -73,10 +71,10 @@ class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
         set_module_args({
             "name": "ansible-test-connection"
         })
-        with pytest.raises(AnsibleExitJson) as context:
+        with self.assertRaises(AnsibleExitJson) as exec_info:
             aws_direct_connect_confirm_connection.main()
 
-        result = context.value.args[0]
+        result = exec_info.exception.args[0]
         assert result["changed"] is False
         assert result["connection_state"] == "requested"
         mock_client.return_value.describe_connections.assert_has_calls([
@@ -85,23 +83,21 @@ class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
         ])
         mock_client.return_value.confirm_connection.assert_not_called()
 
-    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
     def test_missing_connection_id(self, mock_client):
         mock_client.return_value.describe_connections.side_effect = ClientError(
             {'Error': {'Code': 'ResourceNotFoundException'}}, 'DescribeConnection')
         set_module_args({
             "connection_id": "dxcon-aaaabbbb"
         })
-        with pytest.raises(AnsibleFailJson) as context:
+        with self.assertRaises(AnsibleFailJson) as exec_info:
             aws_direct_connect_confirm_connection.main()
 
-        result = context.value.args[0]
+        result = exec_info.exception.args[0]
         assert result["failed"] is True
         mock_client.return_value.describe_connections.assert_has_calls([
             call(connectionId="dxcon-aaaabbbb")
         ])
 
-    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
     def test_missing_name(self, mock_client):
         mock_client.return_value.describe_connections.return_value = {
             "connections": [
@@ -119,16 +115,15 @@ class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
         set_module_args({
             "name": "foobar"
         })
-        with pytest.raises(AnsibleFailJson) as context:
+        with self.assertRaises(AnsibleFailJson) as exec_info:
             aws_direct_connect_confirm_connection.main()
 
-        result = context.value.args[0]
+        result = exec_info.exception.args[0]
         assert result["failed"] is True
         mock_client.return_value.describe_connections.assert_has_calls([
             call()
         ])
 
-    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
     def test_confirm(self, mock_client):
         mock_client.return_value.describe_connections.return_value = {
             "connections": [
@@ -147,10 +142,10 @@ class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
         set_module_args({
             "connection_id": "dxcon-fgq9rgot"
         })
-        with pytest.raises(AnsibleExitJson) as context:
+        with self.assertRaises(AnsibleExitJson) as exec_info:
             aws_direct_connect_confirm_connection.main()
 
-        result = context.value.args[0]
+        result = exec_info.exception.args[0]
         assert result["changed"] is True
         mock_client.return_value.describe_connections.assert_has_calls([
             call(connectionId="dxcon-fgq9rgot"),

--- a/tests/unit/modules/test_aws_direct_connect_confirm_connection.py
+++ b/tests/unit/modules/test_aws_direct_connect_confirm_connection.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     pass
 
+
 @patch('ansible_collections.amazon.aws.plugins.module_utils.core.HAS_BOTO3', new=True)
 @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
 class TestAWSDirectConnectConfirmConnection(ModuleTestCase):

--- a/tests/unit/modules/test_aws_direct_connect_confirm_connection.py
+++ b/tests/unit/modules/test_aws_direct_connect_confirm_connection.py
@@ -1,0 +1,160 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from ansible_collections.community.aws.tests.unit.compat.mock import MagicMock, patch, call
+from ansible_collections.community.aws.tests.unit.modules.utils import (AnsibleExitJson,
+                                                                        AnsibleFailJson,
+                                                                        ModuleTestCase,
+                                                                        set_module_args)
+from ansible_collections.community.aws.plugins.modules import aws_direct_connect_confirm_connection
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
+
+class TestAWSDirectConnectConfirmConnection(ModuleTestCase):
+    def test_missing_required_parameters(self):
+        set_module_args({})
+        with pytest.raises(AnsibleFailJson) as context:
+            aws_direct_connect_confirm_connection.main()
+
+        result = context.value.args[0]
+        assert result["failed"] is True
+        assert "name" in result["msg"]
+        assert "connection_id" in result["msg"]
+
+    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
+    def test_get_by_connection_id(self, mock_client):
+        mock_client.return_value.describe_connections.return_value = {
+            "connections": [
+                {
+                    "connectionState": "requested",
+                    "connectionId": "dxcon-fgq9rgot",
+                    "location": "EqSe2",
+                    "connectionName": "ansible-test-connection",
+                    "bandwidth": "1Gbps",
+                    "ownerAccount": "448830907657",
+                    "region": "us-west-2"
+                }
+            ]
+        }
+        set_module_args({
+            "connection_id": "dxcon-fgq9rgot"
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            aws_direct_connect_confirm_connection.main()
+
+        result = context.value.args[0]
+        assert result["changed"] is False
+        assert result["connection_state"] == "requested"
+        mock_client.return_value.describe_connections.assert_has_calls([
+            call(connectionId="dxcon-fgq9rgot")
+        ])
+        mock_client.return_value.confirm_connection.assert_not_called()
+
+    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
+    def test_get_by_name(self, mock_client):
+        mock_client.return_value.describe_connections.return_value = {
+            "connections": [
+                {
+                    "connectionState": "requested",
+                    "connectionId": "dxcon-fgq9rgot",
+                    "location": "EqSe2",
+                    "connectionName": "ansible-test-connection",
+                    "bandwidth": "1Gbps",
+                    "ownerAccount": "448830907657",
+                    "region": "us-west-2"
+                }
+            ]
+        }
+        set_module_args({
+            "name": "ansible-test-connection"
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            aws_direct_connect_confirm_connection.main()
+
+        result = context.value.args[0]
+        assert result["changed"] is False
+        assert result["connection_state"] == "requested"
+        mock_client.return_value.describe_connections.assert_has_calls([
+            call(),
+            call(connectionId="dxcon-fgq9rgot")
+        ])
+        mock_client.return_value.confirm_connection.assert_not_called()
+
+    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
+    def test_missing_connection_id(self, mock_client):
+        mock_client.return_value.describe_connections.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException'}}, 'DescribeConnection')
+        set_module_args({
+            "connection_id": "dxcon-aaaabbbb"
+        })
+        with pytest.raises(AnsibleFailJson) as context:
+            aws_direct_connect_confirm_connection.main()
+
+        result = context.value.args[0]
+        assert result["failed"] is True
+        mock_client.return_value.describe_connections.assert_has_calls([
+            call(connectionId="dxcon-aaaabbbb")
+        ])
+
+    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
+    def test_missing_name(self, mock_client):
+        mock_client.return_value.describe_connections.return_value = {
+            "connections": [
+                {
+                    "connectionState": "requested",
+                    "connectionId": "dxcon-fgq9rgot",
+                    "location": "EqSe2",
+                    "connectionName": "ansible-test-connection",
+                    "bandwidth": "1Gbps",
+                    "ownerAccount": "448830907657",
+                    "region": "us-west-2"
+                }
+            ]
+        }
+        set_module_args({
+            "name": "foobar"
+        })
+        with pytest.raises(AnsibleFailJson) as context:
+            aws_direct_connect_confirm_connection.main()
+
+        result = context.value.args[0]
+        assert result["failed"] is True
+        mock_client.return_value.describe_connections.assert_has_calls([
+            call()
+        ])
+
+    @patch.object(aws_direct_connect_confirm_connection.AnsibleAWSModule, "client")
+    def test_confirm(self, mock_client):
+        mock_client.return_value.describe_connections.return_value = {
+            "connections": [
+                {
+                    "connectionState": "ordering",
+                    "connectionId": "dxcon-fgq9rgot",
+                    "location": "EqSe2",
+                    "connectionName": "ansible-test-connection",
+                    "bandwidth": "1Gbps",
+                    "ownerAccount": "448830907657",
+                    "region": "us-west-2"
+                }
+            ]
+        }
+        mock_client.return_value.confirm_connection.return_value = [{}]
+        set_module_args({
+            "connection_id": "dxcon-fgq9rgot"
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            aws_direct_connect_confirm_connection.main()
+
+        result = context.value.args[0]
+        assert result["changed"] is True
+        mock_client.return_value.describe_connections.assert_has_calls([
+            call(connectionId="dxcon-fgq9rgot"),
+            call(connectionId="dxcon-fgq9rgot"),
+            call(connectionId="dxcon-fgq9rgot")
+        ])
+        mock_client.return_value.confirm_connection.assert_called_once_with(connectionId="dxcon-fgq9rgot")


### PR DESCRIPTION
##### SUMMARY
DirectConnect connections that are created by a Hosted provider
require approval by users.  This module simply finds the
DirectConnect connection and confirms it if it's in the
'ordering' state.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
aws_direct_connect_confirm_connection

##### ADDITIONAL INFORMATION
I have a playbook of tests, but these tests require an AWS account with 2 DirectConnect connections created via a hosted DirectConnect provider.  Still trying to understand how I'd go about mocking this into unit tests.

The test playbook I used looks like the following:
```yml
---
- hosts: localhost
  collections:
    - community.aws
  tasks:
    - name: validate you cannot pass both name and connection_id
      aws_direct_connect_confirm_connection:
        name: my_host_direct_connect
        connection_id: my_host_direct_connect
      register: bad_result
      ignore_errors: yes
    - debug: var=bad_result

    - name: validate you must pass one of name and connection_id
      aws_direct_connect_confirm_connection:
      register: bad_result
      ignore_errors: yes
    - debug: var=bad_result

    - name: confirm a bad connection name
      aws_direct_connect_confirm_connection:
        name: my_host_direct_connect
      register: bad_result
      ignore_errors: yes
    - debug: var=bad_result

    - name: confirm a bad connection id
      aws_direct_connect_confirm_connection:
        connection_id: my_host_direct_connect
      register: bad_result
      ignore_errors: yes
    - debug: var=bad_result

    - name: confirm a valid connection name
      aws_direct_connect_confirm_connection:
        name: 'My Direct Connect connection'
      register: result
    - debug: var=result
    - fail:
      when: result.changed != true
      
    - name: confirm a valid connection name (no change)
      aws_direct_connect_confirm_connection:
        name: 'My Direct Connect connection'
      register: result
    - debug: var=result
    - fail:
      when: result.changed == true

    - name: confirm a valid connection id
      aws_direct_connect_confirm_connection:
        connection_id: dxcon-xxxxxxx
      register: result
    - debug: var=result
    - fail:
      when: result.changed != true

    - name: confirm a valid connection id
      aws_direct_connect_confirm_connection:
        connection_id: dxcon-xxxxxxx
      register: result
    - debug: var=result
    - fail:
      when: result.changed == true
```

---
For more info on a Hosted DirectConnect, you can read about it here, https://docs.aws.amazon.com/directconnect/latest/UserGuide/WorkingWithConnections.html.
> Hosted Connection: A physical Ethernet connection that an AWS Direct Connect Partner provisions on behalf of a customer. Customers request a hosted connection by contacting a partner in the AWS Direct Connect Partner Program, who provisions the connection.