### PR TITLE
[WIP] Adding tags & purge_tags to aws_glue_job module

### DIFF
--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -349,7 +349,7 @@ def create_or_update_glue_job(connection, module, glue_job):
     if changed:
         glue_job = _get_glue_job(connection, module, params['Name'])
 
-    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_job))
+    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_job, ignore_list=['tags']))
 
 
 def delete_glue_job(connection, module, glue_job):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -210,6 +210,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (compare_aws
                                                                      boto3_tag_list_to_ansible_dict,
                                                                      ansible_dict_to_boto3_tag_list
                                                                      )
+from ansible_collections.amazon.aws.plugins.module_utils.iam import get_aws_account_id
 
 # Non-ansible imports
 import copy
@@ -282,15 +283,7 @@ def _compare_glue_job_params(user_params, current_params):
 
 
 def _get_glue_job_arn(module):
-    return "arn:aws:glue:{0}:{1}:job/{2}".format(module.region, _get_aws_account_id(module), module.params.get('name'))
-
-
-def _get_aws_account_id(module):
-    try:
-        client = module.client('sts')
-        return client.get_caller_identity()['Account']
-    except (ClientError, BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Unable to obtain AWS account id")
+    return "arn:aws:glue:{0}:{1}:job/{2}".format(module.region, get_aws_account_id(module), module.params.get('name'))
 
 
 def _update_glue_job_tags(connection, module):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -205,8 +205,8 @@ timeout:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
-                                                                     compare_aws_tags,
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (compare_aws_tags,
+                                                                     camel_dict_to_snake_dict,
                                                                      boto3_tag_list_to_ansible_dict,
                                                                      ansible_dict_to_boto3_tag_list
                                                                      )

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -311,6 +311,7 @@ def _update_glue_job_tags(connection, module):
 
     return True
 
+
 def create_or_update_glue_job(connection, module, glue_job):
     """
     Create or update an AWS Glue job

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -66,9 +66,10 @@ options:
       - Required when I(state=present).
     type: str
   purge_tags:
-    description:
+    description: 
+      - If yes, existing tags will be deleted if they are not specified in I(tags)
     default: yes
-    type: 
+    type: bool
   state:
     description:
       - Create or delete the AWS Glue job.
@@ -77,6 +78,7 @@ options:
     type: str
   tags:
     description: 
+      - The hash/dictionary resource tags to associate with this job.
     type: dict
   timeout:
     description:
@@ -114,7 +116,7 @@ allocated_capacity:
     type: int
     sample: 10
 arn:
-    description: 
+    description: the Amazon Resource Name (ARN) specifying the job
     returned: when state is present
     type: str
     sample: arn:aws:glue:us-east-1:123456789:job/my-glue-job
@@ -190,6 +192,11 @@ role:
     returned: when state is present
     type: str
     sample: my-iam-role
+tags:
+    description: The resource tags associated with this job.
+    returned: when state is present
+    type: dict
+    sample: "{ 'mytag1': 'myvalue1' }"
 timeout:
     description: The job timeout in minutes.
     returned: when state is present
@@ -387,7 +394,7 @@ def main():
             max_concurrent_runs=dict(type='int'),
             max_retries=dict(type='int'),
             name=dict(required=True, type='str'),
-            purge_tags=dict(default=True, type='bool'),
+            purge_tags=dict(type='bool', default=True),
             role=dict(type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             tags=dict(type='dict'),

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -283,7 +283,7 @@ def _compare_glue_job_params(user_params, current_params):
 
 def _get_glue_job_arn(module, job_name):
     (region, account_id) = (module.region, _get_aws_account_id(module))
-    return f"arn:aws:glue:{region}:{account_id}:job/{job_name}"
+    return "arn:aws:glue:" + region + ":" + account_id + ":" + "job/" + job_name
 
 
 def _get_aws_account_id(module):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -204,9 +204,9 @@ timeout:
     sample: 300
 '''
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (compare_aws_tags,
-                                                                     camel_dict_to_snake_dict,
                                                                      boto3_tag_list_to_ansible_dict,
                                                                      ansible_dict_to_boto3_tag_list
                                                                      )

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -106,6 +106,11 @@ allocated_capacity:
     returned: when state is present
     type: int
     sample: 10
+arn:
+    description: 
+    returned: when state is present
+    type: str
+    sample: arn:aws:glue:us-east-1:123456789:job/my-glue-job
 command:
     description: The JobCommand that executes this job.
     returned: when state is present

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -66,7 +66,7 @@ options:
       - Required when I(state=present).
     type: str
   purge_tags:
-    description: 
+    description:
       - If yes, existing tags will be deleted if they are not specified in I(tags)
     default: yes
     type: bool
@@ -77,7 +77,7 @@ options:
     choices: [ 'present', 'absent' ]
     type: str
   tags:
-    description: 
+    description:
       - The hash/dictionary resource tags to associate with this job.
     type: dict
   timeout:
@@ -205,7 +205,11 @@ timeout:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict, compare_aws_tags, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
+                                                                     compare_aws_tags,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     ansible_dict_to_boto3_tag_list
+                                                                     )
 
 # Non-ansible imports
 import copy
@@ -289,6 +293,7 @@ def _get_aws_account_id(module):
     except (ClientError, BotoCoreError) as e:
         module.fail_json_aws(e, msg="Unable to obtain AWS account id")
 
+
 def create_or_update_glue_job(connection, module, glue_job):
     """
     Create or update an AWS Glue job
@@ -337,18 +342,18 @@ def create_or_update_glue_job(connection, module, glue_job):
             changed = True
         except (BotoCoreError, ClientError) as e:
             module.fail_json_aws(e)
-    
+
     # handle resource tags
     resource_arn = _get_glue_job_arn(module, params['Name'])
 
     new_tags = module.params.get('tags')
     existing_tags = connection.get_tags(ResourceArn=resource_arn).get('Tags')
     tags_to_add, tags_to_remove = compare_aws_tags(existing_tags, new_tags if new_tags else {}, module.params.get('purge_tags'))
-    
+
     if tags_to_remove:
         connection.untag_resource(ResourceArn=resource_arn, TagsToRemove=tags_to_remove)
         changed = True
-    if tags_to_add :
+    if tags_to_add:
         connection.tag_resource(ResourceArn=resource_arn, TagsToAdd=tags_to_add)
         changed = True
 
@@ -418,6 +423,7 @@ def main():
         create_or_update_glue_job(connection, module, glue_job)
     else:
         delete_glue_job(connection, module, glue_job)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/integration/targets/aws_glue_job/aliases
+++ b/tests/integration/targets/aws_glue_job/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,2 +1,2 @@
-glue_role_name: '{{ resource_prefix }}-role'
+glue_role_name: 'ansible-test-{{ resource_prefix }}'
 glue_job_name: '{{ resource_prefix }}-job'

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,0 +1,2 @@
+role_name: '{{ resource_prefix }}-role'
+job_name: '{{ resource_prefix }}-job'

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,2 +1,2 @@
-role_name: '{{ resource_prefix }}-role'
-job_name: '{{ resource_prefix }}-job'
+glue_role_name: '{{ resource_prefix }}-role'
+glue_job_name: '{{ resource_prefix }}-job'

--- a/tests/integration/targets/aws_glue_job/files/args.json
+++ b/tests/integration/targets/aws_glue_job/files/args.json
@@ -1,0 +1,4 @@
+{
+    "--job-bookmark-option": "job-bookmark-enable",
+    "--enable-metrics": ""
+}

--- a/tests/integration/targets/aws_glue_job/files/args2.json
+++ b/tests/integration/targets/aws_glue_job/files/args2.json
@@ -1,0 +1,3 @@
+{
+    "--job-bookmark-option": "job-bookmark-disable"
+}

--- a/tests/integration/targets/aws_glue_job/files/args2.json
+++ b/tests/integration/targets/aws_glue_job/files/args2.json
@@ -1,3 +1,0 @@
-{
-    "--job-bookmark-option": "job-bookmark-disable"
-}

--- a/tests/integration/targets/aws_glue_job/files/policy.json
+++ b/tests/integration/targets/aws_glue_job/files/policy.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "glue.amazonaws.com"
+            }
+        }
+    ]
+}

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -13,13 +13,10 @@
     # integration test setup
     - name: create aws glue iam role for integration tests
       iam_role:
-        name: '{{ item }}'
+        name: my-glue-iam-role
         description: IAM role needed for aws_glue_job integration tests.
         assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
         state: present
-      loop:
-        - my-glue-iam-role
-        - my-glue-iam-role-2
     
     # resource creation 
     - name: test create glue job
@@ -64,6 +61,9 @@
     - assert:
         that:
           - result.changed 
+          - result.tags is defined
+          - result.tags.Environment == 'IntegrationTest'
+          - ((result.tags | dict2items) | length) == 1
 
     - name: test update glue job - update tags
       aws_glue_job:
@@ -81,6 +81,10 @@
     - assert:
         that:
           - result.changed 
+          - result.tags is defined
+          - result.tags.Environment == 'IntegrationTest2'
+          - result.tags.AnotherTag == 'foobar'
+          - ((result.tags | dict2items) | length) == 2
     
     - name: test update glue job - remove tags
       aws_glue_job:
@@ -95,6 +99,8 @@
     - assert:
         that:
           - result.changed 
+          - result.tags is defined
+          - ((result.tags | dict2items) | length) == 0
 
     - name: test update glue job - updated default args - set
       aws_glue_job:
@@ -220,8 +226,5 @@
     
     - name: cleanup iam roles used in tests
       iam_role:
-        name: '{{ item }}'
+        name: my-glue-iam-role
         state: absent
-      loop:
-        - my-glue-iam-role
-        - my-glue-iam-role-2

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -17,7 +17,7 @@
         description: IAM role needed for aws_glue_job integration tests.
         assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
         state: present
-    
+
     # resource creation 
     - name: test create glue job
       aws_glue_job:
@@ -31,6 +31,8 @@
     - assert:
         that:
           - result.changed
+          - result.arn is defined
+          - "result.arn | regex_search('^arn:aws:glue:([a-zA-Z0-9\\-]+):([0-9]+):job/my-glue-job$')"
 
     # resource creation idempotence
     - name: test idempotence when creating same glue job
@@ -116,13 +118,15 @@
         that:
           - result.changed
           - result.default_arguments is defined
+          - ((result.default_arguments | dict2items) | length) == 2
 
     - name: test update glue job - updated default args - change
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        default_arguments: "{{ lookup('file', 'args2.json') }}"
+        default_arguments: 
+          '--job-bookmark-option': job-bookmark-disable
         role: my-glue-iam-role
         state: present
       register: result
@@ -131,6 +135,8 @@
         that:
           - result.changed
           - result.default_arguments is defined
+          - ((result.default_arguments | dict2items) | length) == 1
+          - "result.default_arguments['--job-bookmark-option'] == 'job-bookmark-disable'"
 
     - name: test update glue job - updated default args - remove
       aws_glue_job:
@@ -146,6 +152,7 @@
         that:
           - result.changed
           - result.default_arguments is defined
+          - ((result.default_arguments | dict2items) | length) == 0
 
     - name: test update glue job - update max retries
       aws_glue_job:
@@ -204,9 +211,8 @@
     - assert:
         that:
           - result.changed
-          - result.command.name == 'glueetl'
           - result.command.script_location == 's3bucket/glue-job-script2.py'
-    
+
     # resource deletion 
     - name: test delete glue job
       aws_glue_job:

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -66,8 +66,30 @@
           - result.tags is defined
           - result.tags.Environment == 'IntegrationTest'
           - ((result.tags | dict2items) | length) == 1
+    
+    - name: test update glue job - update tags w/o purge
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
+        purge_tags: no
+        tags:
+          AnotherTag: foobar
+          YetAnotherTag: hello_world
+        state: present
+      register: result
 
-    - name: test update glue job - update tags
+    - assert:
+        that:
+          - result.changed 
+          - result.tags is defined
+          - result.tags.Environment == 'IntegrationTest'
+          - result.tags.AnotherTag == 'foobar'
+          - result.tags.YetAnotherTag == 'hello_world'
+          - ((result.tags | dict2items) | length) == 3
+
+    - name: test update glue job - update tags w/ purge
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -6,6 +6,7 @@
       aws_secret_key: "{{ aws_secret_key }}"
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+      purge_tags: no
 
   block:
     
@@ -47,35 +48,53 @@
     - assert:
         that: 
           - not result.changed
+    
+    # resource modification - tags
+    - name: test update glue job - add tags
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
+        tags:
+          Environment: IntegrationTest
+        state: present
+      register: result
 
-    # resource modification
-    # - name: test update glue job - updated connections
-    #   aws_glue_job:
-    #     name: my-glue-job
-    #     command_script_location: s3bucket/glue-job-script.py
-    #     connections: [ my-test-connection, my-test-connection-2 ]
-    #     role: my-glue-iam-role
-    #     state: present
-    #   register: result
+    - assert:
+        that:
+          - result.changed 
 
-    # - assert:
-    #     that:
-    #       - result.changed
-    #       - result.connections | length == 2
+    - name: test update glue job - update tags
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
+        purge_tags: yes
+        tags:
+          Environment: IntegrationTest2
+          AnotherTag: foobar
+        state: present
+      register: result
 
-    # - name: test update glue job - updated connections - removed
-    #   aws_glue_job:
-    #     name: my-glue-job
-    #     command_script_location: s3bucket/glue-job-script.py
-    #     connections: [ my-test-connection ]
-    #     role: my-glue-iam-role
-    #     state: present
-    #   register: result
+    - assert:
+        that:
+          - result.changed 
+    
+    - name: test update glue job - remove tags
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
+        purge_tags: yes
+        state: present
+      register: result
 
-    # - assert:
-    #     that:
-    #       - result.changed
-    #       - result.connections | length == 1
+    - assert:
+        that:
+          - result.changed 
 
     - name: test update glue job - updated default args - set
       aws_glue_job:
@@ -151,19 +170,6 @@
         that: 
           - result.changed
           - result.execution_property.max_concurrent_runs == 5
-    
-    # - name: test update glue job - updated role
-    #   aws_glue_job:
-    #     name: my-glue-job
-    #     command_script_location: s3bucket/glue-job-script.py
-    #     role: my-glue-iam-role-2
-    #     state: present
-    #   register: result
-
-    # - assert:
-    #     that: 
-    #       - result.changed
-    #       - result.role == 'my-glue-iam-role-2'
     
     - name: test update glue job - updated timeout
       aws_glue_job:

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -1,4 +1,5 @@
-- name: set up aws connection info
+---
+- name: run aws_glue_job integration tests
   module_defaults:
     group/aws:
       aws_access_key: "{{ aws_access_key }}"
@@ -7,12 +8,28 @@
       region: "{{ aws_region }}"
 
   block:
+    
+    # integration test setup
+    - name: create aws glue iam role for integration tests
+      iam_role:
+        name: my-glue-iam-role
+        description: IAM role needed for aws_glue_job integration tests.
+        assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
+        state: present
 
-    - name: create glue job
+    - name: create second aws glue iam role for integration tests
+      iam_role:
+        name: my-glue-iam-role-2
+        description: IAM role needed for aws_glue_job integration tests.
+        assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
+        state: present
+    
+    # resource creation 
+    - name: test create glue job
       aws_glue_job:
-        command_script_location: s3bucket/script.py
         name: my-glue-job
-        role: my-iam-role
+        command_script_location: s3bucket/glue-job-script.py
+        role: my-glue-iam-role
         state: present
       register: result
 
@@ -20,21 +37,186 @@
         that:
           - result.changed
 
+    # resource creation idempotence
     - name: test idempotence when creating same glue job
       aws_glue_job:
-        command_script_location: s3bucket/script.py
         name: my-glue-job
-        role: my-iam-role
+        command_script_location: s3bucket/glue-job-script.py
+        role: my-glue-iam-role
         state: present
       register: result
 
     - assert:
         that: 
           - not result.changed
+
+    # resource modification
+    - name: test update glue job - updated connections
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
+        state: present
+      register: result
+
+    - assert:
+      that:
+        - result.changed
+        - result.connections | length == 1
+
+    - name: test update glue job - updated connections - removed
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        connections: []
+        role: my-glue-iam-role
+        state: present
+      register: result
+
+    - assert:
+      that:
+        - result.changed
+        - result.connections | length == 0
+
+    - name: test update glue job - updated default args - set
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        default_arguments: "{{ lookup('file', 'args.json') }}"
+        role: my-glue-iam-role
+        state: present
+      register: result
+
+    - assert:
+      that:
+        - result.changed
+        - result.default_arguments is defined
+
+    - name: test update glue job - updated default args - change
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        default_arguments: "{{ lookup('file', 'args2.json') }}"
+        role: my-glue-iam-role
+        state: present
+      register: result
+
+    - assert:
+      that:
+        - result.changed
+        - result.default_arguments is defined
+
+    - name: test update glue job - updated default args - remove
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        role: my-glue-iam-role
+        state: present
+      register: result
+
+    - assert:
+      that:
+        - result.changed
+        - result.default_arguments is not defined
+
+    - name: test update glue job - update max retries
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        max_retries: 2
+        role: my-glue-iam-role
+        state: present
+      register: result
+    
+    - assert: 
+      that:
+        - result.changed
+        - result.max_retries == 2
+
+    - name: test update glue job - updated maximum concurrent runs
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        max_concurrent_runs: 5
+        role: my-glue-iam-role
+        state: present
+      register: result
+    
+    - assert: 
+      that: 
+        - result.changed
+        - result.execution_property.max_concurrent_runs == 5
+
+    - name: test update glue job - updated maximum concurrent runs - reset to default
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        role: my-glue-iam-role
+        state: present
+      register: result
+    
+    - assert: 
+      that: 
+        - result.changed
+        - result.execution_property.max_concurrent_runs == 1
+    
+    - name: test update glue job - updated role
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        role: my-glue-iam-role-2
+        state: present
+      register: result
+
+    - assert:
+      that: 
+        - result.changed
+        - result.role == 'my-glue-iam-role-2'
+    
+    - name: test update glue job - updated timeout
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script.py
+        role: my-glue-iam-role-2
+        timeout: 5760
+        state: present
+      register: result
+
+    - assert:
+      that:
+        - result.changed 
+        - result.timeout == 5760
+
+    - name: test update glue job - updated script location
+      aws_glue_job:
+        name: my-glue-job
+        command_script_location: s3bucket/glue-job-script2.py
+        role: my-glue-iam-role-2
+        state: present
+      register: result
+    
+    - assert:
+      that:
+        - result.changed
+        - result.command.name == 'glueetl'
+        - result.command.script_location == 's3bucket/glue-job-script2.py'
+    
+    # resource deletion 
+    - name: test delete glue job
+      aws_glue_job:
+        name: my-glue-job
+        state: absent
+      register: result
+    
+    - assert:
+      that:
+        - result.changed
+        - result.job_name == 'my-glue-job'
+        - result.execution_property is defined
   
   always:
     - name: delete glue job
       aws_glue_job:
         name: my-glue-job
         state: absent
-       

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -13,7 +13,7 @@
     # integration test setup
     - name: create aws glue iam role for integration tests
       iam_role:
-        name: my-glue-iam-role
+        name: '{{ role_name }}'
         description: IAM role needed for aws_glue_job integration tests.
         assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
         state: present
@@ -21,10 +21,10 @@
     # resource creation 
     - name: test create glue job
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
 
@@ -32,15 +32,15 @@
         that:
           - result.changed
           - result.arn is defined
-          - "result.arn | regex_search('^arn:aws:glue:([a-zA-Z0-9\\-]+):([0-9]+):job/my-glue-job$')"
+          - "result.arn | regex_search('^arn:aws:glue:([a-zA-Z0-9\\-]+):([0-9]+):job/{{ job_name }}$')"
 
     # resource creation idempotence
     - name: test idempotence when creating same glue job
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
 
@@ -51,10 +51,10 @@
     # resource modification - tags
     - name: test update glue job - add tags
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         tags:
           Environment: IntegrationTest
         state: present
@@ -69,10 +69,10 @@
     
     - name: test update glue job - update tags w/o purge
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         purge_tags: no
         tags:
           AnotherTag: foobar
@@ -91,10 +91,10 @@
 
     - name: test update glue job - update tags w/ purge
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         purge_tags: yes
         tags:
           Environment: IntegrationTest2
@@ -112,10 +112,10 @@
     
     - name: test update glue job - remove tags
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         purge_tags: yes
         state: present
       register: result
@@ -128,11 +128,11 @@
 
     - name: test update glue job - updated default args - set
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: "{{ lookup('file', 'args.json') }}"
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
 
@@ -144,12 +144,12 @@
 
     - name: test update glue job - updated default args - change
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: 
           '--job-bookmark-option': job-bookmark-disable
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
 
@@ -162,11 +162,11 @@
 
     - name: test update glue job - updated default args - remove
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: {}
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
 
@@ -178,11 +178,11 @@
 
     - name: test update glue job - update max retries
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         max_retries: 2
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
     
@@ -193,11 +193,11 @@
 
     - name: test update glue job - updated maximum concurrent runs
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         max_concurrent_runs: 5
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
     
@@ -208,10 +208,10 @@
     
     - name: test update glue job - updated timeout
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         timeout: 5760
         state: present
       register: result
@@ -223,10 +223,10 @@
 
     - name: test update glue job - updated script location
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         command_script_location: s3bucket/glue-job-script2.py
         connections: [ my-test-connection ]
-        role: my-glue-iam-role
+        role: '{{ role_name }}'
         state: present
       register: result
     
@@ -238,7 +238,7 @@
     # resource deletion 
     - name: test delete glue job
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         state: absent
       register: result
     
@@ -249,10 +249,10 @@
   always:
     - name: delete glue job
       aws_glue_job:
-        name: my-glue-job
+        name: '{{ job_name }}'
         state: absent
     
     - name: cleanup iam roles used in tests
       iam_role:
-        name: my-glue-iam-role
+        name: '{{ role_name }}'
         state: absent

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -4,7 +4,7 @@
     group/aws:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
+      security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   block:
@@ -12,23 +12,20 @@
     # integration test setup
     - name: create aws glue iam role for integration tests
       iam_role:
-        name: my-glue-iam-role
+        name: '{{ item }}'
         description: IAM role needed for aws_glue_job integration tests.
         assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
         state: present
-
-    - name: create second aws glue iam role for integration tests
-      iam_role:
-        name: my-glue-iam-role-2
-        description: IAM role needed for aws_glue_job integration tests.
-        assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
-        state: present
+      loop:
+        - my-glue-iam-role
+        - my-glue-iam-role-2
     
     # resource creation 
     - name: test create glue job
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
         role: my-glue-iam-role
         state: present
       register: result
@@ -42,6 +39,7 @@
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
         role: my-glue-iam-role
         state: present
       register: result
@@ -51,156 +49,151 @@
           - not result.changed
 
     # resource modification
-    - name: test update glue job - updated connections
-      aws_glue_job:
-        name: my-glue-job
-        command_script_location: s3bucket/glue-job-script.py
-        connections: [ my-test-connection ]
-        role: my-glue-iam-role
-        state: present
-      register: result
+    # - name: test update glue job - updated connections
+    #   aws_glue_job:
+    #     name: my-glue-job
+    #     command_script_location: s3bucket/glue-job-script.py
+    #     connections: [ my-test-connection, my-test-connection-2 ]
+    #     role: my-glue-iam-role
+    #     state: present
+    #   register: result
 
-    - assert:
-      that:
-        - result.changed
-        - result.connections | length == 1
+    # - assert:
+    #     that:
+    #       - result.changed
+    #       - result.connections | length == 2
 
-    - name: test update glue job - updated connections - removed
-      aws_glue_job:
-        name: my-glue-job
-        command_script_location: s3bucket/glue-job-script.py
-        connections: []
-        role: my-glue-iam-role
-        state: present
-      register: result
+    # - name: test update glue job - updated connections - removed
+    #   aws_glue_job:
+    #     name: my-glue-job
+    #     command_script_location: s3bucket/glue-job-script.py
+    #     connections: [ my-test-connection ]
+    #     role: my-glue-iam-role
+    #     state: present
+    #   register: result
 
-    - assert:
-      that:
-        - result.changed
-        - result.connections | length == 0
+    # - assert:
+    #     that:
+    #       - result.changed
+    #       - result.connections | length == 1
 
     - name: test update glue job - updated default args - set
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
         default_arguments: "{{ lookup('file', 'args.json') }}"
         role: my-glue-iam-role
         state: present
       register: result
 
     - assert:
-      that:
-        - result.changed
-        - result.default_arguments is defined
+        that:
+          - result.changed
+          - result.default_arguments is defined
 
     - name: test update glue job - updated default args - change
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
         default_arguments: "{{ lookup('file', 'args2.json') }}"
         role: my-glue-iam-role
         state: present
       register: result
 
     - assert:
-      that:
-        - result.changed
-        - result.default_arguments is defined
+        that:
+          - result.changed
+          - result.default_arguments is defined
 
     - name: test update glue job - updated default args - remove
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        default_arguments: {}
         role: my-glue-iam-role
         state: present
       register: result
 
     - assert:
-      that:
-        - result.changed
-        - result.default_arguments is not defined
+        that:
+          - result.changed
+          - result.default_arguments is defined
 
     - name: test update glue job - update max retries
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
         max_retries: 2
         role: my-glue-iam-role
         state: present
       register: result
     
     - assert: 
-      that:
-        - result.changed
-        - result.max_retries == 2
+        that:
+          - result.changed
+          - result.max_retries == 2
 
     - name: test update glue job - updated maximum concurrent runs
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
         max_concurrent_runs: 5
         role: my-glue-iam-role
         state: present
       register: result
     
     - assert: 
-      that: 
-        - result.changed
-        - result.execution_property.max_concurrent_runs == 5
-
-    - name: test update glue job - updated maximum concurrent runs - reset to default
-      aws_glue_job:
-        name: my-glue-job
-        command_script_location: s3bucket/glue-job-script.py
-        role: my-glue-iam-role
-        state: present
-      register: result
+        that: 
+          - result.changed
+          - result.execution_property.max_concurrent_runs == 5
     
-    - assert: 
-      that: 
-        - result.changed
-        - result.execution_property.max_concurrent_runs == 1
-    
-    - name: test update glue job - updated role
-      aws_glue_job:
-        name: my-glue-job
-        command_script_location: s3bucket/glue-job-script.py
-        role: my-glue-iam-role-2
-        state: present
-      register: result
+    # - name: test update glue job - updated role
+    #   aws_glue_job:
+    #     name: my-glue-job
+    #     command_script_location: s3bucket/glue-job-script.py
+    #     role: my-glue-iam-role-2
+    #     state: present
+    #   register: result
 
-    - assert:
-      that: 
-        - result.changed
-        - result.role == 'my-glue-iam-role-2'
+    # - assert:
+    #     that: 
+    #       - result.changed
+    #       - result.role == 'my-glue-iam-role-2'
     
     - name: test update glue job - updated timeout
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script.py
-        role: my-glue-iam-role-2
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
         timeout: 5760
         state: present
       register: result
 
     - assert:
-      that:
-        - result.changed 
-        - result.timeout == 5760
+        that:
+          - result.changed 
+          - result.timeout == 5760
 
     - name: test update glue job - updated script location
       aws_glue_job:
         name: my-glue-job
         command_script_location: s3bucket/glue-job-script2.py
-        role: my-glue-iam-role-2
+        connections: [ my-test-connection ]
+        role: my-glue-iam-role
         state: present
       register: result
     
     - assert:
-      that:
-        - result.changed
-        - result.command.name == 'glueetl'
-        - result.command.script_location == 's3bucket/glue-job-script2.py'
+        that:
+          - result.changed
+          - result.command.name == 'glueetl'
+          - result.command.script_location == 's3bucket/glue-job-script2.py'
     
     # resource deletion 
     - name: test delete glue job
@@ -210,13 +203,19 @@
       register: result
     
     - assert:
-      that:
-        - result.changed
-        - result.job_name == 'my-glue-job'
-        - result.execution_property is defined
+        that:
+          - result.changed
   
   always:
     - name: delete glue job
       aws_glue_job:
         name: my-glue-job
         state: absent
+    
+    - name: cleanup iam roles used in tests
+      iam_role:
+        name: '{{ item }}'
+        state: absent
+      loop:
+        - my-glue-iam-role
+        - my-glue-iam-role-2

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -13,7 +13,7 @@
     # integration test setup
     - name: create aws glue iam role for integration tests
       iam_role:
-        name: '{{ role_name }}'
+        name: '{{ glue_role_name }}'
         description: IAM role needed for aws_glue_job integration tests.
         assume_role_policy_document: "{{ lookup('file', 'policy.json') }}"
         state: present
@@ -21,10 +21,10 @@
     # resource creation 
     - name: test create glue job
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -32,15 +32,15 @@
         that:
           - result.changed
           - result.arn is defined
-          - "result.arn | regex_search('^arn:aws:glue:([a-zA-Z0-9\\-]+):([0-9]+):job/{{ job_name }}$')"
+          - "result.arn | regex_search('^arn:aws:glue:([a-zA-Z0-9\\-]+):([0-9]+):job/{{ glue_job_name }}$')"
     
     # resource creation idempotence
     - name: test idempotence when creating same glue job
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -51,10 +51,10 @@
     # resource modification - tags
     - name: test update glue job - add tags
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         tags:
           Environment: IntegrationTest
         state: present
@@ -69,10 +69,10 @@
 
     - name: test update glue job - add tags - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         tags:
           Environment: IntegrationTest
         state: present
@@ -84,10 +84,10 @@
     
     - name: test update glue job - update tags w/o purge
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         purge_tags: no
         tags:
           AnotherTag: foobar
@@ -106,10 +106,10 @@
 
     - name: test update glue job - update tags w/o purge - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         purge_tags: no
         tags:
           AnotherTag: foobar
@@ -123,10 +123,10 @@
 
     - name: test update glue job - update tags w/ purge
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         purge_tags: yes
         tags:
           Environment: IntegrationTest2
@@ -144,10 +144,10 @@
     
     - name: test update glue job - remove tags
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         purge_tags: yes
         state: present
       register: result
@@ -160,10 +160,10 @@
 
     - name: test update glue job - remove tags - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         purge_tags: yes
         state: present
       register: result
@@ -174,11 +174,11 @@
 
     - name: test update glue job - updated default args - set
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: "{{ lookup('file', 'args.json') }}"
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -190,11 +190,11 @@
 
     - name: test update glue job - updated default args - set - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: "{{ lookup('file', 'args.json') }}"
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -204,12 +204,12 @@
 
     - name: test update glue job - updated default args - change
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: 
           '--job-bookmark-option': job-bookmark-disable
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -222,12 +222,12 @@
 
     - name: test update glue job - updated default args - change - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: 
           '--job-bookmark-option': job-bookmark-disable
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -237,11 +237,11 @@
 
     - name: test update glue job - updated default args - remove
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: {}
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -253,11 +253,11 @@
 
     - name: test update glue job - updated default args - remove - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         default_arguments: {}
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
 
@@ -267,11 +267,11 @@
 
     - name: test update glue job - update max retries
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         max_retries: 2
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
     
@@ -282,11 +282,11 @@
 
     - name: test update glue job - update max retries - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         max_retries: 2
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
     
@@ -296,11 +296,11 @@
 
     - name: test update glue job - updated maximum concurrent runs
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         max_concurrent_runs: 5
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
     
@@ -311,11 +311,11 @@
 
     - name: test update glue job - updated maximum concurrent runs - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         max_concurrent_runs: 5
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
     
@@ -325,10 +325,10 @@
     
     - name: test update glue job - updated timeout
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         timeout: 5760
         state: present
       register: result
@@ -340,10 +340,10 @@
 
     - name: test update glue job - updated timeout - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         timeout: 5760
         state: present
       register: result
@@ -354,10 +354,10 @@
 
     - name: test update glue job - updated script location
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script2.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
     
@@ -368,10 +368,10 @@
 
     - name: test update glue job - updated script location - idempotence
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         command_script_location: s3bucket/glue-job-script2.py
         connections: [ my-test-connection ]
-        role: '{{ role_name }}'
+        role: '{{ glue_role_name }}'
         state: present
       register: result
     
@@ -382,7 +382,7 @@
     # resource deletion 
     - name: test delete glue job
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         state: absent
       register: result
     
@@ -393,10 +393,10 @@
   always:
     - name: delete glue job
       aws_glue_job:
-        name: '{{ job_name }}'
+        name: '{{ glue_job_name }}'
         state: absent
     
     - name: cleanup iam roles used in tests
       iam_role:
-        name: '{{ role_name }}'
+        name: '{{ glue_role_name }}'
         state: absent

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -6,7 +6,6 @@
       aws_secret_key: "{{ aws_secret_key }}"
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
-      purge_tags: no
 
   block:
     
@@ -148,6 +147,7 @@
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         role: '{{ glue_role_name }}'
+        tags: {}
         purge_tags: yes
         state: present
       register: result
@@ -164,6 +164,7 @@
         command_script_location: s3bucket/glue-job-script.py
         connections: [ my-test-connection ]
         role: '{{ glue_role_name }}'
+        tags: {}
         purge_tags: yes
         state: present
       register: result

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -1,0 +1,40 @@
+- name: set up aws connection info
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+
+  block:
+
+    - name: create glue job
+      aws_glue_job:
+        command_script_location: s3bucket/script.py
+        name: my-glue-job
+        role: my-iam-role
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - result.changed
+
+    - name: test idempotence when creating same glue job
+      aws_glue_job:
+        command_script_location: s3bucket/script.py
+        name: my-glue-job
+        role: my-iam-role
+        state: present
+      register: result
+
+    - assert:
+        that: 
+          - not result.changed
+  
+  always:
+    - name: delete glue job
+      aws_glue_job:
+        name: my-glue-job
+        state: absent
+       

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -33,7 +33,7 @@
           - result.changed
           - result.arn is defined
           - "result.arn | regex_search('^arn:aws:glue:([a-zA-Z0-9\\-]+):([0-9]+):job/{{ job_name }}$')"
-
+    
     # resource creation idempotence
     - name: test idempotence when creating same glue job
       aws_glue_job:
@@ -66,6 +66,21 @@
           - result.tags is defined
           - result.tags.Environment == 'IntegrationTest'
           - ((result.tags | dict2items) | length) == 1
+
+    - name: test update glue job - add tags - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: '{{ role_name }}'
+        tags:
+          Environment: IntegrationTest
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed
     
     - name: test update glue job - update tags w/o purge
       aws_glue_job:
@@ -88,6 +103,23 @@
           - result.tags.AnotherTag == 'foobar'
           - result.tags.YetAnotherTag == 'hello_world'
           - ((result.tags | dict2items) | length) == 3
+
+    - name: test update glue job - update tags w/o purge - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: '{{ role_name }}'
+        purge_tags: no
+        tags:
+          AnotherTag: foobar
+          YetAnotherTag: hello_world
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed 
 
     - name: test update glue job - update tags w/ purge
       aws_glue_job:
@@ -126,6 +158,20 @@
           - result.tags is defined
           - ((result.tags | dict2items) | length) == 0
 
+    - name: test update glue job - remove tags - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: '{{ role_name }}'
+        purge_tags: yes
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed 
+
     - name: test update glue job - updated default args - set
       aws_glue_job:
         name: '{{ job_name }}'
@@ -141,6 +187,20 @@
           - result.changed
           - result.default_arguments is defined
           - ((result.default_arguments | dict2items) | length) == 2
+
+    - name: test update glue job - updated default args - set - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        default_arguments: "{{ lookup('file', 'args.json') }}"
+        role: '{{ role_name }}'
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed
 
     - name: test update glue job - updated default args - change
       aws_glue_job:
@@ -160,6 +220,21 @@
           - ((result.default_arguments | dict2items) | length) == 1
           - "result.default_arguments['--job-bookmark-option'] == 'job-bookmark-disable'"
 
+    - name: test update glue job - updated default args - change - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        default_arguments: 
+          '--job-bookmark-option': job-bookmark-disable
+        role: '{{ role_name }}'
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed
+
     - name: test update glue job - updated default args - remove
       aws_glue_job:
         name: '{{ job_name }}'
@@ -176,6 +251,20 @@
           - result.default_arguments is defined
           - ((result.default_arguments | dict2items) | length) == 0
 
+    - name: test update glue job - updated default args - remove - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        default_arguments: {}
+        role: '{{ role_name }}'
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed
+
     - name: test update glue job - update max retries
       aws_glue_job:
         name: '{{ job_name }}'
@@ -191,6 +280,20 @@
           - result.changed
           - result.max_retries == 2
 
+    - name: test update glue job - update max retries - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        max_retries: 2
+        role: '{{ role_name }}'
+        state: present
+      register: result
+    
+    - assert: 
+        that:
+          - not result.changed
+
     - name: test update glue job - updated maximum concurrent runs
       aws_glue_job:
         name: '{{ job_name }}'
@@ -205,6 +308,20 @@
         that: 
           - result.changed
           - result.execution_property.max_concurrent_runs == 5
+
+    - name: test update glue job - updated maximum concurrent runs - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        max_concurrent_runs: 5
+        role: '{{ role_name }}'
+        state: present
+      register: result
+    
+    - assert: 
+        that: 
+          - not result.changed
     
     - name: test update glue job - updated timeout
       aws_glue_job:
@@ -221,6 +338,20 @@
           - result.changed 
           - result.timeout == 5760
 
+    - name: test update glue job - updated timeout - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script.py
+        connections: [ my-test-connection ]
+        role: '{{ role_name }}'
+        timeout: 5760
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - not result.changed
+
     - name: test update glue job - updated script location
       aws_glue_job:
         name: '{{ job_name }}'
@@ -234,6 +365,19 @@
         that:
           - result.changed
           - result.command.script_location == 's3bucket/glue-job-script2.py'
+
+    - name: test update glue job - updated script location - idempotence
+      aws_glue_job:
+        name: '{{ job_name }}'
+        command_script_location: s3bucket/glue-job-script2.py
+        connections: [ my-test-connection ]
+        role: '{{ role_name }}'
+        state: present
+      register: result
+    
+    - assert:
+        that:
+          - not result.changed
 
     # resource deletion 
     - name: test delete glue job


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a `tags` & `purge_tags` parameter to the `aws_glue_job` module. This change also returns `tags` and `arn` in the response object when using this module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`aws_glue_job`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Today, the `aws_glue_job` module does not allow the setting of AWS resource tags, however the underlying `boto3` client supports tagging and untagging of AWS Glue resources. This PR should allow tags to be set and removed using the `tags` & `purge_tags` parameters.

This PR is also adding integration tests for this module since there was not existing coverage here.