### PR TITLE
Update documentation for security_groups parameter

### DIFF
--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -311,7 +311,9 @@ options:
     type: list
     elements: str
   security_groups:
-    description: A list of security group names (VPC or EC2-Classic) that the new instances will be added to.
+    description: >
+      A list of security group names (Default VPC or EC2-Classic) that the new instances will be added to.
+      For any VPC other than Default, you must use I(security_group_ids).
     type: list
     elements: str
   tags:


### PR DESCRIPTION
Clarified documentation surrounding using security_groups for any VPC other than Default.

##### SUMMARY
Updated documentation for security_groups param as it caught me out.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_launch_template

##### ADDITIONAL INFORMATION
N/A