### PR TITLE
dynamodb_table: AnsibleAwsModule, billing_mode, point_in_time_recovery

### DIFF
--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -2,6 +2,7 @@
 # Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import traceback
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -11,18 +12,18 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: dynamodb_table
 short_description: Create, update or delete AWS Dynamo DB tables
+version_added: "2.0"
 description:
   - Create or delete AWS Dynamo DB tables.
   - Can update the provisioned throughput on existing tables.
   - Returns the status of the specified table.
 author: Alan Loi (@loia)
 requirements:
-  - "boto >= 2.37.0"
-  - "boto3 >= 1.4.4 (for tagging)"
+  - "boto3 >= 1.4.4"
 options:
   state:
     description:
@@ -56,6 +57,12 @@ options:
     choices: ['STRING', 'NUMBER', 'BINARY']
     default: 'STRING'
     type: str
+  billing_mode:
+    version_added: "2.10"
+    description:
+      - Controls how you are charged for read and write throughput and how you manage capacity.
+    choices: ['PROVISIONED', 'PAY_PER_REQUEST']
+    type: str
   read_capacity:
     description:
       - Read throughput capacity (units) to provision.
@@ -66,6 +73,12 @@ options:
       - Write throughput capacity (units) to provision.
     default: 1
     type: int
+  point_in_time_recovery:
+    version_added: "2.10"
+    description:
+      - Disables or enables point in time recovery on the table.
+    default: False
+    type: bool
   indexes:
     description:
       - list of dictionaries describing indexes to add to the table. global indexes can be updated. local indexes don't support updates or have throughput.
@@ -107,25 +120,62 @@ options:
           - Write throughput capacity (units) to provision for the index.
         type: int
     default: []
+    version_added: "2.1"
     type: list
     elements: dict
   tags:
+    version_added: "2.4"
     description:
       - A hash/dictionary of tags to add to the new instance or for starting/stopping instance by tag.
       - 'For example: C({"key":"value"}) and C({"key":"value","key2":"value2"})'
     type: dict
+  purge_tags:
+    version_added: "2.10"
+    description:
+      - Disables or enables tag purging on the table.
+    default: False
+    type: bool
   wait_for_active_timeout:
+    version_added: "2.4"
     description:
       - how long before wait gives up, in seconds. only used when tags is set
     default: 60
     type: int
+  sse_enabled:
+    version_added: "2.10"
+    type: bool
+    description:
+    - boolean for setting server-side encryption
+  stream_enabled:
+    version_added: "2.10"
+    type: bool
+    description:
+    - Indicates whether DynamoDB Streams is enabled (true) or disabled (false) on the table
+  stream_view_type:
+    version_added: "2.10"
+    type: str
+    choices: ['KEYS_ONLY', 'NEW_IMAGE', 'OLD_IMAGE', 'NEW_AND_OLD_IMAGES']
+    description:
+    - when an item in the table is modified, stream_view_type determines what information is written to the stream for this table.
+    - "valid types: : ['KEYS_ONLY', 'NEW_IMAGE', 'OLD_IMAGE', 'NEW_AND_OLD_IMAGES']"
+  sse_type:
+    version_added: "2.10"
+    type: str
+    choices: ['AES256', 'KMS']
+    description:
+    - server-side encryption type
+  sse_kms_master_key_id:
+    version_added: "2.10"
+    type: str
+    description:
+    - The KMS Master Key (CMK) which should be used for the KMS encryption.
+    - To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+    - aws
+    - ec2
+"""
 
-'''
-
-EXAMPLES = '''
+EXAMPLES = """
 # Create dynamo table with hash and range primary key
 - dynamodb_table:
     name: my-table
@@ -145,6 +195,14 @@ EXAMPLES = '''
     region: us-east-1
     read_capacity: 10
     write_capacity: 10
+
+# Switch to On-demand capacity and enable point in time recovery on existing dynamo table
+- dynamodb_table:
+    name: my-table
+    region: us-east-1
+    billing_mode: PAY_PER_REQUEST
+    point_in_time_recovery: True
+
 
 # set index on existing dynamo table
 - dynamodb_table:
@@ -166,150 +224,431 @@ EXAMPLES = '''
     name: my-table
     region: us-east-1
     state: absent
-'''
+"""
 
-RETURN = '''
+RETURN = """
 table_status:
     description: The current status of the table.
     returned: success
     type: str
     sample: ACTIVE
-'''
+"""
 
-import time
-import traceback
 
 try:
-    import boto
-    import boto.dynamodb2
-    from boto.dynamodb2.table import Table
-    from boto.dynamodb2.fields import HashKey, RangeKey, AllIndex, GlobalAllIndex, GlobalIncludeIndex, GlobalKeysOnlyIndex, IncludeIndex, KeysOnlyIndex
-    from boto.dynamodb2.types import STRING, NUMBER, BINARY
-    from boto.exception import BotoServerError, NoAuthHandlerFound, JSONResponseError
-    from boto.dynamodb2.exceptions import ValidationException
-    HAS_BOTO = True
-
-    DYNAMO_TYPE_MAP = {
-        'STRING': STRING,
-        'NUMBER': NUMBER,
-        'BINARY': BINARY
-    }
-
+    from ansible.module_utils.ec2 import (
+        AWSRetry,
+        ansible_dict_to_boto3_tag_list,
+        boto3_tag_list_to_ansible_dict,
+        compare_aws_tags,
+    )
+    from ansible.module_utils.aws.core import (
+        AnsibleAWSModule,
+        is_boto3_error_code,
+    )
+    from ansible.module_utils.common.dict_transformations import dict_merge
+    from botocore.exceptions import (
+        ClientError,
+        NoCredentialsError,
+    )
 except ImportError:
-    HAS_BOTO = False
-
-try:
-    import botocore
-    from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list, boto3_conn
-    HAS_BOTO3 = True
-except ImportError:
-    HAS_BOTO3 = False
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+    pass  # caught by AnsibleAWSModule
 
 
 DYNAMO_TYPE_DEFAULT = 'STRING'
-INDEX_REQUIRED_OPTIONS = ['name', 'type', 'hash_key_name']
-INDEX_OPTIONS = INDEX_REQUIRED_OPTIONS + ['hash_key_type', 'range_key_name', 'range_key_type', 'includes', 'read_capacity', 'write_capacity']
-INDEX_TYPE_OPTIONS = ['all', 'global_all', 'global_include', 'global_keys_only', 'include', 'keys_only']
+INDEX_REQUIRED_OPTIONS = [
+    'name',
+    'type',
+    'hash_key_name'
+]
+INDEX_OPTIONS = INDEX_REQUIRED_OPTIONS + [
+    'hash_key_type',
+    'range_key_name',
+    'range_key_type',
+    'includes',
+    'read_capacity',
+    'write_capacity'
+]
+INDEX_TYPE_OPTIONS = [
+    'all',
+    'global_all',
+    'global_include',
+    'global_keys_only',
+    'include',
+    'keys_only'
+]
 
 
-def create_or_update_dynamo_table(connection, module, boto3_dynamodb=None, boto3_sts=None, region=None):
+@AWSRetry.exponential_backoff(
+    catch_extra_error_codes=['DynamoDBTableNotActive']
+)
+def wait_for_table_active(table):
+    table.load()
+
+    if table.table_status == 'ACTIVE':
+        return
+
+    elif table.table_status in ('CREATING', 'UPDATING'):
+        raise ClientError(
+            {
+                'Error': {
+                    'Code': 'DynamoDBTableNotActive',
+                    'Message': "Table '{0}' status is {1}. Expecting ACTIVE.".format(
+                        table.table_name,
+                        table.table_status
+                    )
+                }
+            },
+            'DynamoDBTableWaitForActive'
+        )
+
+    raise Exception(
+        "Error validating ACTIVE state of '{0}' DynamoDB table.".format(
+            table.table_name)
+    )
+
+
+@AWSRetry.exponential_backoff()
+def get_table_tags_change(
+        client,
+        table,
+        tags,
+        purge_tags=False):
+
+    table_tags = boto3_tag_list_to_ansible_dict(
+        client.list_tags_of_resource(
+            ResourceArn=table.table_arn
+        )['Tags']
+    )
+
+    tags_add, tags_remove = compare_aws_tags(
+        table_tags,
+        tags,
+        purge_tags=purge_tags
+    )
+
+    result_tags = dict(
+        (k, v)
+        for k, v in dict_merge(tags, table_tags).items()
+        if k not in tags_remove
+    )
+
+    return {
+        'changed': tags_add or tags_remove,
+        'add': tags_add,
+        'remove': tags_remove,
+        'tags': result_tags
+    }
+
+
+@AWSRetry.exponential_backoff()
+def update_table_tags(
+        client,
+        table,
+        tags,
+        purge_tags=False):
+
+    tags_change = get_table_tags_change(
+        client,
+        table,
+        tags,
+        purge_tags
+    )
+
+    if not tags_change['changed']:
+        return tags_change
+
+    if tags_change['remove']:
+        client.untag_resource(
+            ResourceArn=table.table_arn,
+            TagKeys=tags_change['remove']
+        )
+
+    if tags_change['add']:
+        client.tag_resource(
+            ResourceArn=table.table_arn,
+            Tags=ansible_dict_to_boto3_tag_list(tags_change['add'])
+        )
+
+    return tags_change
+
+
+@AWSRetry.exponential_backoff()
+def has_continuous_backup_changed(
+        client,
+        table,
+        point_in_time_recovery):
+
+    table_continuous_backup = client.describe_continuous_backups(
+        TableName=table.table_name
+    )['ContinuousBackupsDescription']
+
+    current_point_in_time_recovery = (
+        table_continuous_backup['PointInTimeRecoveryDescription']['PointInTimeRecoveryStatus'] == 'ENABLED'
+    )
+
+    return point_in_time_recovery != current_point_in_time_recovery
+
+
+@AWSRetry.exponential_backoff(
+    catch_extra_error_codes=['ContinuousBackupsUnavailableException']
+)
+def update_table_continuous_backups(
+        client,
+        table,
+        is_point_in_time_recovery):
+
+    if not has_continuous_backup_changed(client, table, is_point_in_time_recovery):
+        return
+
+    client.update_continuous_backups(
+        TableName=table.table_name,
+        PointInTimeRecoverySpecification={
+            'PointInTimeRecoveryEnabled': is_point_in_time_recovery
+        }
+    )
+
+
+def create_or_update_dynamo_table(resource, module):
     table_name = module.params.get('name')
     hash_key_name = module.params.get('hash_key_name')
     hash_key_type = module.params.get('hash_key_type')
     range_key_name = module.params.get('range_key_name')
     range_key_type = module.params.get('range_key_type')
+    billing_mode = module.params.get('billing_mode')
     read_capacity = module.params.get('read_capacity')
     write_capacity = module.params.get('write_capacity')
     all_indexes = module.params.get('indexes')
     tags = module.params.get('tags')
+    purge_tags = module.params.get('purge_tags')
     wait_for_active_timeout = module.params.get('wait_for_active_timeout')
+
+    # stream specification
+    stream_enabled = module.params.get('stream_enabled')
+    stream_view_type = module.params.get('stream_view_type')
+
+    # sse specification
+    sse_enabled = module.params.get('sse_enabled')
+    sse_type = module.params.get('sse_type')
+    sse_kms_master_key_id = module.params.get('sse_kms_master_key_id')
+
+    point_in_time_recovery = module.params.get('point_in_time_recovery')
+
+    key_type_mapping = {'STRING': 'S', 'BINARY': 'B', 'NUMBER': 'N'}
 
     for index in all_indexes:
         validate_index(index, module)
-
-    schema = get_schema_param(hash_key_name, hash_key_type, range_key_name, range_key_type)
 
     throughput = {
         'read': read_capacity,
         'write': write_capacity
     }
+    stream_specification = None
+    sse_specification = None
+    if stream_enabled:
+        stream_specification = {
+            'StreamEnabled': stream_enabled,
+            'StreamViewType': stream_view_type
+        }
+    if sse_enabled:
+        sse_specification = {
+            'Enabled': sse_enabled,
+            'SSEType': sse_type
+        }
+        if sse_kms_master_key_id and sse_kms_master_key_id != '':
+            sse_specification.update({'KMSMasterKeyId': sse_kms_master_key_id})
 
-    indexes, global_indexes = get_indexes(all_indexes)
+    (
+        local_secondary_indexes,
+        global_secondary_indexes,
+        attribute_definitions
+    ) = serialize_indexes(all_indexes, billing_mode)
 
     result = dict(
-        region=region,
         table_name=table_name,
+        billing_mode=billing_mode,
+        point_in_time_recovery=point_in_time_recovery,
         hash_key_name=hash_key_name,
         hash_key_type=hash_key_type,
         range_key_name=range_key_name,
         range_key_type=range_key_type,
-        read_capacity=read_capacity,
-        write_capacity=write_capacity,
         indexes=all_indexes,
     )
 
     try:
-        table = Table(table_name, connection=connection)
+        client = module.client('dynamodb')
+        table = resource.Table(table_name)
 
-        if dynamo_table_exists(table):
-            result['changed'] = update_dynamo_table(table, throughput=throughput, check_mode=module.check_mode, global_indexes=global_indexes)
-        else:
-            if not module.check_mode:
-                Table.create(table_name, connection=connection, schema=schema, throughput=throughput, indexes=indexes, global_indexes=global_indexes)
+        try:
+            table_status = table.table_status
+        except is_boto3_error_code('ResourceNotFoundException'):
+            table_status = 'TABLE_NOT_FOUND'
+
+        if table_status in ('ACTIVE', 'CREATING', 'UPDATING'):
+            # The table exists and might need to be updated.
+            wait_for_table_active(table)
+
+            result.update(
+                update_dynamo_table(
+                    module,
+                    client,
+                    table,
+                    billing_mode=billing_mode,
+                    throughput=throughput,
+                    stream_spec=stream_specification,
+                    sse_spec=sse_specification,
+                    point_in_time_recovery=point_in_time_recovery,
+                    check_mode=module.check_mode,
+                    global_indexes=global_secondary_indexes,
+                    global_attr_definitions=attribute_definitions
+                )
+            )
+
+            if tags:
+                tags_change = (
+                    get_table_tags_change(
+                        client,
+                        table,
+                        tags,
+                        purge_tags
+                    )
+                    if module.check_mode
+                    else update_table_tags(
+                        client,
+                        table,
+                        tags,
+                        purge_tags
+                    )
+                )
+
+                if tags_change['changed'] and not result['changed']:
+                    result['changed'] = True
+
+                result['tags'] = tags_change['tags']
+
+        elif not module.check_mode:
+            # The table doesn't exist and needs to be created.
             result['changed'] = True
 
-        if not module.check_mode:
-            result['table_status'] = table.describe()['Table']['TableStatus']
+            kwargs = {}
+            key_schema = []
 
-        if tags:
-            # only tables which are active can be tagged
-            wait_until_table_active(module, table, wait_for_active_timeout)
-            account_id = get_account_id(boto3_sts)
-            boto3_dynamodb.tag_resource(
-                ResourceArn='arn:aws:dynamodb:' +
-                region +
-                ':' +
-                account_id +
-                ':table/' +
-                table_name,
-                Tags=ansible_dict_to_boto3_tag_list(tags))
+            if range_key_name:
+                key_schema.append(
+                    {'AttributeName': hash_key_name, 'KeyType': 'HASH'})
+                key_schema.append(
+                    {'AttributeName': range_key_name, 'KeyType': 'RANGE'})
+                attribute_definitions.append(
+                    {
+                        'AttributeName': hash_key_name,
+                        'AttributeType': key_type_mapping[hash_key_type.upper()]
+                    }
+                )
+                attribute_definitions.append(
+                    {
+                        'AttributeName': range_key_name,
+                        'AttributeType': key_type_mapping[range_key_type.upper()]
+                    }
+                )
+            else:
+                key_schema.append(
+                    {'AttributeName': hash_key_name, 'KeyType': 'HASH'})
+                attribute_definitions.append(
+                    {
+                        'AttributeName': hash_key_name,
+                        'AttributeType': key_type_mapping[hash_key_type.upper()]
+                    }
+                )
+
+            kwargs.update(
+                {
+                    'AttributeDefinitions': remove_duplicates(attribute_definitions),
+                    'TableName': table_name,
+                    'KeySchema': key_schema
+                }
+            )
+
+            if billing_mode == 'PAY_PER_REQUEST':
+                kwargs.update({'BillingMode': 'PAY_PER_REQUEST'})
+                result['billing_mode'] = 'PAY_PER_REQUEST'
+            else:
+                kwargs.update(
+                    {
+                        'ProvisionedThroughput': {
+                            'ReadCapacityUnits': read_capacity,
+                            'WriteCapacityUnits': write_capacity
+                        }
+                    }
+                )
+                result['billing_mode'] = 'PROVISIONED'
+
+            if local_secondary_indexes:
+                kwargs.update(
+                    {'LocalSecondaryIndexes': local_secondary_indexes})
+            if global_secondary_indexes:
+                kwargs.update(
+                    {'GlobalSecondaryIndexes': global_secondary_indexes})
+            if stream_specification:
+                kwargs.update({'StreamSpecification': stream_specification})
+            if sse_specification:
+                kwargs.update({'SSESpecification': sse_specification})
+
+            resource.create_table(**kwargs)
+
+            if point_in_time_recovery:
+                wait_for_table_active(table)
+                update_table_continuous_backups(
+                    client,
+                    table,
+                    point_in_time_recovery
+                )
+
+            if tags:
+                wait_for_table_active(table)
+                result['tags'] = update_table_tags(
+                    client,
+                    table,
+                    tags,
+                    purge_tags
+                )['tags']
+
+            result['table_status'] = table.table_status
+            result['global_secondary_indexes'] = table.global_secondary_indexes
+            result['local_secondary_indexes'] = table.local_secondary_indexes
+
+        else:
+            # The table doesn't exist and creation skipped due to check_mode.
+            result['changed'] = True
             result['tags'] = tags
 
-    except BotoServerError:
-        result['msg'] = 'Failed to create/update dynamo table due to error: ' + traceback.format_exc()
-        module.fail_json(**result)
+    except NoCredentialsError as e:
+        module.fail_json_aws(
+            e, 'Unable to locate credentials: ' + traceback.format_exc())
+    except ClientError as e:
+        module.fail_json_aws(e, 'Client Error: ' + traceback.format_exc())
+    except Exception as e:
+        module.fail_json_aws(
+            e, 'Ansible dynamodb operation failed: ' + traceback.format_exc())
     else:
         module.exit_json(**result)
 
 
-def get_account_id(boto3_sts):
-    return boto3_sts.get_caller_identity()["Account"]
-
-
-def wait_until_table_active(module, table, wait_timeout):
-    max_wait_time = time.time() + wait_timeout
-    while (max_wait_time > time.time()) and (table.describe()['Table']['TableStatus'] != 'ACTIVE'):
-        time.sleep(5)
-    if max_wait_time <= time.time():
-        # waiting took too long
-        module.fail_json(msg="timed out waiting for table to exist")
-
-
-def delete_dynamo_table(connection, module):
+def delete_dynamo_table(resource, module):
     table_name = module.params.get('name')
 
     result = dict(
-        region=module.params.get('region'),
         table_name=table_name,
     )
 
     try:
-        table = Table(table_name, connection=connection)
+        table = resource.Table(table_name)
+        table.wait_until_exists()
+        try:
+            table_status = table.table_status
+        except is_boto3_error_code('ResourceNotFoundException'):
+            table_status = 'TABLE_NOT_FOUND'
 
-        if dynamo_table_exists(table):
+        if table_status == 'ACTIVE':
             if not module.check_mode:
                 table.delete()
             result['changed'] = True
@@ -317,104 +656,331 @@ def delete_dynamo_table(connection, module):
         else:
             result['changed'] = False
 
-    except BotoServerError:
-        result['msg'] = 'Failed to delete dynamo table due to error: ' + traceback.format_exc()
-        module.fail_json(**result)
+    except ClientError as e:
+        module.fail_json_aws(
+            e, 'Failed to delete dynamo table due to error: ' + traceback.format_exc())
     else:
         module.exit_json(**result)
 
 
-def dynamo_table_exists(table):
-    try:
-        table.describe()
-        return True
+def update_dynamodb_table_args(
+        table_name,
+        billing_mode=None,
+        prov_throughput=None,
+        stream_spec=None,
+        sse_spec=None,
+        global_indexes=None,
+        global_attr_definitions=None):
+    kwargs = {}
 
-    except JSONResponseError as e:
-        if e.message and e.message.startswith('Requested resource not found'):
-            return False
-        else:
-            raise e
+    if billing_mode is not None:
+        kwargs.update({'BillingMode': billing_mode})
+
+    if prov_throughput is not None:
+        kwargs.update({'ProvisionedThroughput': prov_throughput})
+
+    if global_indexes is not None:
+        kwargs.update(
+            {
+                'AttributeDefinitions': global_attr_definitions,
+                'GlobalSecondaryIndexUpdates': global_indexes
+            }
+        )
+
+    if stream_spec is not None:
+        kwargs.update({'StreamSpecification': stream_spec})
+
+    if isinstance(sse_spec, dict):
+        # if kms master key id is empty pop it off
+        if 'KMSMasterKeyId' in sse_spec and sse_spec['KMSMasterKeyId'] == '':
+            sse_spec.pop('KMSMasterKeyId', None)
+
+        kwargs.update({'SSESpecification': sse_spec})
+
+    if kwargs:
+        kwargs.update({'TableName': table_name})
+
+    return kwargs
 
 
-def update_dynamo_table(table, throughput=None, check_mode=False, global_indexes=None):
-    table.describe()  # populate table details
-    throughput_changed = False
-    global_indexes_changed = False
-    if has_throughput_changed(table, throughput):
-        if not check_mode:
-            throughput_changed = table.update(throughput=throughput)
-        else:
-            throughput_changed = True
+def update_dynamo_table(
+        module,
+        client,
+        table,
+        billing_mode=None,
+        throughput=None,
+        stream_spec=None,
+        sse_spec=None,
+        point_in_time_recovery=None,
+        check_mode=False,
+        global_indexes=None,
+        global_attr_definitions=None):
 
-    removed_indexes, added_indexes, index_throughput_changes = get_changed_global_indexes(table, global_indexes)
-    if removed_indexes:
-        if not check_mode:
-            for name, index in removed_indexes.items():
-                global_indexes_changed = table.delete_global_secondary_index(name) or global_indexes_changed
-        else:
-            global_indexes_changed = True
+    if global_indexes is None:
+        global_indexes = []
 
-    if added_indexes:
-        if not check_mode:
-            for name, index in added_indexes.items():
-                global_indexes_changed = table.create_global_secondary_index(global_index=index) or global_indexes_changed
-        else:
-            global_indexes_changed = True
+    change_state = {
+        'changed': False
+    }
+    table_name = table.table_name
 
-    if index_throughput_changes:
-        if not check_mode:
-            # todo: remove try once boto has https://github.com/boto/boto/pull/3447 fixed
-            try:
-                global_indexes_changed = table.update_global_secondary_index(global_indexes=index_throughput_changes) or global_indexes_changed
-            except ValidationException:
-                pass
-        else:
-            global_indexes_changed = True
+    # NOTE: BillingModeSummary is NOT returned strangely if you are using
+    # provisioned but IS returned if you are using PAY_PER_REQUEST
+    # (https://github.com/boto/boto3/issues/1875)
+    current_billing_mode = (
+        table.billing_mode_summary['BillingMode']
+        if table.billing_mode_summary
+        else 'PROVISIONED'
+    )
 
-    return throughput_changed or global_indexes_changed
+    set_billing_mode = (
+        billing_mode
+        if current_billing_mode != billing_mode
+        else None
+    )
+
+    # Ignore ProvisionedThroughput if desired BillingMode is 'PAY_PER_REQUEST'.
+    if ((set_billing_mode is None and current_billing_mode == 'PROVISIONED')
+            or set_billing_mode == 'PROVISIONED'
+        ) and has_throughput_changed(table, throughput):
+        set_prov_throughput = {
+            'ReadCapacityUnits': throughput['read'],
+            'WriteCapacityUnits': throughput['write']
+        }
+    else:
+        set_prov_throughput = None
+
+    set_global_indexes = get_changed_global_indexes(
+        table.global_secondary_indexes,
+        global_indexes
+    )
+
+    set_stream_spec = (
+        has_stream_spec_changed(table, stream_spec)
+        if stream_spec
+        else None
+    )
+
+    set_sse_spec = (
+        has_sse_spec_changed(table, sse_spec)
+        if sse_spec
+        else None
+    )
+
+    set_continuous_backup = has_continuous_backup_changed(
+        client,
+        table,
+        point_in_time_recovery
+    )
+
+    kwargs = update_dynamodb_table_args(
+        table_name,
+        billing_mode=set_billing_mode,
+        prov_throughput=set_prov_throughput,
+        stream_spec=set_stream_spec,
+        sse_spec=set_sse_spec,
+        global_indexes=set_global_indexes,
+        global_attr_definitions=global_attr_definitions
+    )
+
+    # Prepare state change response
+    if set_billing_mode is not None:
+        # billing_mode is always displayed, therefore only 'changed' is updated.
+        change_state['changed'] = True
+        change_state['billing_mode'] = set_billing_mode
+    else:
+        change_state['billing_mode'] = current_billing_mode
+
+    if set_prov_throughput is not None:
+        change_state.update(
+            {
+                'changed': True,
+                'read_capacity': set_prov_throughput['ReadCapacityUnits'],
+                'write_capacity': set_prov_throughput['WriteCapacityUnits']
+            }
+        )
+    elif billing_mode == 'PROVISIONED':
+        # Display read/write capacity even if not changed when appropriate.
+        change_state.update(
+            {
+                'read_capacity': throughput['read'],
+                'write_capacity': throughput['write']
+            }
+        )
+
+    if set_global_indexes is not None:
+        change_state.update(
+            {
+                'changed': True,
+                'global_indexes_updates': set_global_indexes
+            }
+        )
+
+    if set_continuous_backup:
+        # point_in_time_recovery is always displayed, therefore only 'changed' is updated.
+        change_state['changed'] = True
+
+    if check_mode:
+        return change_state
+
+    if kwargs:
+        client.update_table(**kwargs)
+
+    if set_continuous_backup:
+        update_table_continuous_backups(client, table, point_in_time_recovery)
+
+    return change_state
+
+
+def has_sse_spec_changed(table, new_sse_spec):
+    if not new_sse_spec:
+        return False
+
+    return (
+        table.sse_description is None
+        or new_sse_spec['Enabled'] != table.sse_description['Status']
+        or new_sse_spec['SSEType'] != table.sse_description['SSEType']
+        or (
+            new_sse_spec['KMSMasterKeyId'] != ''
+            and new_sse_spec['KMSMasterKeyId'] != table.sse_description['KMSMasterKeyId']
+        )
+    )
+
+
+def has_stream_spec_changed(table, new_stream_spec):
+    if not new_stream_spec:
+        return False
+
+    return (
+        table.stream_specification is None
+        or new_stream_spec['StreamEnabled'] != table.stream_specification['StreamEnabled']
+        or new_stream_spec['StreamViewType'] != table.stream_specification['StreamViewType']
+    )
 
 
 def has_throughput_changed(table, new_throughput):
     if not new_throughput:
         return False
 
-    return new_throughput['read'] != table.throughput['read'] or \
-        new_throughput['write'] != table.throughput['write']
+    return (
+        new_throughput['read'] != table.provisioned_throughput['ReadCapacityUnits']
+        or new_throughput['write'] != table.provisioned_throughput['WriteCapacityUnits']
+    )
 
 
-def get_schema_param(hash_key_name, hash_key_type, range_key_name, range_key_type):
+def remove_duplicates(attr_definitions):
+    seen = set()
+    new_l = []
+    for d in attr_definitions:
+        t = tuple(d.items())
+        if t not in seen:
+            seen.add(t)
+            new_l.append(d)
+
+    return new_l
+
+
+def get_schema_param(
+        hash_key_name,
+        hash_key_type,
+        range_key_name,
+        range_key_type):
     if range_key_name:
         schema = [
-            HashKey(hash_key_name, DYNAMO_TYPE_MAP.get(hash_key_type, DYNAMO_TYPE_MAP[DYNAMO_TYPE_DEFAULT])),
-            RangeKey(range_key_name, DYNAMO_TYPE_MAP.get(range_key_type, DYNAMO_TYPE_MAP[DYNAMO_TYPE_DEFAULT]))
+            {'AttributeName': hash_key_name, 'KeyType': 'HASH'},
+            {'AttributeName': range_key_name, 'KeyType': 'RANGE'}
         ]
     else:
         schema = [
-            HashKey(hash_key_name, DYNAMO_TYPE_MAP.get(hash_key_type, DYNAMO_TYPE_MAP[DYNAMO_TYPE_DEFAULT]))
+            {'AttributeName': hash_key_name, 'KeyType': 'HASH'}
         ]
+
     return schema
 
 
-def get_changed_global_indexes(table, global_indexes):
-    table.describe()
+def deserialize_index_names(indexes, key='IndexName'):
+    return set(
+        index[key]
+        for index in indexes or []
+        if key in index
+    )
 
-    table_index_info = dict((index.name, index.schema()) for index in table.global_indexes)
-    table_index_objects = dict((index.name, index) for index in table.global_indexes)
-    set_index_info = dict((index.name, index.schema()) for index in global_indexes)
-    set_index_objects = dict((index.name, index) for index in global_indexes)
 
-    removed_indexes = dict((name, index) for name, index in table_index_info.items() if name not in set_index_info)
-    added_indexes = dict((name, set_index_objects[name]) for name, index in set_index_info.items() if name not in table_index_info)
-    # todo: uncomment once boto has https://github.com/boto/boto/pull/3447 fixed
-    # for name, index in set_index_objects.items():
-    #      if (name not in added_indexes and
-    #             (index.throughput['read'] != str(table_index_objects[name].throughput['read']) or
-    #              index.throughput['write'] != str(table_index_objects[name].throughput['write']))):
-    #         index_throughput_changes[name] = index.throughput
-    # todo: remove once boto has https://github.com/boto/boto/pull/3447 fixed
-    index_throughput_changes = dict((name, index.throughput) for name, index in set_index_objects.items() if name not in added_indexes)
+def filter_index_by_name(key, indexes):
+    for index in indexes:
+        if index['IndexName'] == key:
+            return index
 
-    return removed_indexes, added_indexes, index_throughput_changes
+    return None
+
+
+def get_changed_global_indexes(table_gsi_indexes, global_indexes):
+    # check if this is a new index to be created
+    if not table_gsi_indexes and not global_indexes:
+        return None
+    elif not table_gsi_indexes:
+        table_gsi_indexes = []
+    elif not global_indexes:
+        global_indexes = []
+
+    global_indexes_updates = []
+    input_gsi_index_names_set = deserialize_index_names(global_indexes)
+    from_aws_gsi_index_names_set = deserialize_index_names(table_gsi_indexes)
+
+    # Find indexes to be deleted and created
+    # An index is deleted when index name exists in the from_aws_gsi_index_names_set and not in the input_gsi_index_names_set
+    # An index is created when index name exists in input_gsi_index_names_set but not in from_aws_gsi_index_names_set
+    indexes_to_be_deleted = from_aws_gsi_index_names_set - input_gsi_index_names_set
+
+    for index_name in indexes_to_be_deleted:
+        global_indexes_updates.append({'Delete': {'IndexName': index_name}})
+
+    indexes_to_be_created = input_gsi_index_names_set - from_aws_gsi_index_names_set
+
+    for index_name in indexes_to_be_created:
+        index = filter_index_by_name(index_name, global_indexes)
+        global_indexes_updates.append({'Create': index})
+
+    # Find indexes that needs to be updated
+    # only provisioned throughput can be updated on an existing gsi index
+    indexes_to_be_updated = input_gsi_index_names_set & from_aws_gsi_index_names_set
+
+    input_gsi_indexes_to_be_updated = [
+        index
+        for index in global_indexes
+        if index['IndexName'] in indexes_to_be_updated
+    ]
+    from_aws_gsi_indexes_to_be_updated = [
+        index
+        for index in table_gsi_indexes
+        if index['IndexName'] in indexes_to_be_updated
+    ]
+
+    for index_name in indexes_to_be_updated:
+        input_gsi_index = filter_index_by_name(index_name, global_indexes)
+        from_aws_gsi_index = filter_index_by_name(
+            index_name, table_gsi_indexes)
+        if input_gsi_index and 'ProvisionedThroughput' in input_gsi_index:
+            input_gsi_index_prov_throughput = input_gsi_index.get(
+                'ProvisionedThroughput')
+            from_aws_gsi_index_prov_throughput = from_aws_gsi_index.get(
+                'ProvisionedThroughput')
+            if (input_gsi_index_prov_throughput.get('ReadCapacityUnits') != from_aws_gsi_index_prov_throughput.get('ReadCapacityUnits')
+                    or input_gsi_index_prov_throughput.get('WriteCapacityUnits') != from_aws_gsi_index_prov_throughput.get('WriteCapacityUnits')):
+                global_indexes_updates.append(
+                    {
+                        'Update': {
+                            'IndexName': index_name,
+                            'ProvisionedThroughput': input_gsi_index_prov_throughput
+                        }
+                    }
+                )
+
+    return (
+        global_indexes_updates
+        if global_indexes_updates
+        else None
+    )
 
 
 def validate_index(index, module):
@@ -423,96 +989,150 @@ def validate_index(index, module):
             module.fail_json(msg='%s is not a valid option for an index' % key)
     for required_option in INDEX_REQUIRED_OPTIONS:
         if required_option not in index:
-            module.fail_json(msg='%s is a required option for an index' % required_option)
+            module.fail_json(
+                msg='%s is a required option for an index' % required_option)
     if index['type'] not in INDEX_TYPE_OPTIONS:
-        module.fail_json(msg='%s is not a valid index type, must be one of %s' % (index['type'], INDEX_TYPE_OPTIONS))
+        module.fail_json(msg='%s is not a valid index type, must be one of %s' % (
+            index['type'], INDEX_TYPE_OPTIONS))
 
 
-def get_indexes(all_indexes):
-    indexes = []
-    global_indexes = []
-    for index in all_indexes:
-        name = index['name']
-        schema = get_schema_param(index.get('hash_key_name'), index.get('hash_key_type'), index.get('range_key_name'), index.get('range_key_type'))
-        throughput = {
-            'read': index.get('read_capacity', 1),
-            'write': index.get('write_capacity', 1)
+def serialize_index_to_json(index, billing_mode):
+    serialized_index = {}
+    serialized_index_attribute_definitions = []
+    name = index['name']
+    index_type = index.get('type')
+    hash_key_name = index.get('hash_key_name')
+    hash_key_type = index.get('hash_key_type', 'STRING')
+    range_key_name = index.get('range_key_name')
+    range_key_type = index.get('range_key_type', 'STRING')
+    schema = get_schema_param(
+        hash_key_name,
+        hash_key_type,
+        range_key_name,
+        range_key_type
+    )
+    projection_type = index_type.replace('global_', '')
+    projection = {'ProjectionType': projection_type.upper()}
+    index_throughput = {
+        'ReadCapacityUnits': index.get('read_capacity', 1),
+        'WriteCapacityUnits': index.get('write_capacity', 1)
+    }
+    key_type_mapping = {'STRING': 'S', 'BINARY': 'B', 'NUMBER': 'N'}
+
+    if projection_type == 'include':
+        projection.update({'NonKeyAttributes': index['includes']})
+
+    serialized_index.update(
+        {
+            'IndexName': name,
+            'KeySchema': schema,
+            'Projection': projection
         }
+    )
 
-        if index['type'] == 'all':
-            indexes.append(AllIndex(name, parts=schema))
+    if billing_mode != "PAY_PER_REQUEST" and index_type in ['global_all', 'global_include', 'global_keys_only']:
+        serialized_index.update({'ProvisionedThroughput': index_throughput})
 
-        elif index['type'] == 'global_all':
-            global_indexes.append(GlobalAllIndex(name, parts=schema, throughput=throughput))
+    if range_key_name:
+        serialized_index_attribute_definitions.append(
+            {
+                'AttributeName': hash_key_name,
+                'AttributeType': key_type_mapping[hash_key_type.upper()]
+            }
+        )
+        serialized_index_attribute_definitions.append(
+            {
+                'AttributeName': range_key_name,
+                'AttributeType': key_type_mapping[range_key_type.upper()]
+            }
+        )
+    else:
+        serialized_index_attribute_definitions.append(
+            {
+                'AttributeName': hash_key_name,
+                'AttributeType': key_type_mapping[hash_key_type.upper()]
+            }
+        )
 
-        elif index['type'] == 'global_include':
-            global_indexes.append(GlobalIncludeIndex(name, parts=schema, throughput=throughput, includes=index['includes']))
+    return (
+        index_type,
+        serialized_index,
+        serialized_index_attribute_definitions
+    )
 
-        elif index['type'] == 'global_keys_only':
-            global_indexes.append(GlobalKeysOnlyIndex(name, parts=schema, throughput=throughput))
 
-        elif index['type'] == 'include':
-            indexes.append(IncludeIndex(name, parts=schema, includes=index['includes']))
+def serialize_indexes(all_indexes, billing_mode):
+    local_secondary_indexes = []
+    global_secondary_indexes = []
+    indexes_attr_definitions = []
+    for index in all_indexes:
+        (
+            index_type,
+            serialized_index_to_json,
+            serialized_index_attribute_definitions
+        ) = serialize_index_to_json(index, billing_mode)
 
-        elif index['type'] == 'keys_only':
-            indexes.append(KeysOnlyIndex(name, parts=schema))
+        for index_attr_definition in serialized_index_attribute_definitions:
+            indexes_attr_definitions.append(index_attr_definition)
 
-    return indexes, global_indexes
+        if index_type in ['all', 'include', 'keys_only']:
+            # local secondary all_indexes
+            local_secondary_indexes.append(serialized_index_to_json)
+        elif index_type in ['global_all', 'global_include', 'global_keys_only']:
+            # global secondary indexes
+            global_secondary_indexes.append(serialized_index_to_json)
+
+    return (
+        local_secondary_indexes,
+        global_secondary_indexes,
+        remove_duplicates(indexes_attr_definitions)
+    )
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(required=True, type='str'),
         hash_key_name=dict(type='str'),
-        hash_key_type=dict(default='STRING', type='str', choices=['STRING', 'NUMBER', 'BINARY']),
+        hash_key_type=dict(default='STRING', type='str', choices=[
+                           'STRING', 'NUMBER', 'BINARY']),
         range_key_name=dict(type='str'),
-        range_key_type=dict(default='STRING', type='str', choices=['STRING', 'NUMBER', 'BINARY']),
+        range_key_type=dict(default='STRING', type='str', choices=[
+                            'STRING', 'NUMBER', 'BINARY']),
+        billing_mode=dict(default=None, type='str', choices=[
+                          'PROVISIONED', 'PAY_PER_REQUEST']),
         read_capacity=dict(default=1, type='int'),
         write_capacity=dict(default=1, type='int'),
-        indexes=dict(default=[], type='list'),
+        indexes=dict(default=[], type='list', elements='dict'),
         tags=dict(type='dict'),
+        purge_tags=dict(default=False, type='bool'),
         wait_for_active_timeout=dict(default=60, type='int'),
-    ))
+        stream_enabled=dict(type='bool'),
+        stream_view_type=dict(type='str', choices=[
+                              'NEW_IMAGE', 'OLD_IMAGE', 'NEW_AND_OLD_IMAGES', 'KEYS_ONLY']),
+        sse_enabled=dict(type='bool'),
+        sse_type=dict(type='str', choices=['AES256', 'KMS']),
+        sse_kms_master_key_id=dict(type='str'),
+        point_in_time_recovery=dict(default=False, type='bool')
+    )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        supports_check_mode=True)
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
-
-    if not HAS_BOTO3 and module.params.get('tags'):
-        module.fail_json(msg='boto3 required when using tags for this module')
-
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
-    if not region:
-        module.fail_json(msg='region must be specified')
-
-    try:
-        connection = connect_to_aws(boto.dynamodb2, region, **aws_connect_params)
-    except (NoAuthHandlerFound, AnsibleAWSError) as e:
-        module.fail_json(msg=str(e))
-
-    if module.params.get('tags'):
-        try:
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            boto3_dynamodb = boto3_conn(module, conn_type='client', resource='dynamodb', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-            if not hasattr(boto3_dynamodb, 'tag_resource'):
-                module.fail_json(msg='boto3 connection does not have tag_resource(), likely due to using an old version')
-            boto3_sts = boto3_conn(module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except botocore.exceptions.NoCredentialsError as e:
-            module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc())
-    else:
-        boto3_dynamodb = None
-        boto3_sts = None
-
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'present', ['name', 'hash_key_name']],
+            ['sse_type', 'KMS', ['sse_type']],
+            ['sse_enabled', 'True', ['sse_type']],
+            ['stream_enabled', 'True', ['stream_view_type']]
+        ]
+    )
+    resource = module.resource('dynamodb')
     state = module.params.get('state')
+
     if state == 'present':
-        create_or_update_dynamo_table(connection, module, boto3_dynamodb, boto3_sts, region)
+        create_or_update_dynamo_table(resource, module)
     elif state == 'absent':
-        delete_dynamo_table(connection, module)
+        delete_dynamo_table(resource, module)
 
 
 if __name__ == '__main__':

--- a/tests/integration/targets/dynamodb_table/aliases
+++ b/tests/integration/targets/dynamodb_table/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/tests/integration/targets/dynamodb_table/defaults/main.yml
+++ b/tests/integration/targets/dynamodb_table/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+table_name: ansible-test-1
+ec2_region: us-west-2

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -1,0 +1,207 @@
+---
+# tasks file for test_dyamodb_table
+
+- name: test incomplete credentials
+  block:
+    # ============================================================
+    - name: test failure with no parameters
+      dynamodb_table:
+      register: result
+      ignore_errors: yes
+
+    - name: assert failure with no parameters
+      assert:
+        that:
+          - result is failed
+          - 'result.msg == "missing required arguments: name"'
+
+    - name: test credentials from environment
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+      environment:
+        EC2_REGION: "{{ ec2_region }}"
+        EC2_ACCESS_KEY: bogus_access_key
+        EC2_SECRET_KEY: bogus_secret_key
+      register: result
+      ignore_errors: yes
+
+    - name: assert dynamodb_table with valid ec2_url
+      assert:
+        that:
+          - result is failed
+          - >
+            "Authentication failure" in result.msg
+            or "token included in the request is invalid" in result.msg
+
+    # ============================================================
+    - name: test credential parameters
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        ec2_region: "{{ ec2_region }}"
+        ec2_access_key: bogus_access_key
+        ec2_secret_key: bogus_secret_key
+        security_token: "{{ security_token | d(omit) }}"
+      register: result
+      ignore_errors: yes
+    - name: assert credential parameters
+      assert:
+        that:
+          - result is failed
+          - >
+            "Authentication failure" in result.msg
+            or "token included in the request is invalid" in result.msg
+
+- name: dynamodb table integration tests
+  module_defaults:
+    dynamodb_table:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      region: "{{ aws_region }}"
+      security_token: "{{ security_token | d(omit) }}"
+  block:
+    # ============================================================
+    - name: create table
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        range_key_name: myrangekey
+        state: present
+        indexes:
+          - name: NamedIndex
+            type: global_all
+            hash_key_name: myhashkey
+          - name: NamedIndexV2
+            type: global_all
+            hash_key_name: myhashkey
+            range_key_name: myrangekey
+          - name: NamedLocalIndex
+            type: keys_only
+            hash_key_name: myhashkey
+            range_key_name: mylocalrangekey
+        tags:
+          First: one
+          Second: two
+      register: result
+      until:
+        - result | json_query('global_secondary_indexes[?IndexName==`NamedIndexV2`].IndexStatus') == ['ACTIVE']
+        - result | json_query('global_secondary_indexes[?IndexName==`NamedIndex`].IndexStatus') == ['ACTIVE']
+      retries: 6
+      delay: 10
+
+    - name: update index on the existing table
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        indexes:
+          - name: NamedIndex
+            type: global_all
+            hash_key_name: myhashkey
+          - name: NamedIndexV2
+            type: global_all
+            hash_key_name: myhashkey
+            range_key_name: myrangekey
+            read_capacity: 10
+            write_capacity: 10
+      register: result
+      until:
+        - result | json_query('indexes[?name==`NamedIndexV2`].read_capacity') == [10]
+        - result | json_query('indexes[?name==`NamedIndexV2`].write_capacity') == [10]
+      retries: 6
+      delay: 10
+
+    - name: delete index on the existing table
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        indexes:
+          - name: NamedIndex
+            type: global_all
+            hash_key_name: myhashkey
+      register: result
+      until: >
+        result.indexes is defined
+        and result.indexes is sequence
+        and result.indexes | length == 1
+      retries: 6
+      delay: 10
+
+    # NOTE: Dropping indexes to speed up billing and backup tests.
+    - name: drop all indexes on the existing table
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+      register: result
+      until: >
+        result.indexes is defined
+        and result.indexes is sequence
+        and result.indexes | length == 0
+      retries: 6
+      delay: 10
+
+    - name: assert current billing mode
+      assert:
+        that:
+          - result.billing_mode == 'PROVISIONED'
+
+    # NOTE: Changing billing_mode to PAY_PER_REQUEST takes long time
+    # to provision and will significantly delay next step because
+    # table will be in stuck UPDATING state.
+    - name: change billing mode
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        billing_mode: PAY_PER_REQUEST
+      register: result
+      until: result.billing_mode | d('') == 'PAY_PER_REQUEST'
+      retries: 6
+      delay: 10
+
+    - name: omit billing mode to ensure no effect
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+      register: result
+      until: result is succeeded
+      retries: 12
+      delay: 10
+
+    - name: assert billing mode was not changed
+      assert:
+        that:
+          - result.billing_mode == 'PAY_PER_REQUEST'
+
+    - name: assert point in time recovery is disabled
+      assert:
+        that:
+          - not result.point_in_time_recovery
+
+    - name: enable point in time recovery
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        point_in_time_recovery: yes
+      register: result
+      until: result.point_in_time_recovery | d(False)
+      retries: 6
+      delay: 10
+
+  always:
+    - name: disable point in time recovery to avoid leftover backup
+      dynamodb_table:
+        name: "{{ table_name }}"
+        hash_key_name: myhashkey
+        point_in_time_recovery: no
+      register: teardown_result
+      until: teardown_result is succeeded
+      retries: 6
+      delay: 10
+
+    - name: delete the table
+      dynamodb_table:
+        name: "{{ table_name }}"
+        state: absent
+      register: teardown_result
+      retries: 10
+      until: teardown_result is succeeded

--- a/tests/unit/modules/test_dynamodb_table.py
+++ b/tests/unit/modules/test_dynamodb_table.py
@@ -1,0 +1,273 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.modules.cloud.amazon import dynamodb_table as dynamodb_table_module
+import unittest
+import json
+
+
+class DynamodbTable_IndexTests(unittest.TestCase):
+    def test_local_get_changed_indexes_create(self):
+        param_local_index = [
+            {
+                "hash_key_name": "myhashkey",
+                "name": "NamedIndex",
+                "type": "all",
+                "read_capacity": 10,
+                "write_capacity": 10
+            }
+        ]
+        indexes, global_indexes, attr_definitions = dynamodb_table_module.serialize_indexes(
+            param_local_index)
+        self.assertEqual(len(indexes), 1)
+        self.assertEqual(indexes[0]['Projection']['ProjectionType'], 'ALL')
+
+    def test_gsi_get_changed_indexes_create(self):
+        table_gsi_indexs = []
+        param_gsi_index = [
+            {
+                "hash_key_name": "myhashkey",
+                "name": "NamedIndex",
+                "type": "global_all",
+                "read_capacity": 10,
+                "write_capacity": 10
+            }
+        ]
+        indexes, global_indexes, attr_definitions = dynamodb_table_module.serialize_indexes(
+            param_gsi_index)
+        actual = dynamodb_table_module.get_changed_global_indexes(
+            table_gsi_indexs, global_indexes)
+        expected = {"Create": {
+            "IndexName": "NamedIndex",
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+            }
+        }
+        }
+        self.assertEqual(len(actual), 1)
+        self.assertTrue('Create' in actual[0])
+        self.assertTrue(actual[0].get('Create').get(
+            'IndexName') == 'NamedIndex')
+
+    def test_gsi_get_changed_indexes_update_nochange(self):
+        table_gsi_indexs = [{
+            "IndexArn": "arn:aws:dynamodb:us-west-2:132601236262:table/ansible-table-/index/NamedIndex",
+            "IndexName": "NamedIndex",
+            "IndexSizeBytes": 0,
+            "IndexStatus": "ACTIVE",
+            "ItemCount": 0,
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+            }
+        },
+            {
+            "IndexArn": "arn:aws:dynamodb:us-west-2:132601236262:table/ansible-table-/index/NamedIndexV2",
+            "IndexName": "NamedIndexV2",
+            "IndexSizeBytes": 0,
+            "IndexStatus": "ACTIVE",
+            "ItemCount": 0,
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "myrangekey",
+                    "KeyType": "RANGE"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "LastIncreaseDateTime": "2018-11-16T12:05:35.779000-05:00",
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+            }
+        }
+        ]
+        param_gsi_index = [
+            {
+                "hash_key_name": "myhashkey",
+                "name": "NamedIndex",
+                "type": "global_all",
+                "read_capacity": 10,
+                "write_capacity": 10
+            },
+            {
+                "hash_key_name": "myhashkey",
+                "range_key_name": "myrangekey",
+                "name": "NamedIndexV2",
+                "type": "global_all",
+                "read_capacity": 10,
+                "write_capacity": 10
+            }
+        ]
+        indexes, global_indexes, attr_definitions = dynamodb_table_module.serialize_indexes(
+            param_gsi_index)
+        actual = dynamodb_table_module.get_changed_global_indexes(
+            table_gsi_indexs, global_indexes)
+        expected = [{'Update': {'ProvisionedThroughput': {'WriteCapacityUnits': 100, 'ReadCapacityUnits': 100}, 'IndexName': 'NamedIndexV2'}},
+                    {'Update': {'ProvisionedThroughput': {'WriteCapacityUnits': 100, 'ReadCapacityUnits': 100}, 'IndexName': 'NamedIndex'}}]
+        self.assertEqual(len(actual), 0)
+
+    def test_gsi_get_changed_indexes_update(self):
+        table_gsi_indexs = [{
+            "IndexArn": "arn:aws:dynamodb:us-west-2:132601236262:table/ansible-table-/index/NamedIndex",
+            "IndexName": "NamedIndex",
+            "IndexSizeBytes": 0,
+            "IndexStatus": "ACTIVE",
+            "ItemCount": 0,
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 1,
+                "WriteCapacityUnits": 1
+            }
+        },
+            {
+            "IndexArn": "arn:aws:dynamodb:us-west-2:132601236262:table/ansible-table-/index/NamedIndexV2",
+            "IndexName": "NamedIndexV2",
+            "IndexSizeBytes": 0,
+            "IndexStatus": "ACTIVE",
+            "ItemCount": 0,
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "myrangekey",
+                    "KeyType": "RANGE"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "LastIncreaseDateTime": "2018-11-16T12:05:35.779000-05:00",
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+            }
+        }
+        ]
+        param_gsi_index = [
+            {
+                "hash_key_name": "myhashkey",
+                "name": "NamedIndex",
+                "type": "global_all",
+                "read_capacity": 100,
+                "write_capacity": 100
+            },
+            {
+                "hash_key_name": "myhashkey",
+                "range_key_name": "myrangekey",
+                "name": "NamedIndexV2",
+                "type": "global_all",
+                "read_capacity": 150,
+                "write_capacity": 150
+            }
+        ]
+        index_type, global_indexes, attr_definitions = dynamodb_table_module.serialize_indexes(
+            param_gsi_index)
+        actual = dynamodb_table_module.get_changed_global_indexes(
+            table_gsi_indexs, global_indexes)
+        expected = [{'Update': {'ProvisionedThroughput': {'WriteCapacityUnits': 100, 'ReadCapacityUnits': 100}, 'IndexName': 'NamedIndexV2'}},
+                    {'Update': {'ProvisionedThroughput': {'WriteCapacityUnits': 100, 'ReadCapacityUnits': 100}, 'IndexName': 'NamedIndex'}}]
+        self.assertEqual(len(actual), 2)
+
+    def test_gsi_get_changed_indexes_delete(self):
+        table_gsi_indexs = [{
+            "IndexArn": "arn:aws:dynamodb:us-west-2:132601236262:table/ansible-table-/index/NamedIndex",
+            "IndexName": "NamedIndex",
+            "IndexSizeBytes": 0,
+            "IndexStatus": "ACTIVE",
+            "ItemCount": 0,
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 1,
+                "WriteCapacityUnits": 1
+            }
+        },
+            {
+            "IndexArn": "arn:aws:dynamodb:us-west-2:132601236262:table/ansible-table-/index/NamedIndexV2",
+            "IndexName": "NamedIndexV2",
+            "IndexSizeBytes": 0,
+            "IndexStatus": "ACTIVE",
+            "ItemCount": 0,
+            "KeySchema": [
+                {
+                    "AttributeName": "myhashkey",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "myrangekey",
+                    "KeyType": "RANGE"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "ALL"
+            },
+            "ProvisionedThroughput": {
+                "LastIncreaseDateTime": "2018-11-16T12:05:35.779000-05:00",
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+            }
+        }
+        ]
+        param_gsi_index = [
+            {
+                "hash_key_name": "myhashkey",
+                "name": "NamedIndex",
+                "type": "global_all",
+                "read_capacity": 1,
+                "write_capacity": 1
+            }
+        ]
+        index_type, global_indexes, attr_definitions = dynamodb_table_module.serialize_indexes(
+            param_gsi_index)
+        actual = dynamodb_table_module.get_changed_global_indexes(
+            table_gsi_indexs, global_indexes)
+        expected = [{'Delete': {'IndexName': 'NamedIndexV2'}}]
+        self.assertEqual(len(actual), 1)


### PR DESCRIPTION
### SUMMARY
This is a fresh PR to transfer over the original PR from the ansible repo to the new community.aws repo as requested to meet new requirements.

#### Original PR's
https://github.com/ansible/ansible/pull/45402
https://github.com/ansible/ansible/pull/68320
https://github.com/anryko/ansible/pull/1

I'm providing the fixes listed below for the changes proposed in https://github.com/ansible/ansible/pull/68320 that are now stale that is in turn based on the below:
> Fix AnsibleAwsModule migration stale PR https://github.com/ansible/ansible/pull/45402. Add billing_mode and point_in_time_recovery. > Small bug fixes. Integration tests fixes.

**Fixes:**
* Fix issue with `ProvisionedThroughput` params being set incorrectly on GSI's when billing is `PAY_PER_REQUEST`.
* Fix incorrect `key_type_mapping`.
* Fix defining of `serialized_index_attribute_definitions` for both the hash and the range key on a GSI. (range key definition was being overwritten).
* Fix defining of SSE spec.
* Remove need for `dict_merge` function that provided some errors.

Fixes #45402
Fixes #56923

#### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

#### COMPONENT NAME
- dynamodb_table

#### ADDITIONAL INFORMATION
```yaml
- name: enable on-demand billing and backups
  dynamodb_table:
  name: table_name
  hash_key_name: myhashkey
  range_key_name: myrangekey
  billing_mode: PAY_PER_REQUEST
  point_in_time_recovery: yes
  indexes:
      - name: myindex
          type: global_all
          hash_key_name: somekey
          range_key_name: myrangekey
```
