### PR TITLE
s3_bucket_notification tests: Be less restrictive in assertion

### DIFF
--- a/tests/integration/targets/s3_bucket_notification/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket_notification/tasks/main.yml
@@ -376,7 +376,7 @@
     assert:
       that:
       - result.failed
-      - 'result.msg.startswith("missing required arguments: event_name, bucket_name")'
+      - '"missing required arguments" in result.msg'
   - name: test abesnt
     s3_bucket_notification: state=absent
     register: result
@@ -385,4 +385,4 @@
     assert:
       that:
       - result.failed
-      - 'result.msg.startswith("missing required arguments: event_name, bucket_name")'
+      - '"missing required arguments" in result.msg'


### PR DESCRIPTION
##### SUMMARY

Failing on missing args assertion due to https://github.com/ansible/ansible/pull/67771
Be less restrictive in what we assert to prevent these types of failures.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/s3_bucket_notification/tasks/main.yml

##### ADDITIONAL INFORMATION
Failure seen in https://app.shippable.com/github/ansible-collections/community.aws/runs/119/10/console
