### PR TITLE
Disable smoketests 

### DIFF
--- a/tests/utils/shippable/aws.sh
+++ b/tests/utils/shippable/aws.sh
@@ -13,22 +13,7 @@ target="shippable/${cloud}/group${group}/"
 
 stage="${S:-prod}"
 
-changed_all_target="shippable/${cloud}/smoketest/"
-
-if ! ansible-test integration "${changed_all_target}" --list-targets > /dev/null 2>&1; then
-    # no smoketest tests are available for this cloud
-    changed_all_target="none"
-fi
-
-if [ "${group}" == "1" ]; then
-    # only run smoketest tests for group1
-    changed_all_mode="include"
-else
-    # smoketest tests already covered by group1
-    changed_all_mode="exclude"
-fi
-
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --remote-terminate always --remote-stage "${stage}" \
-    --docker --python "${python}" --changed-all-target "${changed_all_target}" --changed-all-mode "${changed_all_mode}"
+    --docker --python "${python}"

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -132,12 +132,12 @@ function cleanup
                     flags="${flags//=/,}"
                     flags="${flags//[^a-zA-Z0-9_,]/_}"
 
-                    codecov \
+                    bash <(curl -s https://codecov.io/bash) \
                         -f "${file}" \
                         -F "${flags}" \
                         -n "${test}" \
                         -t 8a86e979-f37b-4d5d-95a4-960c280d5eaa \
-                        -X pycov \
+                        -X coveragepy \
                         -X gcov \
                         -X fix \
                         -X search \

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -132,12 +132,12 @@ function cleanup
                     flags="${flags//=/,}"
                     flags="${flags//[^a-zA-Z0-9_,]/_}"
 
-                    bash <(curl -s https://codecov.io/bash) \
+                    codecov \
                         -f "${file}" \
                         -F "${flags}" \
                         -n "${test}" \
                         -t 8a86e979-f37b-4d5d-95a4-960c280d5eaa \
-                        -X coveragepy \
+                        -X pycov \
                         -X gcov \
                         -X fix \
                         -X search \


### PR DESCRIPTION
##### SUMMARY
Smoketests are not needed in collections, and none exist in this
collection anyway.
https://github.com/ansible-collections/overview/issues/45#issuecomment-630466482

~~`amazon.aws` will be using the pip package, so keep this one consistent.~~
We won't be using codecov-python, does not seem to be a drop-in replacement after all.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/utils/shippable/aws.sh
tests/utils/shippable/shippable.sh