### PR TITLE
[WIP] Require a recent version of botocore when running unit tests with python 3.9

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,5 @@
 boto3
+botocore > 1.15.38 ; python_version > '3.8'
 placebo
 pycrypto
 passlib

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-botocore > 1.15.38 ; python_version > '3.8'
+botocore > 1.15.38
 placebo
 pycrypto
 passlib


### PR DESCRIPTION
##### SUMMARY

The 3.9 Unit tests are currently spitting out errors due to 
```
No module named 'xml.etree.cElementTree' 
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unit tests

##### ADDITIONAL INFORMATION
Example
https://app.shippable.com/github/ansible-collections/community.aws/runs/181/6/console