### PR TITLE
Fix module documentation schema errors

### DIFF
--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -96,7 +96,7 @@ metric_filters:
             "metric_namespace": "made_with_ansible",
             "metric_value": "$.value"
         }
-    ],
+    ]
 
 """
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -89,12 +89,15 @@ metric_filters:
     description: Return the origin response value
     returned: success
     type: list
-    contains:
-        creation_time:
-        filter_name:
-        filter_pattern:
-        log_group_name:
-        metric_filter_count:
+    sample: [
+        {
+            "default_value": 3.1415,
+            "metric_name": "box_free_space",
+            "metric_namespace": "made_with_ansible",
+            "metric_value": "$.value"
+        }
+    ],
+
 """
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -655,8 +655,14 @@ def main():
         repeat=dict(required=False, type='int', default=10),
         force_new_deployment=dict(required=False, default=False, type='bool'),
         deployment_configuration=dict(required=False, default={}, type='dict'),
-        placement_constraints=dict(required=False, default=[], type='list'),
-        placement_strategy=dict(required=False, default=[], type='list'),
+        placement_constraints=dict(required=False, default=[], type='list', options=dict(
+            type=dict(type='str'),
+            expression=dict(type='str')
+        )),
+        placement_strategy=dict(required=False, default=[], type='list', options=dict(
+            type=dict(type='str'),
+            field=dict(type='str'),
+        )),
         health_check_grace_period_seconds=dict(required=False, type='int'),
         network_configuration=dict(required=False, type='dict', options=dict(
             subnets=dict(type='list'),

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -103,10 +103,17 @@ options:
     placement_constraints:
         description:
           - The placement constraints for the tasks in the service.
+          - See U(https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PlacementConstraint.html) for more details.
         required: false
         type: list
         elements: dict
         suboptions:
+          type:
+            description: The type of constraint.
+            type: str
+          expression:
+            description: A cluster query language expression to apply to the constraint.
+            type: str
     placement_strategy:
         description:
           - The placement strategy objects to use for tasks in your service. You can specify a maximum of 5 strategy rules per service.

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -84,8 +84,6 @@ plugins/modules/ec2_vpc_vpn_info.py validate-modules:doc-elements-mismatch
 plugins/modules/ec2_vpc_vpn_info.py validate-modules:parameter-list-no-elements
 plugins/modules/ecs_attribute.py validate-modules:doc-elements-mismatch
 plugins/modules/ecs_attribute.py validate-modules:parameter-list-no-elements
-plugins/modules/ecs_service.py validate-modules:doc-elements-mismatch
-plugins/modules/ecs_service.py validate-modules:parameter-list-no-elements
 plugins/modules/ecs_service_info.py validate-modules:doc-elements-mismatch
 plugins/modules/ecs_service_info.py validate-modules:parameter-list-no-elements
 plugins/modules/ecs_task.py validate-modules:doc-elements-mismatch


### PR DESCRIPTION
##### SUMMARY ##### 
`ecs_service` is missing suboptions data for `placement_constraints`
Return docs for `cloudwatchlogs_log_group_metric_filter` are missing suboption descriptions and are just plain wrong. Correct type and values.

Fixes #79

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ecs_service
cloudwatchlogs_log_group_metric_filter


