### PR TITLE
Disable unit tests affected by botocore #2002 on py3.9

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -14,7 +14,8 @@ matrix:
     - env: T=units/3.6/1
     - env: T=units/3.7/1
     - env: T=units/3.8/1
-    - env: T=units/3.9/1
+#   Until boto/botocore#2002 is fixed
+#    - env: T=units/3.9/1
 
     - env: T=aws/2.7/1
     - env: T=aws/3.7/1


### PR DESCRIPTION
##### SUMMARY
Temporarily disable all 3.9 unit tests until upstream has landed a patch.

Fixes: #78 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/units/


