### PR TITLE
Add support for shippable testing on different releases of ansible

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -8,6 +8,7 @@ IFS='/:' read -ra args <<< "$1"
 script="${args[0]}"
 
 test="$1"
+ansible_version="${ANSIBLE_BASE_REV:-devel}"
 
 docker images ansible/ansible
 docker images quay.io/ansible/*
@@ -74,7 +75,7 @@ set +ux
 set -ux
 
 pip install setuptools==44.1.0
-pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+pip install https://github.com/ansible/ansible/archive/${ansible_version}.tar.gz --disable-pip-version-check
 
 #ansible-galaxy collection install community.general
 mkdir -p "${HOME}/.ansible/collections/ansible_collections/community"

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -75,10 +75,10 @@ set -ux
 
 pip install setuptools==44.1.0
 
-if [ -z "${ANSIBLE_BASE_REV}" ]; then
-    pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
-else
+if [ -n "${ANSIBLE_BASE_REV:-}" ]; then
     pip install "ansible~=${ANSIBLE_BASE_REV}"
+else
+    pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 fi
 
 #ansible-galaxy collection install community.general

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -8,7 +8,6 @@ IFS='/:' read -ra args <<< "$1"
 script="${args[0]}"
 
 test="$1"
-ansible_version="${ANSIBLE_BASE_REV:-devel}"
 
 docker images ansible/ansible
 docker images quay.io/ansible/*
@@ -75,7 +74,12 @@ set +ux
 set -ux
 
 pip install setuptools==44.1.0
-pip install https://github.com/ansible/ansible/archive/${ansible_version}.tar.gz --disable-pip-version-check
+
+if [ -z "${ANSIBLE_BASE_REV}" ]; then
+    pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+else
+    pip install "ansible~=${ANSIBLE_BASE_REV}"
+fi
 
 #ansible-galaxy collection install community.general
 mkdir -p "${HOME}/.ansible/collections/ansible_collections/community"


### PR DESCRIPTION
##### SUMMARY
Use an envvar in shippable.sh to determine which ansible tgz to use for testing collection.  Defaults to devel.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
shippable.sh

##### ADDITIONAL INFORMATION
Supports https://github.com/ansible/ansible-shippable-sync/pull/21 for enabling nightly jobs on 2.9