### PR TITLE
fix: ansible kinesis stream paginated shards bug

### DIFF
--- a/changelogs/fragments/93-kinesis_stream-get-more-shards-resolve.yml
+++ b/changelogs/fragments/93-kinesis_stream-get-more-shards-resolve.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- kinesis_stream - fixes issue where kinesis streams with > 100 shards get stuck in an infinite loop (https://github.com/ansible-collections/community.aws/pull/93)

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -362,6 +362,7 @@ def find_stream(client, stream_name, check_mode=False):
                 )
                 shards.extend(results.pop('Shards'))
                 has_more_shards = results['HasMoreShards']
+                params['ExclusiveStartShardId'] = shards[-1]['ShardId']
             results['Shards'] = shards
             num_closed_shards = len([s for s in shards if 'EndingSequenceNumber' in s['SequenceNumberRange']])
             results['OpenShardsCount'] = len(shards) - num_closed_shards

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -362,7 +362,8 @@ def find_stream(client, stream_name, check_mode=False):
                 )
                 shards.extend(results.pop('Shards'))
                 has_more_shards = results['HasMoreShards']
-                params['ExclusiveStartShardId'] = shards[-1]['ShardId']
+                if has_more_shards:
+                    params['ExclusiveStartShardId'] = shards[-1]['ShardId']
             results['Shards'] = shards
             num_closed_shards = len([s for s in shards if 'EndingSequenceNumber' in s['SequenceNumberRange']])
             results['OpenShardsCount'] = len(shards) - num_closed_shards


### PR DESCRIPTION
##### SUMMARY
"Fixes #92"

It looks like `has_more_shards` isn't really used other than for the purposes of this while loop so it is safe to set `ExclusiveStartShardId` to the last shard and pass those params at the next call of the while loop which subsequently sets `has_more_shards` to False. Otherwise, due to a kinesis stream having > 100 shards, `has_more_shards` will always be True making us stuck in this while loop and we'll get timeouts.


##### ISSUE TYPE
- Bugfix Pull Request
