### PR TITLE
Collections related fixes for CI

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -219,161 +219,161 @@ plugin_routing:
   modules:
     aws_acm_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     aws_kms_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     aws_region_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     aws_s3_bucket_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     aws_sgw_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     aws_waf_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     cloudfront_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     cloudwatchlogs_log_group_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_asg_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_customer_gateway_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_instance_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_eip_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_elb_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_lc_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_placement_group_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_endpoint_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_igw_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_nacl_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_nat_gateway_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_peering_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_route_table_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_vgw_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ec2_vpc_vpn_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ecs_service_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     ecs_taskdefinition_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     efs_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     elasticache_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     elb_application_lb_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     elb_classic_lb_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     elb_target_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     elb_target_group_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     iam_cert_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     iam_mfa_device_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     iam_role_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     iam_server_certificate_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     lambda_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     rds_instance_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     rds_snapshot_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     redshift_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details
     route53_facts:
       deprecation:
-        removal_date: TBD
+        removal_date: 2021-12-01
         warning_text: see plugin documentation for details

--- a/plugins/modules/aws_acm_info.py
+++ b/plugins/modules/aws_acm_info.py
@@ -274,7 +274,7 @@ def main():
     acm_info = ACMServiceManager(module)
 
     if module._name == 'aws_acm_facts':
-        module.deprecate("The 'aws_acm_facts' module has been renamed to 'aws_acm_info'", version='2.13')
+        module.deprecate("The 'aws_acm_facts' module has been renamed to 'aws_acm_info'", date='2021-12-01', collection_name='community.aws')
 
     client = module.client('acm')
 

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -1052,7 +1052,7 @@ def main():
 
     if module.params.get('policy_grant_types') or mode == 'deny':
         module.deprecate('Managing the KMS IAM Policy via policy_mode and policy_grant_types is fragile'
-                         ' and has been deprecated in favour of the policy option.', version='2.13')
+                         ' and has been deprecated in favour of the policy option.', date='2021-12-01', collection_name='community.aws')
         result = update_policy_grants(kms, module, key_metadata, mode)
         module.exit_json(**result)
 

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -409,7 +409,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
     if module._name == 'aws_kms_facts':
-        module.deprecate("The 'aws_kms_facts' module has been renamed to 'aws_kms_info'", version='2.13')
+        module.deprecate("The 'aws_kms_facts' module has been renamed to 'aws_kms_info'", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 and botocore are required for this module')

--- a/plugins/modules/aws_region_info.py
+++ b/plugins/modules/aws_region_info.py
@@ -70,7 +70,7 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'aws_region_facts':
-        module.deprecate("The 'aws_region_facts' module has been renamed to 'aws_region_info'", version='2.13')
+        module.deprecate("The 'aws_region_facts' module has been renamed to 'aws_region_info'", date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -94,7 +94,7 @@ def main():
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
-                         "and the renamed one no longer returns ansible_facts", version='2.13')
+                         "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
 
     # Verify Boto3 is used
     if not HAS_BOTO3:

--- a/plugins/modules/aws_sgw_info.py
+++ b/plugins/modules/aws_sgw_info.py
@@ -345,7 +345,7 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'aws_sgw_facts':
-        module.deprecate("The 'aws_sgw_facts' module has been renamed to 'aws_sgw_info'", version='2.13')
+        module.deprecate("The 'aws_sgw_facts' module has been renamed to 'aws_sgw_info'", date='2021-12-01', collection_name='community.aws')
     client = module.client('storagegateway')
 
     if client is None:  # this should never happen

--- a/plugins/modules/aws_waf_info.py
+++ b/plugins/modules/aws_waf_info.py
@@ -126,7 +126,7 @@ def main():
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'aws_waf_facts':
-        module.deprecate("The 'aws_waf_facts' module has been renamed to 'aws_waf_info'", version='2.13')
+        module.deprecate("The 'aws_waf_facts' module has been renamed to 'aws_waf_info'", date='2021-12-01', collection_name='community.aws')
 
     resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
     client = module.client(resource)

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -601,7 +601,7 @@ def main():
     is_old_facts = module._name == 'cloudfront_facts'
     if is_old_facts:
         module.deprecate("The 'cloudfront_facts' module has been renamed to 'cloudfront_info', "
-                         "and the renamed one no longer returns ansible_facts", version='2.13')
+                         "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -110,7 +110,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'cloudwatchlogs_log_group_facts':
-        module.deprecate("The 'cloudwatchlogs_log_group_facts' module has been renamed to 'cloudwatchlogs_log_group_info'", version='2.13')
+        module.deprecate("The 'cloudwatchlogs_log_group_facts' module has been renamed to 'cloudwatchlogs_log_group_info'",
+                         date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -123,8 +123,7 @@ options:
     type: dict
   version:
     description:
-      - The version option has never had any effect and will be removed in
-        Ansible 2.14
+      - The version option has never had any effect and will be removed after 2022-06-01.
     type: str
 '''
 
@@ -605,7 +604,7 @@ def main():
     argument_spec.update(
         dict(
             name=dict(required=True),
-            version=dict(removed_in_version='2.14'),
+            version=dict(removed_at_date='2022-06-01', removed_from_collection='community.aws'),
             description=dict(required=False, default=''),
             objects=dict(required=False, type='list', default=[]),
             parameters=dict(required=False, type='list', default=[]),

--- a/plugins/modules/ec2_asg_info.py
+++ b/plugins/modules/ec2_asg_info.py
@@ -394,7 +394,7 @@ def main():
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_asg_facts':
-        module.deprecate("The 'ec2_asg_facts' module has been renamed to 'ec2_asg_info'", version='2.13')
+        module.deprecate("The 'ec2_asg_facts' module has been renamed to 'ec2_asg_info'", date='2021-12-01', collection_name='community.aws')
 
     asg_name = module.params.get('name')
     asg_tags = module.params.get('tags')

--- a/plugins/modules/ec2_customer_gateway_info.py
+++ b/plugins/modules/ec2_customer_gateway_info.py
@@ -126,7 +126,8 @@ def main():
                               mutually_exclusive=[['customer_gateway_ids', 'filters']],
                               supports_check_mode=True)
     if module._module._name == 'ec2_customer_gateway_facts':
-        module._module.deprecate("The 'ec2_customer_gateway_facts' module has been renamed to 'ec2_customer_gateway_info'", version='2.13')
+        module._module.deprecate("The 'ec2_customer_gateway_facts' module has been renamed to 'ec2_customer_gateway_info'",
+                                 date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('ec2')
 

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -78,7 +78,7 @@ options:
     type: str
   wait_timeout:
     description:
-      - The I(wait_timeout) option does nothing and will be removed in Ansible 2.14.
+      - The I(wait_timeout) option does nothing and will be removed after 2022-06-01
     type: int
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -525,7 +525,7 @@ def main():
                                        default=False),
         release_on_disassociation=dict(required=False, type='bool', default=False),
         allow_reassociation=dict(type='bool', default=False),
-        wait_timeout=dict(type='int', removed_in_version='2.14'),
+        wait_timeout=dict(type='int', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         private_ip_address=dict(),
         tag_name=dict(),
         tag_value=dict(),

--- a/plugins/modules/ec2_eip_info.py
+++ b/plugins/modules/ec2_eip_info.py
@@ -133,7 +133,7 @@ def main():
         supports_check_mode=True
     )
     if module._module._name == 'ec2_eip_facts':
-        module._module.deprecate("The 'ec2_eip_facts' module has been renamed to 'ec2_eip_info'", version='2.13')
+        module._module.deprecate("The 'ec2_eip_facts' module has been renamed to 'ec2_eip_info'", date='2021-12-01', collection_name='community.aws')
 
     module.exit_json(changed=False, addresses=get_eips_details(module))
 

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -239,7 +239,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
     if module._name == 'ec2_elb_facts':
-        module.deprecate("The 'ec2_elb_facts' module has been renamed to 'ec2_elb_info'", version='2.13')
+        module.deprecate("The 'ec2_elb_facts' module has been renamed to 'ec2_elb_info'", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -551,7 +551,7 @@ def main():
                            supports_check_mode=True
                            )
     if module._name == 'ec2_instance_facts':
-        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", version='2.13')
+        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -176,7 +176,7 @@ options:
     choices: ['default', 'dedicated']
   associate_public_ip_address:
     description:
-      - The I(associate_public_ip_address) option does nothing and will be removed in Ansible 2.14.
+      - The I(associate_public_ip_address) option does nothing and will be removed after 2022-06-01
     type: bool
 
 extends_documentation_fragment:
@@ -669,7 +669,7 @@ def main():
             ramdisk_id=dict(),
             instance_profile_name=dict(),
             ebs_optimized=dict(default=False, type='bool'),
-            associate_public_ip_address=dict(type='bool', removed_in_version='2.14'),
+            associate_public_ip_address=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
             instance_monitoring=dict(default=False, type='bool'),
             assign_public_ip=dict(type='bool'),
             classic_link_vpc_security_groups=dict(type='list'),

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -217,7 +217,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec)
     if module._name == 'ec2_lc_facts':
-        module.deprecate("The 'ec2_lc_facts' module has been renamed to 'ec2_lc_info'", version='2.13')
+        module.deprecate("The 'ec2_lc_facts' module has been renamed to 'ec2_lc_info'", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/ec2_metric_alarm.py
+++ b/plugins/modules/ec2_metric_alarm.py
@@ -58,7 +58,7 @@ options:
     comparison:
         description:
           - Determines how the threshold value is compared
-          - Symbolic comparison operators have been deprecated, and will be removed in 2.14
+          - Symbolic comparison operators have been deprecated, and will be removed after 2022-06-22.
         required: false
         type: str
         choices:
@@ -238,7 +238,8 @@ def create_metric_alarm(connection, module):
                    '>': 'GreaterThanThreshold'}
     if comparison in ('<=', '<', '>', '>='):
         module.deprecate('Using the <=, <, > and >= operators for comparison has been deprecated. Please use LessThanOrEqualToThreshold, '
-                         'LessThanThreshold, GreaterThanThreshold or GreaterThanOrEqualToThreshold instead.', version="2.14")
+                         'LessThanThreshold, GreaterThanThreshold or GreaterThanOrEqualToThreshold instead.',
+                         date='2022-06-01', collection_name='community.aws')
         comparison = comparisons[comparison]
 
     if not isinstance(dimensions, list):

--- a/plugins/modules/ec2_placement_group_info.py
+++ b/plugins/modules/ec2_placement_group_info.py
@@ -113,7 +113,8 @@ def main():
         supports_check_mode=True
     )
     if module._module._name == 'ec2_placement_group_facts':
-        module._module.deprecate("The 'ec2_placement_group_facts' module has been renamed to 'ec2_placement_group_info'", version='2.13')
+        module._module.deprecate("The 'ec2_placement_group_facts' module has been renamed to 'ec2_placement_group_info'",
+                                 date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('ec2')
 

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -174,7 +174,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_endpoint_facts':
-        module.deprecate("The 'ec2_vpc_endpoint_facts' module has been renamed to 'ec2_vpc_endpoint_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_endpoint_facts' module has been renamed to 'ec2_vpc_endpoint_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
     if not HAS_BOTO3:

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -137,7 +137,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_igw_facts':
-        module.deprecate("The 'ec2_vpc_igw_facts' module has been renamed to 'ec2_vpc_igw_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_igw_facts' module has been renamed to 'ec2_vpc_igw_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
     if not HAS_BOTO3:

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -209,7 +209,7 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_nacl_facts':
-        module.deprecate("The 'ec2_vpc_nacl_facts' module has been renamed to 'ec2_vpc_nacl_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_nacl_facts' module has been renamed to 'ec2_vpc_nacl_info'", date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -133,7 +133,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
     if module._name == 'ec2_vpc_nat_gateway_facts':
-        module.deprecate("The 'ec2_vpc_nat_gateway_facts' module has been renamed to 'ec2_vpc_nat_gateway_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_nat_gateway_facts' module has been renamed to 'ec2_vpc_nat_gateway_info'",
+                         date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
     if not HAS_BOTO3:

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -113,7 +113,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
     if module._name == 'ec2_vpc_peering_facts':
-        module.deprecate("The 'ec2_vpc_peering_facts' module has been renamed to 'ec2_vpc_peering_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_peering_facts' module has been renamed to 'ec2_vpc_peering_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
     if not HAS_BOTO3:

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -107,7 +107,8 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
     if module._name == 'ec2_vpc_route_table_facts':
-        module.deprecate("The 'ec2_vpc_route_table_facts' module has been renamed to 'ec2_vpc_route_table_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_route_table_facts' module has been renamed to 'ec2_vpc_route_table_info'",
+                         date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -143,7 +143,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_vgw_facts':
-        module.deprecate("The 'ec2_vpc_vgw_facts' module has been renamed to 'ec2_vpc_vgw_info'", version='2.13')
+        module.deprecate("The 'ec2_vpc_vgw_facts' module has been renamed to 'ec2_vpc_vgw_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
     if not HAS_BOTO3:

--- a/plugins/modules/ec2_vpc_vpn_info.py
+++ b/plugins/modules/ec2_vpc_vpn_info.py
@@ -205,7 +205,7 @@ def main():
                               mutually_exclusive=[['vpn_connection_ids', 'filters']],
                               supports_check_mode=True)
     if module._module._name == 'ec2_vpc_vpn_facts':
-        module._module.deprecate("The 'ec2_vpc_vpn_facts' module has been renamed to 'ec2_vpc_vpn_info'", version='2.13')
+        module._module.deprecate("The 'ec2_vpc_vpn_facts' module has been renamed to 'ec2_vpc_vpn_info'", date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('ec2')
 

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -43,7 +43,7 @@ options:
     purge_policy:
         description:
             - If yes, remove the policy from the repository.
-            - Alias C(delete_policy) has been deprecated and will be removed in Ansible 2.14
+            - Alias C(delete_policy) has been deprecated and will be removed after 2022-06-01.
         required: false
         default: false
         type: bool
@@ -502,7 +502,7 @@ def main():
         image_tag_mutability=dict(required=False, choices=['mutable', 'immutable'],
                                   default='mutable'),
         purge_policy=dict(required=False, type='bool', aliases=['delete_policy'],
-                          deprecated_aliases=[dict(name='delete_policy', version='2.14')]),
+                          deprecated_aliases=[dict(name='delete_policy', date='2022-06-01', collection_name='community.aws')]),
         lifecycle_policy=dict(required=False, type='json'),
         purge_lifecycle_policy=dict(required=False, type='bool')
     )

--- a/plugins/modules/ecs_service_info.py
+++ b/plugins/modules/ecs_service_info.py
@@ -225,7 +225,7 @@ def main():
     is_old_facts = module._name == 'ecs_service_facts'
     if is_old_facts:
         module.deprecate("The 'ecs_service_facts' module has been renamed to 'ecs_service_info', "
-                         "and the renamed one no longer returns ansible_facts", version='2.13')
+                         "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
 
     show_details = module.params.get('details')
 

--- a/plugins/modules/ecs_taskdefinition_info.py
+++ b/plugins/modules/ecs_taskdefinition_info.py
@@ -314,7 +314,8 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ecs_taskdefinition_facts':
-        module.deprecate("The 'ecs_taskdefinition_facts' module has been renamed to 'ecs_taskdefinition_info'", version='2.13')
+        module.deprecate("The 'ecs_taskdefinition_facts' module has been renamed to 'ecs_taskdefinition_info'",
+                         date='2021-12-01', collection_name='community.aws')
 
     ecs = module.client('ecs')
 

--- a/plugins/modules/efs_info.py
+++ b/plugins/modules/efs_info.py
@@ -365,7 +365,7 @@ def main():
     is_old_facts = module._name == 'efs_facts'
     if is_old_facts:
         module.deprecate("The 'efs_facts' module has been renamed to 'efs_info', "
-                         "and the renamed one no longer returns ansible_facts", version='2.13')
+                         "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
 
     connection = EFSConnection(module)
 

--- a/plugins/modules/elasticache_info.py
+++ b/plugins/modules/elasticache_info.py
@@ -299,7 +299,7 @@ def main():
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'elasticache_facts':
-        module.deprecate("The 'elasticache_facts' module has been renamed to 'elasticache_info'", version='2.13')
+        module.deprecate("The 'elasticache_facts' module has been renamed to 'elasticache_info'", date='2021-12-01', collection_name='community.aws')
 
     client = module.client('elasticache')
 

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -273,7 +273,8 @@ def main():
                            supports_check_mode=True
                            )
     if module._name == 'elb_application_lb_facts':
-        module.deprecate("The 'elb_application_lb_facts' module has been renamed to 'elb_application_lb_info'", version='2.13')
+        module.deprecate("The 'elb_application_lb_facts' module has been renamed to 'elb_application_lb_info'",
+                         date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -197,7 +197,7 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)
     if module._name == 'elb_classic_lb_facts':
-        module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", version='2.13')
+        module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('elb')
 

--- a/plugins/modules/elb_network_lb.py
+++ b/plugins/modules/elb_network_lb.py
@@ -440,7 +440,7 @@ def main():
         # See below, unless state==present we delete.  Ouch.
         module.deprecate('State currently defaults to absent.  This is inconsistent with other modules'
                          ' and the default will be changed to `present` in Ansible 2.14',
-                         version='2.14')
+                         date='2022-06-01', collection_name='community.aws')
 
     # Quick check of listeners parameters
     listeners = module.params.get("listeners")

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -309,7 +309,7 @@ def main():
                            supports_check_mode=True
                            )
     if module._name == 'elb_target_group_facts':
-        module.deprecate("The 'elb_target_group_facts' module has been renamed to 'elb_target_group_info'", version='2.13')
+        module.deprecate("The 'elb_target_group_facts' module has been renamed to 'elb_target_group_info'", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/elb_target_info.py
+++ b/plugins/modules/elb_target_info.py
@@ -416,7 +416,7 @@ def main():
         supports_check_mode=True,
     )
     if module._name == 'elb_target_facts':
-        module.deprecate("The 'elb_target_facts' module has been renamed to 'elb_target_info'", version='2.13')
+        module.deprecate("The 'elb_target_facts' module has been renamed to 'elb_target_info'", date='2021-12-01', collection_name='community.aws')
 
     instance_id = module.params["instance_id"]
     get_unused_target_groups = module.params["get_unused_target_groups"]

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -45,7 +45,7 @@ options:
     type: str
   fail_on_delete:
     description:
-    - The I(fail_on_delete) option does nothing and will be removed in Ansible 2.14.
+    - The I(fail_on_delete) option does nothing and will be removed after 2022-06-01
     type: bool
 
 author: "Dan Kozlowski (@dkhenry)"
@@ -289,7 +289,7 @@ def main():
         policy=dict(type='json'),
         make_default=dict(type='bool', default=True),
         only_version=dict(type='bool', default=False),
-        fail_on_delete=dict(type='bool', removed_in_version='2.14'),
+        fail_on_delete=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         state=dict(default='present', choices=['present', 'absent']),
     ))
 

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -98,7 +98,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec)
     if module._name == 'iam_mfa_device_facts':
-        module.deprecate("The 'iam_mfa_device_facts' module has been renamed to 'iam_mfa_device_info'", version='2.13')
+        module.deprecate("The 'iam_mfa_device_facts' module has been renamed to 'iam_mfa_device_info'", date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -304,13 +304,13 @@ def main():
     if (skip_duplicates is None):
         module.deprecate('The skip_duplicates behaviour has caused confusion and'
                          ' will be disabled by default in Ansible 2.14',
-                         version='2.14')
+                         date='2022-06-01', collection_name='community.aws')
         skip_duplicates = True
 
     if module.params.get('policy_document'):
         module.deprecate('The policy_document option has been deprecated and'
                          ' will be removed in Ansible 2.14',
-                         version='2.14')
+                         date='2022-06-01', collection_name='community.aws')
 
     args = dict(
         client=module.client('iam'),

--- a/plugins/modules/iam_role.py
+++ b/plugins/modules/iam_role.py
@@ -629,7 +629,7 @@ def main():
 
     if module.params.get('purge_policies') is None:
         module.deprecate('In Ansible 2.14 the default value of purge_policies will change from true to false.'
-                         '  To maintain the existing behaviour explicity set purge_policies=true', version='2.14')
+                         '  To maintain the existing behaviour explicity set purge_policies=true', date='2022-06-01', collection_name='community.aws')
 
     if module.params.get('boundary'):
         if module.params.get('create_instance_profile'):

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -242,7 +242,7 @@ def main():
                               supports_check_mode=True,
                               mutually_exclusive=[['name', 'path_prefix']])
     if module._name == 'iam_role_facts':
-        module.deprecate("The 'iam_role_facts' module has been renamed to 'iam_role_info'", version='2.13')
+        module.deprecate("The 'iam_role_facts' module has been renamed to 'iam_role_info'", date='2021-12-01', collection_name='community.aws')
 
     client = module.client('iam')
 

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -147,7 +147,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,)
     if module._name == 'iam_server_certificate_facts':
-        module.deprecate("The 'iam_server_certificate_facts' module has been renamed to 'iam_server_certificate_info'", version='2.13')
+        module.deprecate("The 'iam_server_certificate_facts' module has been renamed to 'iam_server_certificate_info'",
+                         date='2021-12-01', collection_name='community.aws')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/lambda_facts.py
+++ b/plugins/modules/lambda_facts.py
@@ -10,7 +10,8 @@ DOCUMENTATION = '''
 ---
 module: lambda_facts
 deprecated:
-  removed_in: '2.13'
+  removed_at_date: '2021-12-01'
+  removed_from_collection: 'community.aws'
   why: Deprecated in favour of C(_info) module.
   alternative: Use M(lambda_info) instead.
 short_description: Gathers AWS Lambda function details as Ansible facts

--- a/plugins/modules/rds_instance_info.py
+++ b/plugins/modules/rds_instance_info.py
@@ -396,7 +396,7 @@ def main():
         supports_check_mode=True,
     )
     if module._name == 'rds_instance_facts':
-        module.deprecate("The 'rds_instance_facts' module has been renamed to 'rds_instance_info'", version='2.13')
+        module.deprecate("The 'rds_instance_facts' module has been renamed to 'rds_instance_info'", date='2021-12-01', collection_name='community.aws')
 
     conn = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10))
 

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -376,7 +376,7 @@ def main():
         mutually_exclusive=[['db_snapshot_identifier', 'db_instance_identifier', 'db_cluster_identifier', 'db_cluster_snapshot_identifier']]
     )
     if module._name == 'rds_snapshot_facts':
-        module.deprecate("The 'rds_snapshot_facts' module has been renamed to 'rds_snapshot_info'", version='2.13')
+        module.deprecate("The 'rds_snapshot_facts' module has been renamed to 'rds_snapshot_info'", date='2021-12-01', collection_name='community.aws')
 
     conn = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10))
     results = dict()

--- a/plugins/modules/redshift_info.py
+++ b/plugins/modules/redshift_info.py
@@ -335,7 +335,7 @@ def main():
         supports_check_mode=True
     )
     if module._name == 'redshift_facts':
-        module.deprecate("The 'redshift_facts' module has been renamed to 'redshift_info'", version='2.13')
+        module.deprecate("The 'redshift_facts' module has been renamed to 'redshift_info'", date='2021-12-01', collection_name='community.aws')
 
     cluster_identifier = module.params.get('cluster_identifier')
     cluster_tags = module.params.get('tags')

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -463,7 +463,7 @@ def main():
         ],
     )
     if module._name == 'route53_facts':
-        module.deprecate("The 'route53_facts' module has been renamed to 'route53_info'", version='2.13')
+        module.deprecate("The 'route53_facts' module has been renamed to 'route53_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
     if not (HAS_BOTO or HAS_BOTO3):

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -115,7 +115,7 @@ options:
     type: list
   requester_pays:
     description:
-      - The I(requester_pays) option does nothing and will be removed in Ansible 2.14.
+      - The I(requester_pays) option does nothing and will be removed after 2022-06-01
     type: bool
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -443,7 +443,7 @@ def main():
         noncurrent_version_transition_days=dict(type='int'),
         noncurrent_version_transitions=dict(type='list'),
         prefix=dict(),
-        requester_pays=dict(type='bool', removed_in_version='2.14'),
+        requester_pays=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         rule_id=dict(),
         state=dict(default='present', choices=['present', 'absent']),
         status=dict(default='enabled', choices=['enabled', 'disabled']),

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -109,7 +109,7 @@ options:
     type: bool
   retries:
     description:
-      - The I(retries) option does nothing and will be removed in Ansible 2.14.
+      - The I(retries) option does nothing and will be removed after 2022-06-01
     type: str
 
 requirements:
@@ -512,7 +512,7 @@ def main():
         file_root=dict(required=True, type='path'),
         permission=dict(required=False, choices=['private', 'public-read', 'public-read-write', 'authenticated-read',
                                                  'aws-exec-read', 'bucket-owner-read', 'bucket-owner-full-control']),
-        retries=dict(required=False, removed_in_version='2.14'),
+        retries=dict(required=False, removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         mime_map=dict(required=False, type='dict'),
         exclude=dict(required=False, default=".*"),
         include=dict(required=False, default="*"),

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,2 @@
+# netaddr is needed for ansible.netcommon.ipv6
+netaddr

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,2 +1,3 @@
 # netaddr is needed for ansible.netcommon.ipv6
 netaddr
+virtualenv

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -87,7 +87,7 @@ git clone https://github.com/ansible-collections/community.general community/gen
 # once community.general is published this will be handled by galaxy cli
 git clone https://github.com/ansible-collections/ansible_collections_google google/cloud
 git clone https://opendev.org/openstack/ansible-collections-openstack openstack/cloud
-ansible-galaxy collection install amazon.aws
+git clone https://github.com/ansible-collections/amazon.aws amazon/aws
 ansible-galaxy collection install ansible.netcommon
 ansible-galaxy collection install community.crypto
 cd "${cwd}"


### PR DESCRIPTION
##### SUMMARY
We've been using galaxy to install amazon.aws in shippable, but that
doesn't really work if we aren't publising faster. Get that collection
from git so it is most up to date.

Also specify python deps needed for shippable.

And update modules deprecations; collections won't track ansible-base versions for deprecations.

##### ISSUE TYPE
- Bugfix Pull Request


