### PR TITLE
Revert "Use git tags for version number instead of galaxy.yml"

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,9 +1,6 @@
 namespace: community
 name: aws
-# the version key is generated during the release by Zuul
-# https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
-# A script based on https://pypi.org/project/pbr/ will generate the version
-# key. The version value depends on the tag or the last git tag.
+version: 0.1.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
Reverts ansible-collections/community.aws#104
This is making installing this collection from source in amazon.aws' shippable tests unhappy.  Zuul will override this value so we can leave it for now.