### PR TITLE
make iam_role idempotent when comparing assume role policies

### DIFF
--- a/plugins/modules/iam_role.py
+++ b/plugins/modules/iam_role.py
@@ -208,7 +208,7 @@ except ImportError:
 
 
 def compare_assume_role_policy_doc(current_policy_doc, new_policy_doc):
-    if not compare_policies(current_policy_doc, json.loads(new_policy_doc)):
+    if not compare_policies(json.loads(current_policy_doc), json.loads(new_policy_doc)):
         return True
     else:
         return False

--- a/tests/integration/targets/iam_role/tasks/main.yml
+++ b/tests/integration/targets/iam_role/tasks/main.yml
@@ -1410,7 +1410,7 @@
     register: iam_role
   - assert:
       that:
-      - iam_role is changed
+      - iam_role is not changed
       - iam_role.iam_role.role_name == test_role
       - 'iam_role.iam_role.arn.startswith("arn")'
       - 'iam_role.iam_role.arn.endswith("role" + test_path + test_role )'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #115 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

iam_role

##### ADDITIONAL INFORMATION

**I have not tested this**

As per #120 , there are not yet any clear instructions on how contributors can run integration tests locally now that these modules have been moved to a separate repo. Similarly I cannot find instructions on how to manually run a playbook with a modified module.

(I'm hoping the Ansibot will run the tests and tell me if they fail.)

For the change to the tests, as far as I can tell that task is identical to the one two above. Therefore it should be marked as not changed. I believe the bug in #115 got past tests because this assertion in the test is backwards.
