### PR TITLE
Fix documentation YAML for redshift and redshift_subnet_group

### DIFF
--- a/plugins/modules/redshift.py
+++ b/plugins/modules/redshift.py
@@ -11,10 +11,10 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 author:
-version_added: 1.0.0
   - "Jens Carl (@j-carl), Hothead Games Inc."
   - "Rafael Driutti (@rafaeldriutti)"
 module: redshift
+version_added: 1.0.0
 short_description: create, delete, or modify an Amazon Redshift instance
 description:
   - Creates, deletes, or modifies Amazon Redshift cluster instances.

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -10,9 +10,9 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 author:
-version_added: 1.0.0
   - "Jens Carl (@j-carl), Hothead Games Inc."
 module: redshift_subnet_group
+version_added: 1.0.0
 short_description: manage Redshift cluster subnet groups
 description:
   - Create, modifies, and deletes Redshift cluster subnet groups.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Attempting to run sanity tests locally turned up a couple of misaligned insertions that broke the documentation structure in these modules.

This was a bit tricky to track down because it causes a traceback in validate-modules, when it should just be a validation failure:
```
Traceback (most recent call last):
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 881, in _validate_docs_schema
    schema(doc)
  File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 386, in validate_mapping
    cval = cvalue(key_path, value)
  File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 205, in _run
    return self._exec(self._compiled, value, path)
  File "/usr/local/lib/python3.6/dist-packages/voluptuous/validators.py", line 285, in _exec
    v = func(path, v)
  File "/usr/local/lib/python3.6/dist-packages/voluptuous/schema_builder.py", line 817, in validate_callable
    return schema(data)
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py", line 420, in author
    m = author_line.search(line)
TypeError: expected string or bytes-like object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate-modules", line 8, in <module>
    main()
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2448, in main
    run()
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2345, in run
    mv1.validate()
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2149, in validate
    doc_info, docs = self._validate_docs()
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1032, in _validate_docs
    'invalid-documentation',
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 883, in _validate_docs_schema
    for error in e.errors:
AttributeError: 'TypeError' object has no attribute 'errors'
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redshift
redshift_subnet_group