### PR TITLE
Add new params to ECS event

### DIFF
--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+
 DOCUMENTATION = r'''
 ---
 module: cloudwatchevent_rule
@@ -200,6 +201,7 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
+
 class CloudWatchEventRule(object):
     def __init__(self, module, name, client, schedule_expression=None,
                  event_pattern=None, description=None, role_arn=None):
@@ -366,6 +368,7 @@ class CloudWatchEventRule(object):
         """Converts camel case to snake case"""
         return camel_dict_to_snake_dict(dict)
 
+
 class CloudWatchEventRuleManager(object):
     RULE_FIELDS = ['name', 'event_pattern', 'schedule_expression', 'description', 'role_arn']
 
@@ -476,6 +479,7 @@ class CloudWatchEventRuleManager(object):
             return
         return description['state']
 
+
 def main():
     argument_spec = dict(
         name=dict(required=True),
@@ -509,6 +513,7 @@ def main():
         module.fail_json(msg="Invalid state '{0}' provided".format(state))
 
     module.exit_json(**cwe_rule_manager.fetch_aws_state())
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -106,6 +106,7 @@ options:
             description: The number of tasks to create based on I(task_definition).
           launch_type:
             type: str
+            choices: ['EC2', 'FARGATE']
             description: Either EC2 or FARGATE.
           network_configuration:
             type: dict
@@ -117,6 +118,7 @@ options:
                 suboptions:
                   assign_public_ip:
                     type: str
+                    choices: ['ENABLED', 'DISABLED']
                     description:
                       - For FARGATE, values can be either ENABLED or DISABLED.
                       - For EC2, it can only be DISABLED.

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -493,18 +493,26 @@ def main():
         id=dict(type='str', required=True),
         arn=dict(type='str', required=True),
         role_arn=dict(type='str'),
+        input=dict(type='str'),
+        input_path=dict(type='str'),
         ecs_parameters=dict(
             type='dict',
-            launch_type=dict(type='str', choices=['EC2', 'FARGATE']),
-            task_definition_arn=dict(type='str'),
-            task_count=dict(type='int'),
-            network_configuration=dict(
-                type='dict',
-                awsvpc_configuration=dict(
+            options=dict(
+                launch_type=dict(type='str', choices=['EC2', 'FARGATE']),
+                task_definition_arn=dict(type='str'),
+                task_count=dict(type='int'),
+                network_configuration=dict(
                     type='dict',
-                    assign_public_ip=dict(type='str', choices=['ENABLED', 'DISABLED']),
-                    security_groups=dict(type='list', elements='str'),
-                    subnets=dict(type='list', elements='str')
+                    options=dict(
+                        awsvpc_configuration=dict(
+                            type='dict',
+                            options=dict(
+                                assign_public_ip=dict(type='str', choices=['ENABLED', 'DISABLED']),
+                                security_groups=dict(type='list', elements='str'),
+                                subnets=dict(type='list', elements='str')
+                            )
+                        )
+                    )
                 )
             )
         )
@@ -518,7 +526,7 @@ def main():
                    default='present'),
         description=dict(),
         role_arn=dict(),
-        targets=dict(type='list', default=[], elements='dict', suboptions=target_options),
+        targets=dict(type='list', default=[], elements='dict', options=target_options),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -493,7 +493,7 @@ def main():
         id=dict(type='str', required=True),
         arn=dict(type='str', required=True),
         role_arn=dict(type='str'),
-        ecs_params=dict(
+        ecs_parameters=dict(
             type='dict',
             launch_type=dict(type='str', choices=['EC2', 'FARGATE']),
             task_definition_arn=dict(type='str'),

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -108,17 +108,21 @@ options:
             type: str
             choices: ['EC2', 'FARGATE']
             description: Either EC2 or FARGATE.
+            required: false
           network_configuration:
             type: dict
             description: Contains network configuration parameters.
+            required: false
             suboptions:
               awsvpc_configuration:
                 type: dict
                 description: Specific VPC parameters.
+                required: false
                 suboptions:
                   assign_public_ip:
                     type: str
                     choices: ['ENABLED', 'DISABLED']
+                    required: false
                     description:
                       - For FARGATE, values can be either ENABLED or DISABLED.
                       - For EC2, it can only be DISABLED.
@@ -126,10 +130,12 @@ options:
                     type: list
                     elements: str
                     description: List of security groups.
+                    required: false
                   subnets:
                     type: list
                     elements: str
                     description: List of subnets.
+                    required: false
     required: false
 '''
 
@@ -484,8 +490,8 @@ class CloudWatchEventRuleManager(object):
 
 def main():
     target_options = dict(
-        id=dict(type='str'),
-        arn=dict(type='str'),
+        id=dict(type='str', required=True),
+        arn=dict(type='str', required=True),
         role_arn=dict(type='str'),
         ecs_params=dict(
             type='dict',
@@ -495,10 +501,10 @@ def main():
             network_configuration=dict(
                 type='dict',
                 awsvpc_configuration=dict(
-                  type='dict',
-                  assign_public_ip=dict(type='str', choices=['ENABLED', 'DISABLED']),
-                  security_groups=dict(type='list', elements='str'),
-                  subnets=dict(type='list', elements='str')
+                    type='dict',
+                    assign_public_ip=dict(type='str', choices=['ENABLED', 'DISABLED']),
+                    security_groups=dict(type='list', elements='str'),
+                    subnets=dict(type='list', elements='str')
                 )
             )
         )

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -518,7 +518,7 @@ def main():
                    default='present'),
         description=dict(),
         role_arn=dict(),
-        targets=dict(type='list', default=[], elements='dict', options=target_options),
+        targets=dict(type='list', default=[], elements='dict', suboptions=target_options),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 DOCUMENTATION = r'''
 ---
 module: cloudwatchevent_rule
@@ -157,7 +156,6 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
-
 class CloudWatchEventRule(object):
     def __init__(self, module, name, client, schedule_expression=None,
                  event_pattern=None, description=None, role_arn=None):
@@ -302,13 +300,27 @@ class CloudWatchEventRule(object):
                     target_request['EcsParameters']['TaskDefinitionArn'] = ecs_parameters['task_definition_arn']
                 if 'task_count' in target['ecs_parameters']:
                     target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count']
+                if 'launch_type' in target['ecs_parameters']:
+                    target_request['EcsParameters']['LaunchType'] = ecs_parameters['launch_type']
+                if 'network_configuration' in target['ecs_parameters']:
+                    network_configuration = ecs_parameters['network_configuration']
+                    _network_config = {}
+                    if 'awsvpc_configuration' in network_configuration:
+                        _network_config['awsvpcConfiguration'] = {}
+                        if 'assign_public_ip' in network_configuration['awsvpc_configuration']:
+                            _network_config['awsvpcConfiguration']['AssignPublicIp'] = network_configuration['awsvpc_configuration']['assign_public_ip']
+                        if 'security_groups' in network_configuration['awsvpc_configuration']:
+                            _network_config['awsvpcConfiguration']['SecurityGroups'] = network_configuration['awsvpc_configuration']['security_groups']
+                        if 'subnets' in network_configuration['awsvpc_configuration']:
+                            _network_config['awsvpcConfiguration']['Subnets'] = network_configuration['awsvpc_configuration']['subnets']
+                    target_request['EcsParameters']['NetworkConfiguration'] = _network_config
+
             targets_request.append(target_request)
         return targets_request
 
     def _snakify(self, dict):
         """Converts camel case to snake case"""
         return camel_dict_to_snake_dict(dict)
-
 
 class CloudWatchEventRuleManager(object):
     RULE_FIELDS = ['name', 'event_pattern', 'schedule_expression', 'description', 'role_arn']
@@ -420,7 +432,6 @@ class CloudWatchEventRuleManager(object):
             return
         return description['state']
 
-
 def main():
     argument_spec = dict(
         name=dict(required=True),
@@ -454,7 +465,6 @@ def main():
         module.fail_json(msg="Invalid state '{0}' provided".format(state))
 
     module.exit_json(**cwe_rule_manager.fetch_aws_state())
-
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -103,6 +103,30 @@ options:
           task_count:
             type: int
             description: The number of tasks to create based on I(task_definition).
+          launch_type:
+            type: str
+            description: Either EC2 or FARGATE.
+          network_configuration:
+            type: dict
+            description: Contains network configuration parameters.
+            suboptions:
+              awsvpc_configuration:
+                type: dict
+                description: Specific VPC parameters.
+                suboptions:
+                  assign_public_ip:
+                    type: str
+                    description:
+                      - For FARGATE, values can be either ENABLED or DISABLED.
+                      - For EC2, it can only be DISABLED.
+                  security_groups:
+                    type: list
+                    elements: str
+                    description: List of security groups.
+                  subnets:
+                    type: list
+                    elements: str
+                    description: List of subnets.
     required: false
 '''
 
@@ -128,6 +152,26 @@ EXAMPLES = r'''
 - community.aws.cloudwatchevent_rule:
     name: MyCronTask
     state: absent
+
+- cloudwatchevent_rule:
+    name: run_foo
+    state: enabled
+    schedule_expression: "rate(60 minutes)"
+    targets:
+    - id: run-job-foo
+      arn: arn:aws:ecs:ap-southeast-2:123456789123:cluster/jobs-cluster
+      role_arn: arn:aws:iam::123456789123:role/ecsEventsRole
+      ecs_parameters:
+        launch_type: FARGATE
+        network_configuration:
+          awsvpc_configuration:
+            assign_public_ip: ENABLED
+            security_groups:
+            - sg-58519c0e3db6f851
+            subnets:
+            - subnet-0c4b66b1d07e4e0c
+        task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
+        task_count: 1
 '''
 
 RETURN = r'''

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -481,6 +481,27 @@ class CloudWatchEventRuleManager(object):
 
 
 def main():
+    target_options = dict(
+        id=dict(type='str'),
+        arn=dict(type='str'),
+        role_arn=dict(type='str'),
+        ecs_params=dict(
+            type='dict',
+            launch_type=dict(type='str', choices=['EC2', 'FARGATE']),
+            task_definition_arn=dict(type='str'),
+            task_count=dict(type='int'),
+            network_configuration=dict(
+                type='dict',
+                awsvpc_configuration=dict(
+                  type='dict',
+                  assign_public_ip=dict(type='str', choices=['ENABLED', 'DISABLED']),
+                  security_groups=dict(type='list', elements='str'),
+                  subnets=dict(type='list', elements='str')
+                )
+            )
+        )
+    )
+
     argument_spec = dict(
         name=dict(required=True),
         schedule_expression=dict(),
@@ -489,7 +510,7 @@ def main():
                    default='present'),
         description=dict(),
         role_arn=dict(),
-        targets=dict(type='list', default=[], elements='dict'),
+        targets=dict(type='list', default=[], elements='dict', options=target_options),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -109,6 +109,15 @@ options:
             choices: ['EC2', 'FARGATE']
             description: Either EC2 or FARGATE.
             required: false
+          platform_version:
+            type: str
+            choices: ['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.4.0', 'LATEST']
+            description: Numeric part of platform version or LATEST
+            required: false
+          group:
+            type: str
+            description: ECS group name for the task.
+            required: false
           network_configuration:
             type: dict
             description: Contains network configuration parameters.
@@ -172,6 +181,8 @@ EXAMPLES = r'''
       role_arn: arn:aws:iam::123456789123:role/ecsEventsRole
       ecs_parameters:
         launch_type: FARGATE
+        platform_version: LATEST
+        group: web-tasks
         network_configuration:
           awsvpc_configuration:
             assign_public_ip: ENABLED
@@ -356,6 +367,10 @@ class CloudWatchEventRule(object):
                     target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count']
                 if 'launch_type' in target['ecs_parameters']:
                     target_request['EcsParameters']['LaunchType'] = ecs_parameters['launch_type']
+                if 'platform_version' in target['ecs_parameters']:
+                    target_request['EcsParameters']['PlatformVersion'] = ecs_parameters['platform_version']
+                if 'group' in target['ecs_parameters']:
+                    target_request['EcsParameters']['Group'] = ecs_parameters['group']
                 if 'network_configuration' in target['ecs_parameters']:
                     network_configuration = ecs_parameters['network_configuration']
                     _network_config = {}
@@ -501,6 +516,8 @@ def main():
                 launch_type=dict(type='str', choices=['EC2', 'FARGATE']),
                 task_definition_arn=dict(type='str'),
                 task_count=dict(type='int'),
+                platform_version=dict(type='str', choices=['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.4.0', 'LATEST']),
+                group=dict(type='str'),
                 network_configuration=dict(
                     type='dict',
                     options=dict(

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -11,7 +11,7 @@
     - name: create cloudwarch event rule for integration test
       register: result
       cloudwatchevent_rule:
-        name: run_foo
+        name: '{{ resource_prefix }}'
         description: 'Run Foo'
         state: enabled
         schedule_expression: "rate(60 minutes)"

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -67,12 +67,12 @@
             task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
             task_count: 1
 
-    - name: check event rule update
+    - name: check event rule update with invalid launch type
       asserts:
         that:
           - result is not changed
           - result.error.code == "ValidationException"
-          - result.error.message == "1 validation error detected: Value 'INVALID_TYPE' at 'targets.1.member.ecsParameters.launchType' failed to satisfy constraint: Member must satisfy enum value set: [FARGATE, EC2]"
+          - "result.error.message == \"1 validation error detected: Value 'INVALID_TYPE' at 'targets.1.member.ecsParameters.launchType' failed to satisfy constraint: Member must satisfy enum value set: [FARGATE, EC2]\""
 
     - name: update cloudwarch event rule with invalid assign public ip option
       register: result
@@ -97,9 +97,9 @@
             task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
             task_count: 1
 
-    - name: check created event rule
+    - name: check event rule update with invalid assign public ip option
       asserts:
         that:
           - result is not changed
           - result.error.code == "ValidationException"
-          - result.error.message == "1 validation error detected: Value 'INVALID_OPTION' at 'targets.1.member.ecsParameters.networkConfiguration.awsvpcConfiguration.assignPublicIp' failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]"
+          - "result.error.message == \"1 validation error detected: Value 'INVALID_OPTION' at 'targets.1.member.ecsParameters.networkConfiguration.awsvpcConfiguration.assignPublicIp' failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]\""

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+
+- module_detauls:
+  group/aws:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token | default(omit) }}"
+    region: "{{ aws_region }}"
+
+  block:
+    - name: create cloudwarch event rule for integration test
+      register: result
+      cloudwatchevent_rule:
+        name: run_foo
+        description: 'Run Foo'
+        state: enabled
+        schedule_expression: "rate(60 minutes)"
+        targets:
+        - id: run-job-foo
+          arn: arn:aws:ecs:ap-southeast-2:123456789123:cluster/jobs-cluster
+          role_arn: arn:aws:iam::123456789123:role/ecsEventsRole
+          ecs_parameters:
+            launch_type: FARGATE
+            network_configuration:
+              awsvpc_configuration:
+                assign_public_ip: ENABLED
+                security_groups:
+                - sg-58519c0e3db6f851
+                subnets:
+                - subnet-0c4b66b1d07e4e0c
+            task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
+            task_count: 1
+
+    - name: check created event rule
+      asserts:
+        that:
+          - result is changed
+          - result.rule.description == "Run Foo"
+          - result.rule.name == "run_foo"
+          - result.schedule_expression == "rate(60 minutes)"
+          - result.state == "ENABLED"
+          - result.targets[0].arn == "arn:aws:ecs:ap-southeast-2:123456789123:cluster/jobs-cluster"
+          - result.targets[0].id == "run-job-foo"
+          - result.targets[0].ecs_parameters.launch_type == "FARGATE"
+          - result.targets[0].ecs_parameters.network_configuration.awsvpc_configuration.assign_public_ip == "ENABLED"
+
+    - name: update cloudwarch event rule with invalid launch type
+      register: result
+      cloudwatchevent_rule:
+        name: run_foo
+        description: 'Run Foo'
+        state: enabled
+        schedule_expression: "rate(60 minutes)"
+        targets:
+        - id: run-job-foo
+          arn: arn:aws:ecs:ap-southeast-2:123456789123:cluster/jobs-cluster
+          role_arn: arn:aws:iam::123456789123:role/ecsEventsRole
+          ecs_parameters:
+            launch_type: INVALID_TYPE
+            network_configuration:
+              awsvpc_configuration:
+                assign_public_ip: ENABLED
+                security_groups:
+                - sg-58519c0e3db6f851
+                subnets:
+                - subnet-0c4b66b1d07e4e0c
+            task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
+            task_count: 1
+
+    - name: check event rule update
+      asserts:
+        that:
+          - result is not changed
+          - result.error.code == "ValidationException"
+          - result.error.message == "1 validation error detected: Value 'INVALID_TYPE' at 'targets.1.member.ecsParameters.launchType' failed to satisfy constraint: Member must satisfy enum value set: [FARGATE, EC2]"
+
+    - name: update cloudwarch event rule with invalid assign public ip option
+      register: result
+      cloudwatchevent_rule:
+        name: run_foo
+        description: 'Run Foo'
+        state: enabled
+        schedule_expression: "rate(60 minutes)"
+        targets:
+        - id: run-job-foo
+          arn: arn:aws:ecs:ap-southeast-2:123456789123:cluster/jobs-cluster
+          role_arn: arn:aws:iam::123456789123:role/ecsEventsRole
+          ecs_parameters:
+            launch_type: FARGATE
+            network_configuration:
+              awsvpc_configuration:
+                assign_public_ip: INVALID_OPTION
+                security_groups:
+                - sg-58519c0e3db6f851
+                subnets:
+                - subnet-0c4b66b1d07e4e0c
+            task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
+            task_count: 1
+
+    - name: check created event rule
+      asserts:
+        that:
+          - result is not changed
+          - result.error.code == "ValidationException"
+          - result.error.message == "1 validation error detected: Value 'ENABLEDkk' at 'targets.1.member.ecsParameters.networkConfiguration.awsvpcConfiguration.assignPublicIp' failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]"

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -102,4 +102,4 @@
         that:
           - result is not changed
           - result.error.code == "ValidationException"
-          - result.error.message == "1 validation error detected: Value 'ENABLEDkk' at 'targets.1.member.ecsParameters.networkConfiguration.awsvpcConfiguration.assignPublicIp' failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]"
+          - result.error.message == "1 validation error detected: Value 'INVALID_OPTION' at 'targets.1.member.ecsParameters.networkConfiguration.awsvpcConfiguration.assignPublicIp' failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]"


### PR DESCRIPTION
##### SUMMARY

I want to be able to provide more parameters for targets in to cloudwatch_rule smodule. Currently, there is no way to define ECS LaunchType and NetworkConfiguration. This is proposed in this issue: https://github.com/ansible-collections/community.aws/issues/143

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

cloudwatch_rule

##### ADDITIONAL INFORMATION

This is an example of task definition:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
---
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
  - name: Schedule for Foo
    cloudwatchevent_rule:
      name: run_foo
      state: enabled
      schedule_expression: "rate(60 minutes)"
      targets:
      - id: run-job-foo
        arn: arn:aws:ecs:ap-southeast-2:123456789123:cluster/jobs-cluster
        role_arn: arn:aws:iam::123456789123:role/ecsEventsRole
        ecs_parameters:
          launch_type: FARGATE
          network_configuration:
            awsvpc_configuration:
              assign_public_ip: ENABLED
              security_groups:
              - sg-58519c0e3db6f851
              subnets:
              - subnet-0c4b66b1d07e4e0c
          task_definition_arn: arn:aws:ecs:ap-southeast-2:123456789123:task-definition/task-to-run:1
          task_count: 1
```
