### PR TITLE
Fix typo in aws_lambda aliases

### DIFF
--- a/tests/integration/targets/aws_lambda/aliases
+++ b/tests/integration/targets/aws_lambda/aliases
@@ -2,4 +2,4 @@ cloud/aws
 shippable/aws/group2
 execute_lambda
 lambda
-lamda_info
+lambda_info


### PR DESCRIPTION
##### SUMMARY
Correct lambda_info spelling so tests will actually run

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lambda_info
