### PR TITLE
Mark a number of integration tests as unstable based on high failure rates over the last week

### DIFF
--- a/tests/integration/targets/aws_api_gateway/aliases
+++ b/tests/integration/targets/aws_api_gateway/aliases
@@ -1,2 +1,4 @@
 cloud/aws
 shippable/aws/group2
+# https://github.com/ansible-collections/community.aws/issues/158
+unstable

--- a/tests/integration/targets/cloudformation_exports_info/aliases
+++ b/tests/integration/targets/cloudformation_exports_info/aliases
@@ -1,2 +1,4 @@
 cloud/aws
 shippable/aws/group3
+# https://github.com/ansible-collections/community.aws/issues/157
+unstable

--- a/tests/integration/targets/ec2_eip/aliases
+++ b/tests/integration/targets/ec2_eip/aliases
@@ -1,2 +1,4 @@
 cloud/aws
 shippable/aws/group2
+# https://github.com/ansible-collections/community.aws/issues/159
+unstable

--- a/tests/integration/targets/ec2_vpc_nacl/aliases
+++ b/tests/integration/targets/ec2_vpc_nacl/aliases
@@ -1,3 +1,5 @@
 ec2_vpc_nacl_info
 cloud/aws
 shippable/aws/group2
+# https://github.com/ansible-collections/community.aws/issues/153
+unstable

--- a/tests/integration/targets/ec2_vpc_vgw/aliases
+++ b/tests/integration/targets/ec2_vpc_vgw/aliases
@@ -1,2 +1,4 @@
 cloud/aws
 shippable/aws/group2
+# https://github.com/ansible-collections/community.aws/issues/154
+unstable

--- a/tests/integration/targets/ec2_vpc_vpn_info/aliases
+++ b/tests/integration/targets/ec2_vpc_vpn_info/aliases
@@ -1,2 +1,4 @@
 cloud/aws
 shippable/aws/group3
+# https://github.com/ansible-collections/community.aws/issues/156
+unstable

--- a/tests/integration/targets/lambda_policy/aliases
+++ b/tests/integration/targets/lambda_policy/aliases
@@ -1,2 +1,4 @@
 cloud/aws
 shippable/aws/group1
+# https://github.com/ansible-collections/community.aws/issues/155
+unstable


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible-collections/community.aws/issues/158
https://github.com/ansible-collections/community.aws/issues/157
https://github.com/ansible-collections/community.aws/issues/159
https://github.com/ansible-collections/community.aws/issues/153
https://github.com/ansible-collections/community.aws/issues/154
https://github.com/ansible-collections/community.aws/issues/155
https://github.com/ansible-collections/community.aws/issues/156

##### ISSUE TYPE

- Test Instability

##### COMPONENT NAME

aws_api_gateway
cloudformation_exports_info
ec2_eip
ec2_vpc_nacl
ec2_vpc_vgw
ec2_vpc_vpn_info
lambda_policy

##### ADDITIONAL INFORMATION

See also https://github.com/orgs/ansible-collections/projects/4