### PR TITLE
aws_api_gateway : Switch to jittered backoff and retry on TooManyRequests

### DIFF
--- a/changelogs/fragments/161-retries.yml
+++ b/changelogs/fragments/161-retries.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add retries for aws_api_gateway when AWS throws `TooManyRequestsException`

--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -315,25 +315,25 @@ def ensure_api_in_correct_state(module, client, api_id, api_data):
     return configure_response, deploy_response
 
 
-retry_params = {"tries": 10, "delay": 5, "backoff": 1.2}
+retry_params = {"retries": 10, "delay": 10, "catch_extra_error_codes": ['TooManyRequestsException']}
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def create_api(client, name=None, description=None, endpoint_type=None):
     return client.create_rest_api(name="ansible-temp-api", description=description, endpointConfiguration={'types': [endpoint_type]})
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def delete_api(client, api_id):
     return client.delete_rest_api(restApiId=api_id)
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def configure_api(client, api_id, api_data=None, mode="overwrite"):
     return client.put_rest_api(restApiId=api_id, mode=mode, body=api_data)
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def create_deployment(client, rest_api_id, **params):
     canary_settings = params.get('stage_canary_settings')
 

--- a/tests/integration/targets/aws_api_gateway/aliases
+++ b/tests/integration/targets/aws_api_gateway/aliases
@@ -1,4 +1,2 @@
 cloud/aws
 shippable/aws/group2
-# https://github.com/ansible-collections/community.aws/issues/158
-unstable


### PR DESCRIPTION
##### SUMMARY

We've been seeing a large number of failures when running the aws_api_gateway tests.

Based on information from https://github.com/aws/aws-sdk-js/issues/1014 it would appear that 'TooManyRequestsException' occurs on the API Gateway APIs when the standard rate limits are exceeded.

fixes: #158 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_api_gateway

##### ADDITIONAL INFORMATION
