### PR TITLE
Add joshsouza to the ignore list

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -8,7 +8,7 @@ files:
   $modules/:
     authors: wimnat
     maintainers: $team_aws
-    ignore: erydo nadirollo seiffert tedder
+    ignore: erydo joshsouza nadirollo seiffert tedder
     label: modules
   $modules/_aws_region_facts.py:
     authors: Sodki


### PR DESCRIPTION
I'm still receiving a significant amount of bot spam re: Ansible, which I no longer use. It appears that this is the new way for me to be removed from the notification list.