### PR TITLE
Preserve permissions when copying lambdas

### DIFF
--- a/tests/integration/targets/aws_lambda/tasks/main.yml
+++ b/tests/integration/targets/aws_lambda/tasks/main.yml
@@ -79,6 +79,7 @@
     copy:
       src: mini_lambda.py
       dest: '{{output_dir}}/mini_lambda.py'
+      mode: preserve
   - name: bundle lambda into a zip
     register: zip_res
     archive:

--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -59,6 +59,7 @@
     copy:
       src: mini_http_lambda.py
       dest: '{{output_dir}}/mini_http_lambda.py'
+      mode: preserve
   - name: bundle lambda into a zip
     register: zip_res
     archive:


### PR DESCRIPTION
##### SUMMARY
ansible/ansible/pull/69993 changed copy's mode behaviour. Lambda tests
which copy files to `'{{ outpur_dir }}'` before zipping are now being
unzipped by Lambda with incorrect permissions, causing test failures.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/lambda
tests/integration/targets/lambda_policy

##### ADDITIONAL INFORMATION
Without `mode: preserve` the file is copied to `'{{ outpur_dir }}'` as 0600 permissions, resulting in:
```
$ zipinfo mini_lambda.zip 
Archive:  mini_lambda.zip
Zip file size: 906 bytes, number of entries: 1
-rw-------  3.0 unx     1382 tx defN 20-Jul-28 15:47 mini_lambda.py
```
AWS accepts the upload (via both the module and console) but can not display the file (in the web console) or execute it.

We need to have:
```
$ zipinfo mini_lambda.zip
Archive:  mini_lambda.zip
Zip file size: 906 bytes, number of entries: 1
-rw-r--r--  3.0 unx     1382 tx defN 20-Jul-28 15:47 mini_lambda.py
1 file, 1382 bytes uncompressed, 728 bytes compressed:  47.3%
```