### PR TITLE
Follow up on #167 - (permission preservation when copying lambdas)

### DIFF
--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -55,21 +55,21 @@
   - name: move lambda into place for archive module
     copy:
       src: mini_lambda.py
-      dest: '{{output_dir}}/mini_lambda.py'
+      dest: '{{ output_dir }}/mini_lambda.py'
       mode: preserve
   - name: bundle lambda into a zip
     register: zip_res
     archive:
       format: zip
-      path: '{{output_dir}}/mini_lambda.py'
-      dest: '{{output_dir}}/mini_lambda.zip'
+      path: '{{ output_dir }}/mini_lambda.py'
+      dest: '{{ output_dir }}/mini_lambda.zip'
   - name: test state=present - upload the lambda
     lambda:
-      name: '{{lambda_function_name}}'
+      name: '{{ lambda_function_name }}'
       runtime: python2.7
       handler: mini_lambda.handler
       role: ansible_lambda_role
-      zip_file: '{{zip_res.dest}}'
+      zip_file: '{{ zip_res.dest }}'
     register: result
   - name: assert lambda upload succeeded
     assert:

--- a/tests/integration/targets/lambda_policy/aliases
+++ b/tests/integration/targets/lambda_policy/aliases
@@ -1,4 +1,2 @@
 cloud/aws
 shippable/aws/group1
-# https://github.com/ansible-collections/community.aws/issues/155
-unstable

--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -58,14 +58,14 @@
   - name: move lambda into place for archive module
     copy:
       src: mini_http_lambda.py
-      dest: '{{output_dir}}/mini_http_lambda.py'
+      dest: '{{ output_dir }}/mini_http_lambda.py'
       mode: preserve
   - name: bundle lambda into a zip
     register: zip_res
     archive:
       format: zip
-      path: '{{output_dir}}/mini_http_lambda.py'
-      dest: '{{output_dir}}/mini_http_lambda.zip'
+      path: '{{ output_dir }}/mini_http_lambda.py'
+      dest: '{{ output_dir }}/mini_http_lambda.zip'
   - name: create minimal lambda role
     iam_role:
       aws_region: '{{ aws_region }}'

--- a/tests/integration/targets/s3_bucket_notification/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket_notification/tasks/main.yml
@@ -14,13 +14,14 @@
   - name: move lambda into place for archive module
     copy:
       src: mini_lambda.py
-      dest: '{{output_dir}}/mini_lambda.py'
+      dest: '{{ output_dir }}/mini_lambda.py'
+      mode: preserve
   - name: bundle lambda into a zip
     register: function_res
     archive:
       format: zip
-      path: '{{output_dir}}/mini_lambda.py'
-      dest: '{{output_dir}}/mini_lambda.zip'
+      path: '{{ output_dir }}/mini_lambda.py'
+      dest: '{{ output_dir }}/mini_lambda.zip'
   - name: register bucket
     s3_bucket:
       aws_access_key: '{{ aws_access_key }}'


### PR DESCRIPTION
##### SUMMARY

lambda_policy should now be stable
apply same change to s3_bucket_notification

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lambda
lambda_policy
s3_bucket_notification

##### ADDITIONAL INFORMATION

fixes #155 