### PR TITLE
ec2_vpc_peer: Remove duplicate 'profile' parameter, it's automatically added by ec2_argument_spec

### DIFF
--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -401,7 +401,6 @@ def main():
             peering_id=dict(),
             peer_owner_id=dict(),
             tags=dict(required=False, type='dict'),
-            profile=dict(),
             state=dict(default='present', choices=['present', 'absent', 'accept', 'reject'])
         )
     )


### PR DESCRIPTION
##### SUMMARY

After adding an extra alias (over in amazon.aws) we're triggering a sanity test failure because:

plugins/modules/ec2_vpc_peer.py:0:0: nonexistent-parameter-documented: Argument 'aws_profile' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

e2c_vpc_peer

##### ADDITIONAL INFORMATION

https://app.shippable.com/github/ansible-collections/community.aws/runs/511/2/tests