### PR TITLE
Bulk migration to AnsibleAWSModule

### DIFF
--- a/changelogs/fragments/173-ansibleawsmodule.yaml
+++ b/changelogs/fragments/173-ansibleawsmodule.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Remaining community.aws AnsibleModule based modules migrated to AnsibleAWSModule.

--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -174,8 +174,7 @@ import json
 try:
     import botocore
 except ImportError:
-    # HAS_BOTOCORE taken care of in AnsibleAWSModule
-    pass
+    pass  # Handled by AnsibleAWSModule
 
 import traceback
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -179,7 +179,8 @@ except ImportError:
 
 import traceback
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AWSRetry, camel_dict_to_snake_dict)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def main():

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -101,9 +101,8 @@ import traceback
 
 try:
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -352,9 +351,6 @@ def main():
                    ('state', 'absent', ['direct_connect_gateway_id'])]
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_if=required_if)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module')
 
     state = module.params.get('state')
 

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -108,6 +108,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -104,7 +104,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -106,12 +106,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     )
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 
 
 def dx_gateway_info(client, gateway_id, module):

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -110,7 +110,6 @@ from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 
@@ -341,13 +340,14 @@ def ensure_absent(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(state=dict(default='present', choices=['present', 'absent']),
-                              name=dict(),
-                              amazon_asn=dict(),
-                              virtual_gateway_id=dict(),
-                              direct_connect_gateway_id=dict(),
-                              wait_timeout=dict(type='int', default=320)))
+    argument_spec = dict(
+        state=dict(default='present', choices=['present', 'absent']),
+        name=dict(),
+        amazon_asn=dict(),
+        virtual_gateway_id=dict(),
+        direct_connect_gateway_id=dict(),
+        wait_timeout=dict(type='int', default=320),
+    )
     required_if = [('state', 'present', ['name', 'amazon_asn']),
                    ('state', 'absent', ['direct_connect_gateway_id'])]
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -350,8 +350,8 @@ def main():
                               wait_timeout=dict(type='int', default=320)))
     required_if = [('state', 'present', ['name', 'amazon_asn']),
                    ('state', 'absent', ['direct_connect_gateway_id'])]
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_if=required_if)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=required_if)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required for this module')

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -423,9 +423,11 @@ def main():
         wait_timeout=dict(type='int', default=120),
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[('link_aggregation_group_id', 'name')],
-                           required_if=[('state', 'present', ('location', 'bandwidth'))])
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_one_of=[('link_aggregation_group_id', 'name')],
+        required_if=[('state', 'present', ('location', 'bandwidth'))],
+    )
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -161,21 +161,6 @@ region:
   returned: when I(state=present)
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    AWSRetry,
-    HAS_BOTO3,
-    boto3_conn,
-    camel_dict_to_snake_dict,
-    ec2_argument_spec,
-    get_aws_connection_info,
-)
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import (
-    DirectConnectError,
-    delete_connection,
-    delete_virtual_interface,
-    disassociate_connection_and_lag,
-)
 import traceback
 import time
 
@@ -184,6 +169,20 @@ try:
 except Exception:
     pass
     # handled by imported HAS_BOTO3
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import DirectConnectError
+from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import delete_connection
+from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import delete_virtual_interface
+from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import disassociate_connection_and_lag
 
 
 def lag_status(client, lag_id):

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -176,7 +176,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import DirectConnectError
@@ -407,8 +406,7 @@ def ensure_absent(client, lag_id, lag_name, force_delete, delete_with_disassocia
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(),
         link_aggregation_group_id=dict(),
@@ -421,7 +419,7 @@ def main():
         force_delete=dict(type='bool', default=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=120),
-    ))
+    )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -171,7 +171,7 @@ except Exception:
     # handled by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -167,13 +167,11 @@ import time
 try:
     import botocore
 except Exception:
-    pass
-    # handled by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -426,9 +424,6 @@ def main():
         required_one_of=[('link_aggregation_group_id', 'name')],
         required_if=[('state', 'present', ('location', 'bandwidth'))],
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     if not region:

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -169,7 +169,6 @@ try:
 except Exception:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -412,8 +412,8 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True)
     if module._name == 'aws_kms_facts':
         module.deprecate("The 'aws_kms_facts' module has been renamed to 'aws_kms_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -223,7 +223,7 @@ except ImportError:
     pass  # caught by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -220,7 +220,7 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
@@ -228,7 +228,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 # Caching lookup for aliases
@@ -412,9 +411,6 @@ def main():
                               supports_check_mode=True)
     if module._name == 'aws_kms_facts':
         module.deprecate("The 'aws_kms_facts' module has been renamed to 'aws_kms_info'", date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 and botocore are required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -222,7 +222,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -225,7 +225,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -404,12 +403,9 @@ def get_kms_info(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(type='dict'),
-            pending_deletion=dict(type='bool', default=False)
-        )
+    argument_spec = dict(
+        filters=dict(type='dict'),
+        pending_deletion=dict(type='bool', default=False),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -215,17 +215,22 @@ keys:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict, HAS_BOTO3
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-
 import traceback
 
 try:
     import botocore
 except ImportError:
     pass  # caught by imported HAS_BOTO3
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 # Caching lookup for aliases
 _aliases = dict()

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -54,14 +54,13 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
@@ -97,12 +96,8 @@ def main():
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
                          "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
 
-    # Verify Boto3 is used
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
-
     # Set up connection
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=HAS_BOTO3)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(module, conn_type='client', resource='s3', region=region, endpoint=ec2_url,
                             **aws_connect_params)
 

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -59,6 +59,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -61,7 +61,6 @@ from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -92,7 +91,7 @@ def main():
     result = {}
 
     # Including ec2 argument spec
-    module = AnsibleAWSModule(argument_spec=ec2_argument_spec(), supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec={}, supports_check_mode=True)
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -56,7 +56,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -92,7 +92,7 @@ def main():
     result = {}
 
     # Including ec2 argument spec
-    module = AnsibleModule(argument_spec=ec2_argument_spec(), supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=ec2_argument_spec(), supports_check_mode=True)
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -58,12 +58,12 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     ec2_argument_spec,
-                                                                     HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_bucket_list(module, connection):

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -268,14 +268,13 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # will be caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
@@ -609,9 +608,6 @@ def main():
     if is_old_facts:
         module.deprecate("The 'cloudfront_facts' module has been renamed to 'cloudfront_info', "
                          "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     service_mgr = CloudFrontServiceManager(module)
 

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -272,6 +272,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -262,9 +262,6 @@ result:
     type: dict
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn, HAS_BOTO3
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
-from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import traceback
 
@@ -272,6 +269,15 @@ try:
     import botocore
 except ImportError:
     pass  # will be caught by imported HAS_BOTO3
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class CloudFrontServiceManager:

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -274,7 +274,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
@@ -584,8 +583,7 @@ def set_facts_for_distribution_id_and_alias(details, facts, distribution_id, ali
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         distribution_id=dict(required=False, type='str'),
         invalidation_id=dict(required=False, type='str'),
         origin_access_identity_id=dict(required=False, type='str'),
@@ -603,8 +601,8 @@ def main():
         list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
         list_invalidations=dict(required=False, default=False, type='bool'),
         list_streaming_distributions=dict(required=False, default=False, type='bool'),
-        summary=dict(required=False, default=False, type='bool')
-    ))
+        summary=dict(required=False, default=False, type='bool'),
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
     is_old_facts = module._name == 'cloudfront_facts'

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -606,7 +606,7 @@ def main():
         summary=dict(required=False, default=False, type='bool')
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
     is_old_facts = module._name == 'cloudfront_facts'
     if is_old_facts:
         module.deprecate("The 'cloudfront_facts' module has been renamed to 'cloudfront_info', "

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -270,8 +270,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -129,19 +129,20 @@ log_groups:
 '''
 
 import traceback
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     boto3_conn,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
 
 try:
     import botocore
 except ImportError:
     pass  # will be detected by imported HAS_BOTO3
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def create_log_group(client, log_group_name, kms_key_id, tags, retention, module):

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -252,7 +252,7 @@ def main():
     ))
 
     mutually_exclusive = [['retention', 'purge_retention_policy'], ['purge_retention_policy', 'overwrite']]
-    module = AnsibleModule(argument_spec=argument_spec, mutually_exclusive=mutually_exclusive)
+    module = AnsibleAWSModule(argument_spec=argument_spec, mutually_exclusive=mutually_exclusive)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -136,7 +136,6 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -138,6 +138,7 @@ except ImportError:
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -142,7 +142,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -239,8 +238,7 @@ def describe_log_group(client, log_group_name, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         log_group_name=dict(required=True, type='str'),
         state=dict(choices=['present', 'absent'],
                    default='present'),
@@ -248,8 +246,8 @@ def main():
         tags=dict(required=False, type='dict'),
         retention=dict(required=False, type='int'),
         purge_retention_policy=dict(required=False, type='bool', default=False),
-        overwrite=dict(required=False, type='bool', default=False)
-    ))
+        overwrite=dict(required=False, type='bool', default=False),
+    )
 
     mutually_exclusive = [['retention', 'purge_retention_policy'], ['purge_retention_policy', 'overwrite']]
     module = AnsibleAWSModule(argument_spec=argument_spec, mutually_exclusive=mutually_exclusive)

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -133,13 +133,12 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -251,9 +250,6 @@ def main():
 
     mutually_exclusive = [['retention', 'purge_retention_policy'], ['purge_retention_policy', 'overwrite']]
     module = AnsibleAWSModule(argument_spec=argument_spec, mutually_exclusive=mutually_exclusive)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     logs = boto3_conn(module, conn_type='client', resource='logs', region=region, endpoint=ec2_url, **aws_connect_kwargs)

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -79,7 +79,6 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -72,19 +72,20 @@ log_groups:
 '''
 
 import traceback
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     boto3_conn,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
 
 try:
     import botocore
 except ImportError:
     pass  # will be detected by imported HAS_BOTO3
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def describe_log_group(client, log_group_name, module):

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -76,13 +76,12 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -113,9 +112,6 @@ def main():
     if module._name == 'cloudwatchlogs_log_group_facts':
         module.deprecate("The 'cloudwatchlogs_log_group_facts' module has been renamed to 'cloudwatchlogs_log_group_info'",
                          date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     logs = boto3_conn(module, conn_type='client', resource='logs', region=region, endpoint=ec2_url, **aws_connect_kwargs)

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -111,7 +111,7 @@ def main():
         log_group_name=dict(),
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'cloudwatchlogs_log_group_facts':
         module.deprecate("The 'cloudwatchlogs_log_group_facts' module has been renamed to 'cloudwatchlogs_log_group_info'",
                          date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -85,7 +85,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -106,10 +105,9 @@ def describe_log_group(client, log_group_name, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         log_group_name=dict(),
-    ))
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'cloudwatchlogs_log_group_facts':

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -81,6 +81,7 @@ except ImportError:
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -213,7 +213,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -606,20 +605,17 @@ def create_pipeline(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True),
-            version=dict(removed_at_date='2022-06-01', removed_from_collection='community.aws'),
-            description=dict(required=False, default=''),
-            objects=dict(required=False, type='list', default=[], elements='dict'),
-            parameters=dict(required=False, type='list', default=[], elements='dict'),
-            timeout=dict(required=False, type='int', default=300),
-            state=dict(default='present', choices=['present', 'absent',
-                                                   'active', 'inactive']),
-            tags=dict(required=False, type='dict', default={}),
-            values=dict(required=False, type='list', default=[], elements='dict')
-        )
+    argument_spec = dict(
+        name=dict(required=True),
+        version=dict(removed_at_date='2022-06-01', removed_from_collection='community.aws'),
+        description=dict(required=False, default=''),
+        objects=dict(required=False, type='list', default=[], elements='dict'),
+        parameters=dict(required=False, type='list', default=[], elements='dict'),
+        timeout=dict(required=False, type='int', default=300),
+        state=dict(default='present', choices=['present', 'absent',
+                                               'active', 'inactive']),
+        tags=dict(required=False, type='dict', default={}),
+        values=dict(required=False, type='list', default=[], elements='dict'),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
 

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -212,6 +212,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -210,8 +210,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, camel_dict_to_snake_dict
 from ansible.module_utils._text import to_text
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 DP_ACTIVE_STATES = ['ACTIVE', 'SCHEDULED']

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -205,9 +205,8 @@ import traceback
 try:
     import boto3
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
@@ -618,9 +617,6 @@ def main():
         values=dict(required=False, type='list', default=[], elements='dict'),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for the datapipeline module!')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -621,7 +621,7 @@ def main():
             values=dict(required=False, type='list', default=[], elements='dict')
         )
     )
-    module = AnsibleModule(argument_spec, supports_check_mode=False)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required for the datapipeline module!')

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -208,7 +208,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -200,6 +200,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -183,20 +183,15 @@ try:
     from boto.dynamodb2.types import STRING, NUMBER, BINARY
     from boto.exception import BotoServerError, NoAuthHandlerFound, JSONResponseError
     from boto.dynamodb2.exceptions import ValidationException
-    HAS_BOTO = True
     DYNAMO_TYPE_MAP = {
         'STRING': STRING,
         'NUMBER': NUMBER,
         'BINARY': BINARY
     }
-except ImportError:
-    HAS_BOTO = False
-
-try:
+    # Boto 2 is mandatory, Boto3 is only needed for tagging
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by ec2.HAS_BOTO and ec2.HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -206,6 +201,8 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 DYNAMO_TYPE_DEFAULT = 'STRING'

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -476,9 +476,11 @@ def main():
         wait_for_active_timeout=dict(default=60, type='int'),
     ))
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        supports_check_mode=True)
+        supports_check_mode=True,
+        check_boto3=False,
+    )
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -205,7 +205,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -461,8 +460,7 @@ def get_indexes(all_indexes):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(required=True, type='str'),
         hash_key_name=dict(type='str'),
@@ -474,7 +472,7 @@ def main():
         indexes=dict(default=[], type='list', elements='dict'),
         tags=dict(type='dict'),
         wait_for_active_timeout=dict(default=60, type='int'),
-    ))
+    )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -193,8 +193,6 @@ try:
 except ImportError:
     pass  # Handled by ec2.HAS_BOTO and ec2.HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -184,13 +184,11 @@ try:
     from boto.exception import BotoServerError, NoAuthHandlerFound, JSONResponseError
     from boto.dynamodb2.exceptions import ValidationException
     HAS_BOTO = True
-
     DYNAMO_TYPE_MAP = {
         'STRING': STRING,
         'NUMBER': NUMBER,
         'BINARY': BINARY
     }
-
 except ImportError:
     HAS_BOTO = False
 
@@ -201,8 +199,13 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list, boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 DYNAMO_TYPE_DEFAULT = 'STRING'

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -75,6 +75,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -74,12 +74,12 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_current_ttl_state(c, table_name):

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -71,12 +71,11 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -132,9 +131,7 @@ def main():
         argument_spec=argument_spec,
     )
 
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
-    elif distutils.version.StrictVersion(botocore.__version__) < distutils.version.StrictVersion('1.5.24'):
+    if distutils.version.StrictVersion(botocore.__version__) < distutils.version.StrictVersion('1.5.24'):
         # TTL was added in this version.
         module.fail_json(msg='Found botocore in version {0}, but >= {1} is required for TTL support'.format(botocore.__version__, '1.5.24'))
 

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -73,8 +73,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -130,7 +130,7 @@ def main():
         table_name=dict(required=True),
         attribute_name=dict(required=True))
     )
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
     )
 

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -79,7 +79,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -124,11 +123,10 @@ def set_ttl_state(c, table_name, state, attribute_name):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(choices=['enable', 'disable']),
         table_name=dict(required=True),
-        attribute_name=dict(required=True))
+        attribute_name=dict(required=True),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -134,7 +134,8 @@ image_id:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible.module_utils._text import to_native
 
 try:
@@ -147,7 +148,7 @@ def copy_image(module, ec2):
     """
     Copies an AMI
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     ec2: ec2 connection object
     """
 

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -538,7 +538,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
 try:
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 ASG_ATTRIBUTES = ('AvailabilityZones', 'DefaultCooldown', 'DesiredCapacity',
                   'HealthCheckGracePeriod', 'HealthCheckType', 'LaunchConfigurationName',

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -122,12 +122,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     AWSRetry,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class Ec2CustomerGatewayManager:

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -111,15 +111,9 @@ gateway.customer_gateways:
 
 try:
     from botocore.exceptions import ClientError
-    HAS_BOTOCORE = True
-except ImportError:
-    HAS_BOTOCORE = False
-
-try:
     import boto3
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -214,12 +208,6 @@ def main():
             ('routing', 'dynamic', ['bgp_asn'])
         ]
     )
-
-    if not HAS_BOTOCORE:
-        module.fail_json(msg='botocore is required.')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     gw_mgr = Ec2CustomerGatewayManager(module)
 

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -115,8 +115,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -127,7 +127,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -200,15 +199,12 @@ class Ec2CustomerGatewayManager:
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            bgp_asn=dict(required=False, type='int'),
-            ip_address=dict(required=True),
-            name=dict(required=True),
-            routing=dict(default='dynamic', choices=['dynamic', 'static']),
-            state=dict(default='present', choices=['present', 'absent']),
-        )
+    argument_spec = dict(
+        bgp_asn=dict(required=False, type='int'),
+        ip_address=dict(required=True),
+        name=dict(required=True),
+        routing=dict(default='dynamic', choices=['dynamic', 'static']),
+        state=dict(default='present', choices=['present', 'absent']),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -123,6 +123,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -211,12 +211,13 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True,
-                           required_if=[
-                               ('routing', 'dynamic', ['bgp_asn'])
-                           ]
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ('routing', 'dynamic', ['bgp_asn'])
+        ]
+    )
 
     if not HAS_BOTOCORE:
         module.fail_json(msg='botocore is required.')

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -222,8 +222,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 
 
 def associate_ip_and_device(ec2, module, address, private_ip_address, device_id, allow_reassociation, check_mode, is_instance=True):
@@ -499,7 +501,7 @@ def allocate_address_from_pool(ec2, module, domain, check_mode, public_ipv4_pool
 
 
 def generate_tag_dict(module, tag_name, tag_value):
-    # type: (AnsibleModule, str, str) -> Optional[Dict]
+    # type: (AnsibleAWSModule, str, str) -> Optional[Dict]
     """ Generates a dictionary to be passed as a filter to Amazon """
     if tag_name and not tag_value:
         if tag_name.startswith('tag:'):

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -91,6 +91,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -326,9 +326,10 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        supports_check_mode=True
+        supports_check_mode=True,
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -95,7 +95,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -315,15 +314,13 @@ class ElbManager:
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state={'required': True, 'choices': ['present', 'absent']},
         instance_id={'required': True},
         ec2_elbs={'default': None, 'required': False, 'type': 'list', 'elements': 'str'},
         enable_availability_zone={'default': True, 'required': False, 'type': 'bool'},
         wait={'required': False, 'default': True, 'type': 'bool'},
-        wait_timeout={'required': False, 'default': 0, 'type': 'int'}
-    )
+        wait_timeout={'required': False, 'default': 0, 'type': 'int'},
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -88,8 +88,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -90,12 +90,12 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError,
-                                                                     HAS_BOTO,
-                                                                     connect_to_aws,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class ElbManager:

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -85,9 +85,8 @@ try:
     import boto.ec2.autoscale
     import boto.ec2.elb
     from boto.regioninfo import RegionInfo
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -221,10 +221,8 @@ class ElbInformation(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         names={'default': [], 'type': 'list', 'elements': 'str'}
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -78,9 +78,8 @@ try:
     import boto.ec2.elb
     from boto.ec2.tag import Tag
     from boto.exception import BotoServerError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by ec2.HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -88,6 +87,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 class ElbInformation(object):

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -74,14 +74,6 @@ EXAMPLES = r'''
 
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    AWSRetry,
-    connect_to_aws,
-    ec2_argument_spec,
-    get_aws_connection_info,
-)
-
 try:
     import boto.ec2.elb
     from boto.ec2.tag import Tag
@@ -89,6 +81,13 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class ElbInformation(object):

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -226,8 +226,8 @@ def main():
         names={'default': [], 'type': 'list', 'elements': 'str'}
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True)
     if module._name == 'ec2_elb_facts':
         module.deprecate("The 'ec2_elb_facts' module has been renamed to 'ec2_elb_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -81,8 +81,6 @@ try:
 except ImportError:
     pass  # Handled by ec2.HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -547,12 +547,13 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[
-                               ['instance_ids', 'filters']
-                           ],
-                           supports_check_mode=True
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['instance_ids', 'filters']
+        ],
+        supports_check_mode=True,
+    )
     if module._name == 'ec2_instance_facts':
         module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -507,7 +507,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -539,12 +538,9 @@ def list_ec2_instances(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            instance_ids=dict(default=[], type='list', elements='str'),
-            filters=dict(default={}, type='dict')
-        )
+    argument_spec = dict(
+        instance_ids=dict(default=[], type='list', elements='str'),
+        filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -502,6 +502,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -496,9 +496,8 @@ import traceback
 try:
     import boto3
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -552,9 +551,6 @@ def main():
     )
     if module._name == 'ec2_instance_facts':
         module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -501,13 +501,13 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
-                                                                     boto3_conn,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_ec2_instances(connection, module):

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -499,8 +499,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -680,9 +680,9 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        mutually_exclusive=[['user_data', 'user_data_path']]
+        mutually_exclusive=[['user_data', 'user_data_path']],
     )
 
     if not HAS_BOTO3:

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -458,6 +458,7 @@ except ImportError:
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -449,22 +449,23 @@ security_groups:
 
 
 import traceback
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (get_aws_connection_info,
-                                                                     ec2_argument_spec,
-                                                                     ec2_connect,
-                                                                     camel_dict_to_snake_dict,
-                                                                     get_ec2_security_group_ids_from_names,
-                                                                     boto3_conn,
-                                                                     snake_dict_to_camel_dict,
-                                                                     HAS_BOTO3,
-                                                                     )
-from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import AnsibleModule
 
 try:
     import botocore
 except ImportError:
     pass
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def create_block_device_meta(module, volume):

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -453,7 +453,7 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
@@ -465,7 +465,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_t
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def create_block_device_meta(module, volume):
@@ -680,9 +679,6 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[['user_data', 'user_data_path']],
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -456,7 +456,6 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -460,7 +460,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
@@ -652,32 +651,29 @@ def delete_launch_config(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True),
-            image_id=dict(),
-            instance_id=dict(),
-            key_name=dict(),
-            security_groups=dict(default=[], type='list', elements='str'),
-            user_data=dict(),
-            user_data_path=dict(type='path'),
-            kernel_id=dict(),
-            volumes=dict(type='list', elements='dict'),
-            instance_type=dict(),
-            state=dict(default='present', choices=['present', 'absent']),
-            spot_price=dict(type='float'),
-            ramdisk_id=dict(),
-            instance_profile_name=dict(),
-            ebs_optimized=dict(default=False, type='bool'),
-            associate_public_ip_address=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
-            instance_monitoring=dict(default=False, type='bool'),
-            assign_public_ip=dict(type='bool'),
-            classic_link_vpc_security_groups=dict(type='list', elements='str'),
-            classic_link_vpc_id=dict(),
-            vpc_id=dict(),
-            placement_tenancy=dict(choices=['default', 'dedicated'])
-        )
+    argument_spec = dict(
+        name=dict(required=True),
+        image_id=dict(),
+        instance_id=dict(),
+        key_name=dict(),
+        security_groups=dict(default=[], type='list', elements='str'),
+        user_data=dict(),
+        user_data_path=dict(type='path'),
+        kernel_id=dict(),
+        volumes=dict(type='list', elements='dict'),
+        instance_type=dict(),
+        state=dict(default='present', choices=['present', 'absent']),
+        spot_price=dict(type='float'),
+        ramdisk_id=dict(),
+        instance_profile_name=dict(),
+        ebs_optimized=dict(default=False, type='bool'),
+        associate_public_ip_address=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
+        instance_monitoring=dict(default=False, type='bool'),
+        assign_public_ip=dict(type='bool'),
+        classic_link_vpc_security_groups=dict(type='list', elements='str'),
+        classic_link_vpc_id=dict(),
+        vpc_id=dict(),
+        placement_tenancy=dict(choices=['default', 'dedicated'])
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_lc_find.py
+++ b/plugins/modules/ec2_lc_find.py
@@ -139,6 +139,7 @@ import re
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_lc_find.py
+++ b/plugins/modules/ec2_lc_find.py
@@ -141,7 +141,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -195,12 +194,10 @@ def find_launch_configs(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name_regex=dict(required=True),
         sort_order=dict(required=False, default='ascending', choices=['ascending', 'descending']),
         limit=dict(required=False, type='int'),
-    )
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_lc_find.py
+++ b/plugins/modules/ec2_lc_find.py
@@ -137,8 +137,6 @@ associate_public_address:
 '''
 import re
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_lc_find.py
+++ b/plugins/modules/ec2_lc_find.py
@@ -203,7 +203,7 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
     )
 

--- a/plugins/modules/ec2_lc_find.py
+++ b/plugins/modules/ec2_lc_find.py
@@ -138,7 +138,10 @@ associate_public_address:
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def find_launch_configs(client, module):

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -160,6 +160,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -157,8 +157,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -154,14 +154,12 @@ user_data:
 try:
     import boto3
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -216,9 +214,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_lc_facts':
         module.deprecate("The 'ec2_lc_facts' module has been renamed to 'ec2_lc_info'", date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -159,12 +159,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_launch_configs(connection, module):

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -217,7 +217,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_lc_facts':
         module.deprecate("The 'ec2_lc_facts' module has been renamed to 'ec2_lc_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -164,7 +164,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -204,17 +203,14 @@ def list_launch_configs(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=False, default=[], type='list', elements='str'),
-            sort=dict(required=False, default=None,
-                      choices=['launch_configuration_name', 'image_id', 'created_time', 'instance_type', 'kernel_id', 'ramdisk_id', 'key_name']),
-            sort_order=dict(required=False, default='ascending',
-                            choices=['ascending', 'descending']),
-            sort_start=dict(required=False, type='int'),
-            sort_end=dict(required=False, type='int'),
-        )
+    argument_spec = dict(
+        name=dict(required=False, default=[], type='list', elements='str'),
+        sort=dict(required=False, default=None,
+                  choices=['launch_configuration_name', 'image_id', 'created_time', 'instance_type', 'kernel_id', 'ramdisk_id', 'key_name']),
+        sort_order=dict(required=False, default='ascending',
+                        choices=['ascending', 'descending']),
+        sort_start=dict(required=False, type='int'),
+        sort_end=dict(required=False, type='int'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -80,7 +80,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -157,17 +156,14 @@ def delete_scaling_policy(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True, type='str'),
-            adjustment_type=dict(type='str', choices=['ChangeInCapacity', 'ExactCapacity', 'PercentChangeInCapacity']),
-            asg_name=dict(required=True, type='str'),
-            scaling_adjustment=dict(type='int'),
-            min_adjustment_step=dict(type='int'),
-            cooldown=dict(type='int'),
-            state=dict(default='present', choices=['present', 'absent']),
-        )
+    argument_spec = dict(
+        name=dict(required=True, type='str'),
+        adjustment_type=dict(type='str', choices=['ChangeInCapacity', 'ExactCapacity', 'PercentChangeInCapacity']),
+        asg_name=dict(required=True, type='str'),
+        scaling_adjustment=dict(type='int'),
+        min_adjustment_step=dict(type='int'),
+        cooldown=dict(type='int'),
+        state=dict(default='present', choices=['present', 'absent']),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -74,8 +74,6 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -76,6 +76,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -75,12 +75,12 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError,
-                                                                     HAS_BOTO,
-                                                                     connect_to_aws,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def create_scaling_policy(connection, module):

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -170,7 +170,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -117,7 +117,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -132,7 +132,7 @@ def copy_snapshot(module, ec2):
     """
     Copies an EC2 Snapshot to another region
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     ec2: ec2 connection object
     """
 
@@ -185,7 +185,7 @@ def main():
         wait_timeout=dict(type='int', default=600),
         tags=dict(type='dict')))
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='botocore and boto3 are required.')

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -123,7 +123,6 @@ from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
@@ -174,8 +173,7 @@ def copy_snapshot(module, ec2):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         source_region=dict(required=True),
         source_snapshot_id=dict(required=True),
         description=dict(default=''),
@@ -183,7 +181,8 @@ def main():
         kms_key_id=dict(type='str', required=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=600),
-        tags=dict(type='dict')))
+        tags=dict(type='dict'),
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -110,9 +110,6 @@ snapshot_id:
 '''
 
 import traceback
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info, camel_dict_to_snake_dict)
-from ansible.module_utils._text import to_native
 
 try:
     import boto3
@@ -120,6 +117,14 @@ try:
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def copy_snapshot(module, ec2):

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -114,9 +114,8 @@ import traceback
 try:
     import boto3
     from botocore.exceptions import ClientError, WaiterError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -185,9 +184,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore and boto3 are required.')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     client = boto3_conn(module, conn_type='client', resource='ec2',

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -121,6 +121,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_vpc_egress_igw.py
+++ b/plugins/modules/ec2_vpc_egress_igw.py
@@ -71,7 +71,7 @@ def delete_eigw(module, conn, eigw_id):
     """
     Delete EIGW.
 
-    module     : AnsibleModule object
+    module     : AnsibleAWSModule object
     conn       : boto3 client connection object
     eigw_id    : ID of the EIGW to delete
     """
@@ -99,7 +99,7 @@ def create_eigw(module, conn, vpc_id):
     """
     Create EIGW.
 
-    module       : AnsibleModule object
+    module       : AnsibleAWSModule object
     conn         : boto3 client connection object
     vpc_id       : ID of the VPC we are operating on
     """
@@ -139,7 +139,7 @@ def describe_eigws(module, conn, vpc_id):
     """
     Describe EIGWs.
 
-    module     : AnsibleModule object
+    module     : AnsibleAWSModule object
     conn       : boto3 client connection object
     vpc_id     : ID of the VPC we are operating on
     """

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -186,13 +186,13 @@ except ImportError:
     pass  # will be picked up by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     ec2_argument_spec,
-                                                                     HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     )
 from ansible.module_utils.six import string_types
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def date_handler(obj):

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -188,6 +188,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -191,7 +191,6 @@ from ansible.module_utils.six import string_types
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
@@ -336,20 +335,17 @@ def setup_removal(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            vpc_id=dict(),
-            service=dict(),
-            policy=dict(type='json'),
-            policy_file=dict(type='path', aliases=['policy_path']),
-            state=dict(default='present', choices=['present', 'absent']),
-            wait=dict(type='bool', default=False),
-            wait_timeout=dict(type='int', default=320, required=False),
-            route_table_ids=dict(type='list', elements='str'),
-            vpc_endpoint_id=dict(),
-            client_token=dict(),
-        )
+    argument_spec = dict(
+        vpc_id=dict(),
+        service=dict(),
+        policy=dict(type='json'),
+        policy_file=dict(type='path', aliases=['policy_path']),
+        state=dict(default='present', choices=['present', 'absent']),
+        wait=dict(type='bool', default=False),
+        wait_timeout=dict(type='int', default=320, required=False),
+        route_table_ids=dict(type='list', elements='str'),
+        vpc_endpoint_id=dict(),
+        client_token=dict(),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -183,7 +183,7 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # will be picked up by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
@@ -191,7 +191,6 @@ from ansible.module_utils.six import string_types
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -358,9 +357,6 @@ def main():
     )
 
     # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore and boto3 are required for this module')
-
     state = module.params.get('state')
 
     try:

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -351,14 +351,14 @@ def main():
             client_token=dict(),
         )
     )
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[['policy', 'policy_file']],
         required_if=[
             ['state', 'present', ['vpc_id', 'service']],
             ['state', 'absent', ['vpc_endpoint_id']],
-        ]
+        ],
     )
 
     # Validate Requirements

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -185,7 +185,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -115,6 +115,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -113,8 +113,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -114,14 +114,14 @@ except ImportError:
     pass  # will be picked up from imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     boto3_conn,
-                                                                     get_aws_connection_info,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     AWSRetry,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
 def date_handler(obj):

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -111,7 +111,7 @@ import json
 try:
     import botocore
 except ImportError:
-    pass  # will be picked up from imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -119,7 +119,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
@@ -175,9 +174,6 @@ def main():
         module.deprecate("The 'ec2_vpc_endpoint_facts' module has been renamed to 'ec2_vpc_endpoint_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore and boto3 are required.')
-
     try:
         region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
         if region:

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -174,7 +174,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_endpoint_facts':
         module.deprecate("The 'ec2_vpc_endpoint_facts' module has been renamed to 'ec2_vpc_endpoint_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -116,7 +116,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
@@ -165,13 +164,10 @@ def get_endpoints(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            query=dict(choices=['services', 'endpoints'], required=True),
-            filters=dict(default={}, type='dict'),
-            vpc_endpoint_ids=dict(type='list', elements='str'),
-        )
+    argument_spec = dict(
+        query=dict(choices=['services', 'endpoints'], required=True),
+        filters=dict(default={}, type='dict'),
+        vpc_endpoint_ids=dict(type='list', elements='str'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -96,7 +96,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -129,12 +128,9 @@ def list_internet_gateways(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(type='dict', default=dict()),
-            internet_gateway_ids=dict(type='list', default=None, elements='str')
-        )
+    argument_spec = dict(
+        filters=dict(type='dict', default=dict()),
+        internet_gateway_ids=dict(type='list', default=None, elements='str'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -93,8 +93,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -95,6 +95,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -91,7 +91,7 @@ changed:
 try:
     import botocore
 except ImportError:
-    pass  # will be captured by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -100,7 +100,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def get_internet_gateway_info(internet_gateway):
@@ -138,9 +137,6 @@ def main():
         module.deprecate("The 'ec2_vpc_igw_facts' module has been renamed to 'ec2_vpc_igw_info'", date='2021-12-01', collection_name='community.aws')
 
     # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore and boto3 are required.')
-
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
         connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_kwargs)

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -94,13 +94,13 @@ except ImportError:
     pass  # will be captured by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     HAS_BOTO3,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def get_internet_gateway_info(internet_gateway):

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -137,7 +137,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_igw_facts':
         module.deprecate("The 'ec2_vpc_igw_facts' module has been renamed to 'ec2_vpc_igw_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -207,7 +207,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -934,20 +933,17 @@ def remove(client, nat_gateway_id, wait=False, wait_timeout=0,
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            subnet_id=dict(type='str'),
-            eip_address=dict(type='str'),
-            allocation_id=dict(type='str'),
-            if_exist_do_not_create=dict(type='bool', default=False),
-            state=dict(default='present', choices=['present', 'absent']),
-            wait=dict(type='bool', default=False),
-            wait_timeout=dict(type='int', default=320, required=False),
-            release_eip=dict(type='bool', default=False),
-            nat_gateway_id=dict(type='str'),
-            client_token=dict(type='str'),
-        )
+    argument_spec = dict(
+        subnet_id=dict(type='str'),
+        eip_address=dict(type='str'),
+        allocation_id=dict(type='str'),
+        if_exist_do_not_create=dict(type='bool', default=False),
+        state=dict(default='present', choices=['present', 'absent']),
+        wait=dict(type='bool', default=False),
+        wait_timeout=dict(type='int', default=320, required=False),
+        release_eip=dict(type='bool', default=False),
+        nat_gateway_id=dict(type='str'),
+        client_token=dict(type='str'),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -949,14 +949,14 @@ def main():
             client_token=dict(type='str'),
         )
     )
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[
             ['allocation_id', 'eip_address']
         ],
         required_if=[['state', 'absent', ['nat_gateway_id']],
-                     ['state', 'present', ['subnet_id']]]
+                     ['state', 'present', ['subnet_id']]],
     )
 
     # Validate Requirements

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -202,7 +202,7 @@ import time
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -210,7 +210,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 DRY_RUN_GATEWAYS = [
@@ -954,10 +953,6 @@ def main():
         required_if=[['state', 'absent', ['nat_gateway_id']],
                      ['state', 'present', ['subnet_id']]],
     )
-
-    # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore/boto3 is required.')
 
     state = module.params.get('state').lower()
     check_mode = module.check_mode

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -205,12 +205,12 @@ except ImportError:
     pass  # caught by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     HAS_BOTO3,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 DRY_RUN_GATEWAYS = [

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -206,6 +206,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -204,8 +204,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -84,14 +84,14 @@ except ImportError:
     pass  # will be detected by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     HAS_BOTO3,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def date_handler(obj):

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -85,6 +85,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -83,8 +83,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -132,8 +132,8 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True,)
     if module._name == 'ec2_vpc_nat_gateway_facts':
         module.deprecate("The 'ec2_vpc_nat_gateway_facts' module has been renamed to 'ec2_vpc_nat_gateway_info'",
                          date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -81,7 +81,7 @@ import json
 try:
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -91,7 +91,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def date_handler(obj):
@@ -133,10 +132,6 @@ def main():
     if module._name == 'ec2_vpc_nat_gateway_facts':
         module.deprecate("The 'ec2_vpc_nat_gateway_facts' module has been renamed to 'ec2_vpc_nat_gateway_info'",
                          date='2021-12-01', collection_name='community.aws')
-
-    # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore/boto3 is required.')
 
     try:
         region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -86,7 +86,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -124,12 +123,9 @@ def get_nat_gateways(client, module, nat_gateway_id=None):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default={}, type='dict'),
-            nat_gateway_ids=dict(default=[], type='list', elements='str'),
-        )
+    argument_spec = dict(
+        filters=dict(default={}, type='dict'),
+        nat_gateway_ids=dict(default=[], type='list', elements='str'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -219,7 +219,7 @@ task:
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 import distutils.version
 import traceback
@@ -229,7 +229,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
@@ -413,8 +412,6 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if)
 
-    if not HAS_BOTO3:
-        module.fail_json(msg='json, botocore and boto3 are required.')
     state = module.params.get('state')
     peering_id = module.params.get('peering_id')
     vpc_id = module.params.get('vpc_id')

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -415,7 +415,7 @@ def main():
         ('state', 'reject', ['peering_id'])
     ]
 
-    module = AnsibleModule(argument_spec=argument_spec, required_if=required_if)
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if)
 
     if not HAS_BOTO3:
         module.fail_json(msg='json, botocore and boto3 are required.')

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -225,7 +225,10 @@ import distutils.version
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -225,6 +225,8 @@ import distutils.version
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -224,8 +224,6 @@ except ImportError:
 import distutils.version
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -228,7 +228,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
@@ -397,17 +396,14 @@ def find_pcx_by_id(pcx_id, client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            vpc_id=dict(),
-            peer_vpc_id=dict(),
-            peer_region=dict(),
-            peering_id=dict(),
-            peer_owner_id=dict(),
-            tags=dict(required=False, type='dict'),
-            state=dict(default='present', choices=['present', 'absent', 'accept', 'reject'])
-        )
+    argument_spec = dict(
+        vpc_id=dict(),
+        peer_vpc_id=dict(),
+        peer_region=dict(),
+        peering_id=dict(),
+        peer_owner_id=dict(),
+        tags=dict(required=False, type='dict'),
+        state=dict(default='present', choices=['present', 'absent', 'accept', 'reject']),
     )
     required_if = [
         ('state', 'present', ['vpc_id', 'peer_vpc_id']),

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -78,7 +78,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
@@ -104,12 +103,9 @@ def get_vpc_peers(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default=dict(), type='dict'),
-            peer_connection_ids=dict(default=None, type='list', elements='str'),
-        )
+    argument_spec = dict(
+        filters=dict(default=dict(), type='dict'),
+        peer_connection_ids=dict(default=None, type='list', elements='str'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -72,7 +72,7 @@ import json
 try:
     import botocore
 except ImportError:
-    pass  # will be picked up by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -81,7 +81,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_li
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -112,10 +111,6 @@ def main():
                               supports_check_mode=True,)
     if module._name == 'ec2_vpc_peering_facts':
         module.deprecate("The 'ec2_vpc_peering_facts' module has been renamed to 'ec2_vpc_peering_info'", date='2021-12-01', collection_name='community.aws')
-
-    # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='botocore and boto3 are required.')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -75,14 +75,14 @@ except ImportError:
     pass  # will be picked up by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_tag_list_to_ansible_dict,
-                                                                     ec2_argument_spec,
-                                                                     boto3_conn,
-                                                                     get_aws_connection_info,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def date_handler(obj):

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -112,8 +112,8 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True,)
     if module._name == 'ec2_vpc_peering_facts':
         module.deprecate("The 'ec2_vpc_peering_facts' module has been renamed to 'ec2_vpc_peering_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -74,8 +74,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -76,6 +76,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -110,8 +110,8 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True)
     if module._name == 'ec2_vpc_route_table_facts':
         module.deprecate("The 'ec2_vpc_route_table_facts' module has been renamed to 'ec2_vpc_route_table_info'",
                          date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -59,6 +59,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -56,8 +56,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -58,7 +58,11 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_route_table_info(route_table):

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -53,9 +53,8 @@ EXAMPLES = '''
 try:
     import boto.vpc
     from boto.exception import BotoServerError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -63,6 +62,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 def get_route_table_info(route_table):

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -62,7 +62,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -103,11 +102,8 @@ def list_ec2_vpc_route_tables(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default=None, type='dict')
-        )
+    argument_spec = dict(
+        filters=dict(default=None, type='dict'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -128,7 +128,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
@@ -545,8 +544,7 @@ def ensure_vgw_absent(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(),
         vpn_gateway_id=dict(),
@@ -555,7 +553,6 @@ def main():
         wait_timeout=dict(type='int', default=320),
         type=dict(default='ipsec.1', choices=['ipsec.1']),
         tags=dict(default=None, required=False, type='dict', aliases=['resource_tags']),
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_if=[['state', 'present', ['name']]])

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -120,7 +120,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -121,11 +121,16 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3, boto3_conn, ec2_argument_spec, get_aws_connection_info, AWSRetry
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 
 
 def get_vgw_info(vgws):

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -557,8 +557,8 @@ def main():
         tags=dict(default=None, required=False, type='dict', aliases=['resource_tags']),
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_if=[['state', 'present', ['name']]])
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[['state', 'present', ['name']]])
 
     if not HAS_BOTO3:
         module.fail_json(msg='json and boto3 is required.')

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -117,16 +117,14 @@ import traceback
 try:
     import botocore
     import boto3
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
@@ -556,9 +554,6 @@ def main():
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_if=[['state', 'present', ['name']]])
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='json and boto3 is required.')
 
     state = module.params.get('state').lower()
 

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -124,6 +124,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -98,6 +98,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -97,13 +97,13 @@ except ImportError:
     pass  # will be captured by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     HAS_BOTO3,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def get_virtual_gateway_info(virtual_gateway):

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -99,7 +99,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -135,12 +134,9 @@ def list_virtual_gateways(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(type='dict', default=dict()),
-            vpn_gateway_ids=dict(type='list', default=None, elements='str')
-        )
+    argument_spec = dict(
+        filters=dict(type='dict', default=dict()),
+        vpn_gateway_ids=dict(type='list', default=None, elements='str')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -94,7 +94,7 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # will be captured by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -103,7 +103,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def get_virtual_gateway_info(virtual_gateway):
@@ -142,10 +141,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_vgw_facts':
         module.deprecate("The 'ec2_vpc_vgw_facts' module has been renamed to 'ec2_vpc_vgw_info'", date='2021-12-01', collection_name='community.aws')
-
-    # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='json and boto3 is required.')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -96,8 +96,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -143,7 +143,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_vgw_facts':
         module.deprecate("The 'ec2_vpc_vgw_facts' module has been renamed to 'ec2_vpc_vgw_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_win_password.py
+++ b/plugins/modules/ec2_win_password.py
@@ -111,9 +111,12 @@ try:
 except ImportError:
     HAS_CRYPTOGRAPHY = False
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
 from ansible.module_utils._text import to_bytes
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 
 
 def setup_module_object():

--- a/plugins/modules/ec2_win_password.py
+++ b/plugins/modules/ec2_win_password.py
@@ -116,19 +116,16 @@ from ansible.module_utils._text import to_bytes
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 
 
 def setup_module_object():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         instance_id=dict(required=True),
         key_file=dict(required=False, default=None, type='path'),
         key_passphrase=dict(no_log=True, default=None, required=False),
         key_data=dict(no_log=True, default=None, required=False),
         wait=dict(type='bool', default=False, required=False),
         wait_timeout=dict(default=120, required=False, type='int'),
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
     return module

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -116,8 +116,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -268,8 +268,11 @@ def main():
 
     required_together = [['cluster', 'ec2_instance_id', 'attributes']]
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True,
-                           required_together=required_together)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_together=required_together,
+    )
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -118,6 +118,8 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -121,7 +121,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -258,13 +257,12 @@ class Ec2EcsInstance(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=False, default='present', choices=['present', 'absent']),
         cluster=dict(required=True, type='str'),
         ec2_instance_id=dict(required=True, type='str'),
         attributes=dict(required=True, type='list', elements='dict'),
-    ))
+    )
 
     required_together = [['cluster', 'ec2_instance_id', 'attributes']]
 

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -118,7 +118,9 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class EcsAttributes(object):

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -113,9 +113,8 @@ attributes:
 try:
     import boto3
     from botocore.exceptions import ClientError, EndpointConnectionError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -271,9 +270,6 @@ def main():
         supports_check_mode=True,
         required_together=required_together,
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     cluster = module.params['cluster']
     ec2_instance_id = module.params['ec2_instance_id']

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -115,7 +115,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -161,13 +160,12 @@ class EcsClusterManager:
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent', 'has_instances']),
         name=dict(required=True, type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10)
-    ))
+    )
     required_together = [['state', 'name']]
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -110,8 +110,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -170,7 +170,11 @@ def main():
     ))
     required_together = [['state', 'name']]
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_together=required_together)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_together=required_together,
+    )
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -107,9 +107,8 @@ import time
 
 try:
     import boto3
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -173,9 +172,6 @@ def main():
         supports_check_mode=True,
         required_together=required_together,
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     cluster_mgr = EcsClusterManager(module)
     try:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -112,6 +112,8 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -112,7 +112,9 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class EcsClusterManager:

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -128,19 +128,20 @@ EXAMPLES = r"""
 """
 from time import sleep
 from traceback import format_exc
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     boto3_conn,
-                                                                     HAS_BOTO3,
-                                                                     camel_dict_to_snake_dict,
-                                                                     )
 
 try:
     import boto3
     import botocore
 except ImportError:
     pass  # will be detected by imported HAS_BOTO3
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class ElastiCacheManager(object):

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -138,7 +138,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
@@ -487,8 +486,7 @@ class ElastiCacheManager(object):
 
 def main():
     """ elasticache ansible module """
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent', 'rebooted']),
         name=dict(required=True),
         engine=dict(default='memcached'),
@@ -503,8 +501,8 @@ def main():
         security_group_ids=dict(default=[], type='list', elements='str'),
         zone=dict(),
         wait=dict(default=True, type='bool'),
-        hard_modify=dict(type='bool')
-    ))
+        hard_modify=dict(type='bool'),
+    )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -135,8 +135,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -137,6 +137,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -506,7 +506,7 @@ def main():
         hard_modify=dict(type='bool')
     ))
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
     )
 

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -133,14 +133,13 @@ try:
     import boto3
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -507,9 +506,6 @@ def main():
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -119,6 +119,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 
 # import module snippets
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -110,9 +110,8 @@ import traceback
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
@@ -288,9 +287,6 @@ def main():
         values=dict(type='dict'),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto required for this module')
 
     parameter_group_family = module.params.get('group_family')
     parameter_group_name = module.params.get('name')

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -291,7 +291,7 @@ def main():
             values=dict(type='dict'),
         )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -122,7 +122,6 @@ from ansible.module_utils.six import string_types
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -281,15 +280,12 @@ def get_info(conn, name):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            group_family=dict(type='str', choices=['memcached1.4', 'memcached1.5', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0', 'redis5.0']),
-            name=dict(required=True, type='str'),
-            description=dict(default='', type='str'),
-            state=dict(required=True, choices=['present', 'absent', 'reset']),
-            values=dict(type='dict'),
-        )
+    argument_spec = dict(
+        group_family=dict(type='str', choices=['memcached1.4', 'memcached1.5', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0', 'redis5.0']),
+        name=dict(required=True, type='str'),
+        description=dict(default='', type='str'),
+        state=dict(required=True, choices=['present', 'absent', 'reset']),
+        values=dict(type='dict'),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -105,11 +105,6 @@ changed:
     changed: true
 """
 
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
-from ansible.module_utils._text import to_text
-from ansible.module_utils.six import string_types
 import traceback
 
 try:
@@ -118,6 +113,16 @@ try:
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six import string_types
+
+# import module snippets
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def create(module, conn, name, group_family, description):

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -113,7 +113,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -121,7 +121,11 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def create(module, connection, replication_id, cluster_id, name):

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -122,6 +122,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -116,9 +116,8 @@ import traceback
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -184,9 +183,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto required for this module')
 
     name = module.params.get('name')
     state = module.params.get('state')

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -187,7 +187,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -119,8 +119,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -125,7 +125,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -175,16 +174,13 @@ def delete(module, connection, name):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True, type='str'),
-            state=dict(required=True, type='str', choices=['present', 'absent', 'copy']),
-            replication_id=dict(type='str'),
-            cluster_id=dict(type='str'),
-            target=dict(type='str'),
-            bucket=dict(type='str'),
-        )
+    argument_spec = dict(
+        name=dict(required=True, type='str'),
+        state=dict(required=True, type='str', choices=['present', 'absent', 'copy']),
+        replication_id=dict(type='str'),
+        cluster_id=dict(type='str'),
+        target=dict(type='str'),
+        bucket=dict(type='str'),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -69,18 +69,15 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(required=True),
         description=dict(required=False),
         subnets=dict(required=False, type='list', elements='str'),
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -64,8 +64,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -67,6 +67,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -82,7 +82,7 @@ def main():
         subnets=dict(required=False, type='list', elements='str'),
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -66,7 +66,10 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def main():

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -61,9 +61,8 @@ try:
     import boto
     from boto.elasticache import connect_to_region
     from boto.exception import BotoServerError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -177,7 +177,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -264,12 +263,9 @@ def list_load_balancers(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            load_balancer_arns=dict(type='list', elements='str'),
-            names=dict(type='list', elements='str')
-        )
+    argument_spec = dict(
+        load_balancer_arns=dict(type='list', elements='str'),
+        names=dict(type='list', elements='str')
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -272,10 +272,11 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[['load_balancer_arns', 'names']],
-                           supports_check_mode=True
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[['load_balancer_arns', 'names']],
+        supports_check_mode=True,
+    )
     if module._name == 'elb_application_lb_facts':
         module.deprecate("The 'elb_application_lb_facts' module has been renamed to 'elb_application_lb_info'",
                          date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -173,6 +173,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -170,8 +170,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -172,12 +172,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_elb_listeners(connection, module, elb_arn):

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -167,9 +167,8 @@ import traceback
 try:
     import boto3
     from botocore.exceptions import ClientError, NoCredentialsError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -276,9 +275,6 @@ def main():
     if module._name == 'elb_application_lb_facts':
         module.deprecate("The 'elb_application_lb_facts' module has been renamed to 'elb_application_lb_info'",
                          date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -1255,9 +1255,10 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        mutually_exclusive=[['security_group_ids', 'security_group_names']]
+        mutually_exclusive=[['security_group_ids', 'security_group_names']],
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -375,7 +375,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -372,9 +372,8 @@ try:
     import boto.vpc
     from boto.ec2.elb.healthcheck import HealthCheck
     from boto.ec2.tag import Tag
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
@@ -384,6 +383,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 def _throttleable_operation(max_retries):

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -381,7 +381,6 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -1228,8 +1227,7 @@ class ElbManager(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state={'required': True, 'choices': ['present', 'absent']},
         name={'required': True},
         listeners={'default': None, 'required': False, 'type': 'list', 'elements': 'dict'},
@@ -1251,8 +1249,7 @@ def main():
         access_logs={'default': None, 'required': False, 'type': 'dict'},
         wait={'default': False, 'type': 'bool', 'required': False},
         wait_timeout={'default': 60, 'type': 'int', 'required': False},
-        tags={'default': None, 'required': False, 'type': 'dict'}
-    )
+        tags={'default': None, 'required': False, 'type': 'dict'},
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -377,9 +377,13 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError, get_aws_connection_info
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def _throttleable_operation(max_retries):

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -380,6 +380,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -91,9 +91,8 @@ try:
     import boto.ec2.autoscale
     import boto.ec2.elb
     from boto.regioninfo import RegionInfo
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -94,8 +94,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -101,7 +101,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -317,15 +316,13 @@ class ElbManager:
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state={'required': True, 'choices': ['present', 'absent']},
         instance_id={'required': True},
         ec2_elbs={'default': None, 'required': False, 'type': 'list', 'elements': 'str'},
         enable_availability_zone={'default': True, 'required': False, 'type': 'bool'},
         wait={'required': False, 'default': True, 'type': 'bool'},
-        wait_timeout={'required': False, 'default': 0, 'type': 'int'}
-    )
+        wait_timeout={'required': False, 'default': 0, 'type': 'int'},
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -96,12 +96,12 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError,
-                                                                     HAS_BOTO,
-                                                                     connect_to_aws,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class ElbManager:

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -328,9 +328,10 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        supports_check_mode=True
+        supports_check_mode=True,
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -97,6 +97,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -110,14 +110,6 @@ RETURN = '''
 
 import traceback
 from time import time, sleep
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     AWSRetry,
-                                                                     )
 
 try:
     import boto3
@@ -125,6 +117,15 @@ try:
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
 @AWSRetry.jittered_backoff(retries=10, delay=10, catch_extra_error_codes=['TargetGroupNotFound'])

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -121,6 +121,7 @@ except ImportError:
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -114,9 +114,8 @@ from time import time, sleep
 try:
     import boto3
     from botocore.exceptions import ClientError, BotoCoreError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
@@ -335,9 +334,6 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[['target_group_arn', 'target_group_name']],
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(module, conn_type='client', resource='elbv2', region=region, endpoint=ec2_url, **aws_connect_params)

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -124,7 +124,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
@@ -320,19 +319,16 @@ def target_status_check(connection, module, target_group_arn, target, target_sta
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            deregister_unused=dict(type='bool', default=False),
-            target_az=dict(type='str'),
-            target_group_arn=dict(type='str'),
-            target_group_name=dict(type='str'),
-            target_id=dict(type='str', required=True),
-            target_port=dict(type='int'),
-            target_status=dict(choices=['initial', 'healthy', 'unhealthy', 'unused', 'draining', 'unavailable'], type='str'),
-            target_status_timeout=dict(type='int', default=60),
-            state=dict(required=True, choices=['present', 'absent'], type='str'),
-        )
+    argument_spec = dict(
+        deregister_unused=dict(type='bool', default=False),
+        target_az=dict(type='str'),
+        target_group_arn=dict(type='str'),
+        target_group_name=dict(type='str'),
+        target_id=dict(type='str', required=True),
+        target_port=dict(type='int'),
+        target_status=dict(choices=['initial', 'healthy', 'unhealthy', 'unused', 'draining', 'unavailable'], type='str'),
+        target_status_timeout=dict(type='int', default=60),
+        state=dict(required=True, choices=['present', 'absent'], type='str'),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -118,7 +118,6 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -335,9 +335,10 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[['target_group_arn', 'target_group_name']]
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[['target_group_arn', 'target_group_name']],
+    )
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -212,9 +212,8 @@ import traceback
 try:
     import boto3
     from botocore.exceptions import ClientError, NoCredentialsError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -311,9 +310,6 @@ def main():
     )
     if module._name == 'elb_target_group_facts':
         module.deprecate("The 'elb_target_group_facts' module has been renamed to 'elb_target_group_info'", date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -217,12 +217,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_target_group_attributes(connection, module, target_group_arn):

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -308,10 +308,11 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[['load_balancer_arn', 'target_group_arns', 'names']],
-                           supports_check_mode=True
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[['load_balancer_arn', 'target_group_arns', 'names']],
+        supports_check_mode=True,
+    )
     if module._name == 'elb_target_group_facts':
         module.deprecate("The 'elb_target_group_facts' module has been renamed to 'elb_target_group_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -222,7 +222,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -298,14 +297,11 @@ def list_target_groups(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            load_balancer_arn=dict(type='str'),
-            target_group_arns=dict(type='list', elements='str'),
-            names=dict(type='list', elements='str'),
-            collect_targets_health=dict(default=False, type='bool', required=False)
-        )
+    argument_spec = dict(
+        load_balancer_arn=dict(type='str'),
+        target_group_arns=dict(type='list', elements='str'),
+        names=dict(type='list', elements='str'),
+        collect_targets_health=dict(default=False, type='bool', required=False),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -215,8 +215,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -218,6 +218,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -138,8 +138,11 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def main():

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -136,7 +136,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -157,7 +157,7 @@ def main():
         version_qualifier=dict(),
         payload=dict(default={}, type='dict'),
     ))
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -140,6 +140,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -133,9 +133,8 @@ import traceback
 
 try:
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -163,9 +162,6 @@ def main():
         ]
     )
 
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
-
     name = module.params.get('name')
     function_arn = module.params.get('function_arn')
     await_return = module.params.get('wait')
@@ -174,13 +170,10 @@ def main():
     version_qualifier = module.params.get('version_qualifier')
     payload = module.params.get('payload')
 
-    if not HAS_BOTO3:
-        module.fail_json(msg='Python module "boto3" is missing, please install it')
-
     if not (name or function_arn):
         module.fail_json(msg="Must provide either a function_arn or a name to invoke.")
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=HAS_BOTO3)
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     if not region:
         module.fail_json(msg="The AWS region must be specified as an "
                          "environment variable or in the AWS credentials "

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -142,13 +142,11 @@ from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(),
         function_arn=dict(),
         wait=dict(default=True, type='bool'),
@@ -156,7 +154,7 @@ def main():
         dry_run=dict(default=False, type='bool'),
         version_qualifier=dict(),
         payload=dict(default={}, type='dict'),
-    ))
+    )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -185,12 +185,11 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO,
-                                                                     boto_exception,
-                                                                     connect_to_aws,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def _paginate(func, attr):

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -184,8 +184,6 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -641,9 +641,10 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         mutually_exclusive=[['trust_policy', 'trust_policy_filepath']],
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -190,7 +190,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -620,8 +619,7 @@ def delete_role(module, iam, name, role_list, prof_list):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         iam_type=dict(required=True, choices=['user', 'group', 'role']),
         groups=dict(type='list', default=None, required=False, elements='str'),
         state=dict(required=True, choices=['present', 'absent', 'update']),
@@ -637,8 +635,7 @@ def main():
         trust_policy=dict(type='dict', default=None, required=False),
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
-        new_path=dict(default=None, required=False)
-    )
+        new_path=dict(default=None, required=False),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -185,6 +185,8 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -116,8 +116,6 @@ EXAMPLES = '''
     state: present
 
 '''
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, connect_to_aws
 import os
 
 try:
@@ -127,6 +125,12 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 
 
 def cert_meta(iam, name):

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -258,7 +258,7 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['new_path', 'key'],
@@ -268,6 +268,7 @@ def main():
             ['new_name', 'cert'],
             ['new_name', 'cert_chain'],
         ],
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -122,15 +122,15 @@ try:
     import boto
     import boto.iam
     import boto.ec2
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 def cert_meta(iam, name):

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -125,8 +125,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -129,7 +129,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 
@@ -244,8 +243,7 @@ def load_data(cert, key, cert_chain):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(required=True),
         cert=dict(),
@@ -254,8 +252,7 @@ def main():
         new_name=dict(),
         path=dict(default='/'),
         new_path=dict(),
-        dup_ok=dict(type='bool')
-    )
+        dup_ok=dict(type='bool'),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -128,6 +128,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -293,11 +293,11 @@ def main():
         only_version=dict(type='bool', default=False),
         fail_on_delete=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         state=dict(default='present', choices=['present', 'absent']),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        required_if=[['state', 'present', ['policy']]]
+        required_if=[['state', 'present', ['policy']]],
     )
 
     if not HAS_BOTO3:

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -127,6 +127,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -122,7 +122,7 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -132,7 +132,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 
 
@@ -297,9 +296,6 @@ def main():
         argument_spec=argument_spec,
         required_if=[['state', 'present', ['policy']]],
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module')
 
     name = module.params.get('policy_name')
     description = module.params.get('policy_description')

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -125,15 +125,15 @@ except ImportError:
     pass  # caught by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     get_aws_connection_info,
-                                                                     ec2_argument_spec,
-                                                                     AWSRetry,
-                                                                     camel_dict_to_snake_dict,
-                                                                     HAS_BOTO3,
-                                                                     compare_policies,
-                                                                     )
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -130,7 +130,6 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
@@ -284,8 +283,7 @@ def detach_all_entities(module, iam, policy, **kwargs):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         policy_name=dict(required=True),
         policy_description=dict(default=''),
         policy=dict(type='json'),

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -124,7 +124,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -68,12 +68,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_mfa_devices(connection, module):

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -63,14 +63,12 @@ EXAMPLES = r'''
 try:
     import boto3
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -99,9 +97,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'iam_mfa_device_facts':
         module.deprecate("The 'iam_mfa_device_facts' module has been renamed to 'iam_mfa_device_info'", date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     if region:

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -69,6 +69,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -100,7 +100,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'iam_mfa_device_facts':
         module.deprecate("The 'iam_mfa_device_facts' module has been renamed to 'iam_mfa_device_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -66,8 +66,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -73,7 +73,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -93,11 +92,8 @@ def list_mfa_devices(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            user_name=dict(required=False, default=None)
-        )
+    argument_spec = dict(
+        user_name=dict(required=False, default=None),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -87,7 +87,10 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_server_certs(iam, name=None):

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -150,7 +150,7 @@ def main():
         name=dict(type='str'),
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec,)
+    module = AnsibleAWSModule(argument_spec=argument_spec,)
     if module._name == 'iam_server_certificate_facts':
         module.deprecate("The 'iam_server_certificate_facts' module has been renamed to 'iam_server_certificate_info'",
                          date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -85,8 +85,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -88,6 +88,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -82,9 +82,8 @@ upload_date:
 try:
     import boto3
     import botocore.exceptions
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -152,9 +151,6 @@ def main():
     if module._name == 'iam_server_certificate_facts':
         module.deprecate("The 'iam_server_certificate_facts' module has been renamed to 'iam_server_certificate_info'",
                          date='2021-12-01', collection_name='community.aws')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -90,7 +90,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -145,10 +144,9 @@ def get_server_certs(iam, name=None):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(type='str'),
-    ))
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,)
     if module._name == 'iam_server_certificate_facts':

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -190,8 +190,12 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3, boto3_conn, ec2_argument_spec, get_aws_connection_info
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def convert_to_lower(data):

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -195,7 +195,6 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -1330,20 +1329,17 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True),
-            shards=dict(default=None, required=False, type='int'),
-            retention_period=dict(default=None, required=False, type='int'),
-            tags=dict(default=None, required=False, type='dict', aliases=['resource_tags']),
-            wait=dict(default=True, required=False, type='bool'),
-            wait_timeout=dict(default=300, required=False, type='int'),
-            state=dict(default='present', choices=['present', 'absent']),
-            encryption_type=dict(required=False, choices=['NONE', 'KMS']),
-            key_id=dict(required=False, type='str'),
-            encryption_state=dict(required=False, choices=['enabled', 'disabled']),
-        )
+    argument_spec = dict(
+        name=dict(required=True),
+        shards=dict(default=None, required=False, type='int'),
+        retention_period=dict(default=None, required=False, type='int'),
+        tags=dict(default=None, required=False, type='dict', aliases=['resource_tags']),
+        wait=dict(default=True, required=False, type='bool'),
+        wait_timeout=dict(default=300, required=False, type='int'),
+        state=dict(default='present', choices=['present', 'absent']),
+        encryption_type=dict(required=False, choices=['NONE', 'KMS']),
+        key_id=dict(required=False, type='str'),
+        encryption_state=dict(required=False, choices=['enabled', 'disabled']),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -1345,7 +1345,7 @@ def main():
             encryption_state=dict(required=False, choices=['enabled', 'disabled']),
         )
     )
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -189,7 +189,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -192,6 +192,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -187,13 +187,12 @@ from functools import reduce
 try:
     import botocore.exceptions
 except ImportError:
-    pass  # Taken care of by ec2.HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
@@ -1363,9 +1362,6 @@ def main():
     if retention_period:
         if retention_period < 24:
             module.fail_json(msg='Retention period can not be less than 24 hours.')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     check_mode = module.check_mode
     try:

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -146,14 +146,12 @@ import re
 try:
     import boto3
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -368,10 +366,6 @@ def main():
         mutually_exclusive=[],
         required_together=[],
     )
-
-    # validate dependencies
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module.')
 
     aws = AWSConnection(module, ['lambda'])
 

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -151,12 +151,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 class AWSConnection:

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -152,6 +152,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -149,8 +149,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -366,11 +366,11 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[],
-        required_together=[]
+        required_together=[],
     )
 
     # validate dependencies

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -156,7 +156,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -355,15 +354,12 @@ def main():
 
     :return dict: ansible facts
     """
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state=dict(required=False, default='present', choices=['present', 'absent']),
-            function_name=dict(required=True),
-            name=dict(required=True, aliases=['alias_name']),
-            function_version=dict(type='int', required=False, default=0, aliases=['version']),
-            description=dict(required=False, default=None),
-        )
+    argument_spec = dict(
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        function_name=dict(required=True),
+        name=dict(required=True, aliases=['alias_name']),
+        function_version=dict(type='int', required=False, default=0, aliases=['version']),
+        description=dict(required=False, default=None),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -125,12 +125,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 # ---------------------------------------------------------------------------------------------------

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -123,8 +123,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -417,11 +417,11 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[['alias', 'version']],
-        required_together=[]
+        required_together=[],
     )
 
     # validate dependencies

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -126,6 +126,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -130,7 +130,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -405,16 +404,13 @@ def main():
     """Produce a list of function suffixes which handle lambda events."""
     source_choices = ["stream", "sqs"]
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state=dict(required=False, default='present', choices=['present', 'absent']),
-            lambda_function_arn=dict(required=True, aliases=['function_name', 'function_arn']),
-            event_source=dict(required=False, default="stream", choices=source_choices),
-            source_params=dict(type='dict', required=True),
-            alias=dict(required=False, default=None),
-            version=dict(type='int', required=False, default=0),
-        )
+    argument_spec = dict(
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        lambda_function_arn=dict(required=True, aliases=['function_name', 'function_arn']),
+        event_source=dict(required=False, default="stream", choices=source_choices),
+        source_params=dict(type='dict', required=True),
+        alias=dict(required=False, default=None),
+        version=dict(type='int', required=False, default=0),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -120,14 +120,12 @@ import sys
 try:
     import boto3
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -419,10 +417,6 @@ def main():
         mutually_exclusive=[['alias', 'version']],
         required_together=[],
     )
-
-    # validate dependencies
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module.')
 
     aws = AWSConnection(module, ['lambda'])
 

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -538,7 +538,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -1316,8 +1315,7 @@ def validate_parameters(required_vars, valid_vars, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         command=dict(choices=['create', 'replicate', 'delete', 'facts', 'modify', 'promote', 'snapshot', 'reboot', 'restore'], required=True),
         instance_name=dict(required=False),
         source_instance=dict(required=False),
@@ -1351,8 +1349,7 @@ def main():
         tags=dict(type='dict', required=False),
         publicly_accessible=dict(required=False),
         character_set_name=dict(required=False),
-        force_failover=dict(type='bool', required=False, default=False)
-    )
+        force_failover=dict(type='bool', required=False, default=False),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -534,6 +534,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -1355,8 +1355,9 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -533,8 +533,12 @@ except ImportError:
     HAS_RDS2 = False
 
 from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 DEFAULT_PORTS = {

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -532,8 +532,6 @@ try:
 except ImportError:
     HAS_RDS2 = False
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -126,7 +126,6 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -316,18 +315,15 @@ def ensure_absent(module, connection):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state=dict(required=True, choices=['present', 'absent']),
-            name=dict(required=True),
-            engine=dict(),
-            description=dict(),
-            params=dict(aliases=['parameters'], type='dict'),
-            immediate=dict(type='bool', aliases=['apply_immediately']),
-            tags=dict(type='dict', default={}),
-            purge_tags=dict(type='bool', default=False)
-        )
+    argument_spec = dict(
+        state=dict(required=True, choices=['present', 'absent']),
+        name=dict(required=True),
+        engine=dict(),
+        description=dict(),
+        params=dict(aliases=['parameters'], type='dict'),
+        immediate=dict(type='bool', aliases=['apply_immediately']),
+        tags=dict(type='dict', default={}),
+        purge_tags=dict(type='bool', default=False),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -118,7 +118,7 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
@@ -129,7 +129,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
@@ -329,9 +328,6 @@ def main():
         argument_spec=argument_spec,
         required_if=[['state', 'present', ['description', 'engine']]],
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 and botocore are required for this module')
 
     # Retrieve any AWS settings from the environment.
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -113,20 +113,26 @@ tags:
     returned: when state is present
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, HAS_BOTO3, compare_aws_tags
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict
-from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
-from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_native
-
 import traceback
 
 try:
     import botocore
 except ImportError:
     pass  # caught by imported HAS_BOTO3
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 INT_MODIFIERS = {
     'K': 1024,

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -120,7 +120,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -329,8 +329,10 @@ def main():
             purge_tags=dict(type='bool', default=False)
         )
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_if=[['state', 'present', ['description', 'engine']]])
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[['state', 'present', ['description', 'engine']]],
+    )
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 and botocore are required for this module')

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -125,6 +125,7 @@ from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -134,7 +134,7 @@ def main():
         subnets=dict(required=False, type='list', elements='str'),
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -93,8 +93,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -96,6 +96,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -99,7 +99,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -126,13 +125,11 @@ def create_result(changed, subnet_group=None):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(required=True),
         description=dict(required=False),
         subnets=dict(required=False, type='list', elements='str'),
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -95,7 +95,11 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_subnet_group_info(subnet_group):

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -90,9 +90,8 @@ subnet_group:
 try:
     import boto.rds
     from boto.exception import BotoServerError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/redshift.py
+++ b/plugins/modules/redshift.py
@@ -258,8 +258,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, snake_dict_to_camel_dict
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 def _collect_facts(resource):
@@ -342,7 +344,7 @@ def create_cluster(module, redshift):
     """
     Create a new cluster
 
-    module: AnsibleModule object
+    module: AnsibleAWSModule object
     redshift: authenticated redshift connection object
 
     Returns:

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -84,9 +84,8 @@ group:
 try:
     import boto
     import boto.redshift
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -93,18 +93,16 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         group_name=dict(required=True, aliases=['name']),
         group_description=dict(required=False, aliases=['description']),
         group_subnets=dict(required=False, aliases=['subnets'], type='list', elements='str'),
-    ))
+    )
     module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 
     if not HAS_BOTO:

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -89,7 +89,10 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def main():

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -105,7 +105,7 @@ def main():
         group_description=dict(required=False, aliases=['description']),
         group_subnets=dict(required=False, aliases=['subnets'], type='list', elements='str'),
     ))
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto v2.9.0+ required for this module')

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -87,8 +87,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -89,6 +89,8 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -372,14 +372,14 @@ try:
     from boto.route53 import Route53Connection
     from boto.route53.record import Record, ResourceRecordSets
     from boto.route53.status import Status
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 MINIMUM_BOTO_VERSION = '2.28.0'

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -519,7 +519,7 @@ def main():
         wait_timeout=dict(type='int', default=300),
     ))
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=[['zone', 'hosted_zone_id']],
@@ -540,6 +540,7 @@ def main():
             region=('identifier',),
             weight=('identifier',),
         ),
+        check_boto3=False,
     )
 
     if not HAS_BOTO:

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -379,7 +379,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -494,8 +493,7 @@ def to_dict(rset, zone_in, zone_id):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(type='str', required=True, choices=['absent', 'create', 'delete', 'get', 'present'], aliases=['command']),
         zone=dict(type='str'),
         hosted_zone_id=dict(type='str'),
@@ -517,7 +515,7 @@ def main():
         vpc_id=dict(type='str'),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=300),
-    ))
+    )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -377,7 +377,8 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 MINIMUM_BOTO_VERSION = '2.28.0'

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -375,8 +375,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -377,6 +377,8 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -127,8 +127,6 @@ except ImportError:
     pass  # Handled by HAS_BOTO
 
 # import module snippets
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -123,15 +123,15 @@ try:
     from boto import route53
     from boto.route53 import Route53Connection, exception
     from boto.route53.healthcheck import HealthCheck
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 # Things that can't get changed:

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -131,7 +131,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -283,8 +282,7 @@ def update_health_check(conn, health_check_id, health_check_version, health_chec
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(choices=['present', 'absent'], default='present'),
         ip_address=dict(),
         port=dict(type='int'),
@@ -294,7 +292,6 @@ def main():
         string_match=dict(),
         request_interval=dict(type='int', choices=[10, 30], default=30),
         failure_threshold=dict(type='int', choices=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], default=3),
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -129,7 +129,9 @@ except ImportError:
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 # Things that can't get changed:

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -296,7 +296,7 @@ def main():
         failure_threshold=dict(type='int', choices=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], default=3),
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto 2.27.0+ required for this module')

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -130,6 +130,7 @@ except ImportError:
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -207,15 +207,9 @@ EXAMPLES = r'''
 try:
     import boto
     import botocore
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
-try:
     import boto3
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by HAS_BOTO and HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -223,6 +217,8 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def get_hosted_zone(client, module):

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -460,12 +460,13 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[
             ['hosted_zone_method', 'health_check_method'],
         ],
+        check_boto3=False,
     )
     if module._name == 'route53_facts':
         module.deprecate("The 'route53_facts' module has been renamed to 'route53_info'", date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -223,7 +223,6 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 
 
 def get_hosted_zone(client, module):
@@ -420,8 +419,7 @@ def hosted_zone_details(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         query=dict(choices=[
             'change',
             'checker_ip_range',
@@ -457,7 +455,6 @@ def main():
             'count',
             'tags',
         ], default='list'),
-    )
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -218,8 +218,11 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 
 
 def get_hosted_zone(client, module):

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -211,7 +211,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO and HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -220,6 +220,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec

--- a/plugins/modules/s3_logging.py
+++ b/plugins/modules/s3_logging.py
@@ -65,8 +65,6 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/s3_logging.py
+++ b/plugins/modules/s3_logging.py
@@ -144,7 +144,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/s3_logging.py
+++ b/plugins/modules/s3_logging.py
@@ -67,7 +67,10 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def compare_bucket_logging(bucket, target_bucket, target_prefix):

--- a/plugins/modules/s3_logging.py
+++ b/plugins/modules/s3_logging.py
@@ -70,7 +70,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -134,14 +133,11 @@ def disable_bucket_logging(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True),
-            target_bucket=dict(required=False, default=None),
-            target_prefix=dict(required=False, default=""),
-            state=dict(required=False, default='present', choices=['present', 'absent'])
-        )
+    argument_spec = dict(
+        name=dict(required=True),
+        target_bucket=dict(required=False, default=None),
+        target_prefix=dict(required=False, default=""),
+        state=dict(required=False, default='present', choices=['present', 'absent']),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/s3_logging.py
+++ b/plugins/modules/s3_logging.py
@@ -62,15 +62,15 @@ try:
     import boto.ec2
     from boto.s3.connection import OrdinaryCallingFormat, Location
     from boto.exception import S3ResponseError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Handled by HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 
 def compare_bucket_logging(bucket, target_bucket, target_prefix):

--- a/plugins/modules/s3_logging.py
+++ b/plugins/modules/s3_logging.py
@@ -68,6 +68,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -229,17 +229,6 @@ import os
 import stat as osstat  # os.stat constants
 import traceback
 
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     boto3_conn,
-                                                                     get_aws_connection_info,
-                                                                     HAS_BOTO3,
-                                                                     boto_exception,
-                                                                     )
-from ansible.module_utils._text import to_text
-
 try:
     from dateutil import tz
     HAS_DATEUTIL = True
@@ -251,6 +240,17 @@ try:
 except ImportError:
     # Handled by imported HAS_BOTO3
     pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+
+# import module snippets
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
 
 
 # the following function, calculate_multipart_etag, is from tlastowka

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -238,8 +238,7 @@ except ImportError:
 try:
     import botocore
 except ImportError:
-    # Handled by imported HAS_BOTO3
-    pass
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
@@ -249,7 +248,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
 
 
@@ -527,9 +525,6 @@ def main():
 
     if not HAS_DATEUTIL:
         module.fail_json(msg='dateutil required for this module')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     result = {}
     mode = module.params['mode']

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -245,6 +245,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 
 # import module snippets
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -247,7 +247,6 @@ from ansible.module_utils._text import to_text
 # import module snippets
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
@@ -505,8 +504,7 @@ def remove_files(s3, sourcelist, params):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         mode=dict(choices=['push'], default='push'),
         file_change_strategy=dict(choices=['force', 'date_size', 'checksum'], default='date_size'),
         bucket=dict(required=True),
@@ -521,7 +519,6 @@ def main():
         cache_control=dict(required=False, default=''),
         delete=dict(required=False, type='bool', default=False),
         # future options: encoding, metadata, storage_class, retries
-    )
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -524,7 +524,7 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
     )
 

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -240,7 +240,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 
 # import module snippets

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -164,14 +164,12 @@ import time
 try:
     import boto3
     from botocore.exceptions import ClientError, ParamValidationError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -309,9 +307,6 @@ def main():
             ['redirect_all_requests', 'error_key']
         ],
     )
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -306,7 +306,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['redirect_all_requests', 'suffix'],

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -170,6 +170,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -169,12 +169,12 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO3,
-                                                                     boto3_conn,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
-                                                                     get_aws_connection_info,
-                                                                     )
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def _create_redirect_dict(url):

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -167,8 +167,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -174,7 +174,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -295,15 +294,12 @@ def disable_bucket_as_website(client_connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(type='str', required=True),
-            state=dict(type='str', required=True, choices=['present', 'absent']),
-            suffix=dict(type='str', required=False, default='index.html'),
-            error_key=dict(type='str', required=False),
-            redirect_all_requests=dict(type='str', required=False)
-        )
+    argument_spec = dict(
+        name=dict(type='str', required=True),
+        state=dict(type='str', required=True, choices=['present', 'absent']),
+        suffix=dict(type='str', required=False, default='index.html'),
+        error_key=dict(type='str', required=False),
+        redirect_all_requests=dict(type='str', required=False),
     )
 
     module = AnsibleAWSModule(
@@ -311,7 +307,8 @@ def main():
         mutually_exclusive=[
             ['redirect_all_requests', 'suffix'],
             ['redirect_all_requests', 'error_key']
-        ])
+        ],
+    )
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -90,7 +90,6 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
@@ -132,13 +131,10 @@ def get_session_token(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            duration_seconds=dict(required=False, default=None, type='int'),
-            mfa_serial_number=dict(required=False, default=None),
-            mfa_token=dict(required=False, default=None)
-        )
+    argument_spec = dict(
+        duration_seconds=dict(required=False, default=None, type='int'),
+        mfa_serial_number=dict(required=False, default=None),
+        mfa_token=dict(required=False, default=None),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -85,8 +85,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -88,6 +88,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -141,7 +141,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 and botocore are required.')

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -82,9 +82,8 @@ EXAMPLES = '''
 try:
     import boto3
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -138,9 +137,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 and botocore are required.')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     if region:

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -87,7 +87,10 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def normalize_credentials(credentials):


### PR DESCRIPTION
##### SUMMARY

Migrate to AnsibleAWSModule en masse
- Use AnsibleAWSModule instead of AnsibleModule
- Remove extra ec2_argument_spec calls
- Let AnsibleAWSModule handle missing Boto 3 libraries
- Use ec2.HAS_BOTO and ec2.HAS_BOTO3 for Boto 2 based modules
- Reorder imports and split into single lines (for cleaner followup PRs when more imports can be removed)

**Note:** I recommend reviewing each commit separately

Does *not* modify Boto connection creation as this is more likely to trigger unit-test breakage / issues / changes in behaviour.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_api_gateway.py
plugins/modules/aws_direct_connect_gateway.py
plugins/modules/aws_direct_connect_link_aggregation_group.py
plugins/modules/aws_kms_info.py
plugins/modules/aws_s3_bucket_info.py
plugins/modules/cloudfront_info.py
plugins/modules/cloudwatchlogs_log_group.py
plugins/modules/cloudwatchlogs_log_group_info.py
plugins/modules/data_pipeline.py
plugins/modules/dynamodb_table.py
plugins/modules/dynamodb_ttl.py
plugins/modules/ec2_ami_copy.py
plugins/modules/ec2_asg.py
plugins/modules/ec2_customer_gateway.py
plugins/modules/ec2_eip.py
plugins/modules/ec2_elb.py
plugins/modules/ec2_elb_info.py
plugins/modules/ec2_instance_info.py
plugins/modules/ec2_lc.py
plugins/modules/ec2_lc_find.py
plugins/modules/ec2_lc_info.py
plugins/modules/ec2_scaling_policy.py
plugins/modules/ec2_snapshot_copy.py
plugins/modules/ec2_vpc_egress_igw.py
plugins/modules/ec2_vpc_endpoint.py
plugins/modules/ec2_vpc_endpoint_info.py
plugins/modules/ec2_vpc_igw_info.py
plugins/modules/ec2_vpc_nat_gateway.py
plugins/modules/ec2_vpc_nat_gateway_info.py
plugins/modules/ec2_vpc_peer.py
plugins/modules/ec2_vpc_peering_info.py
plugins/modules/ec2_vpc_route_table_info.py
plugins/modules/ec2_vpc_vgw.py
plugins/modules/ec2_vpc_vgw_info.py
plugins/modules/ec2_win_password.py
plugins/modules/ecs_attribute.py
plugins/modules/ecs_cluster.py
plugins/modules/elasticache.py
plugins/modules/elasticache_parameter_group.py
plugins/modules/elasticache_snapshot.py
plugins/modules/elasticache_subnet_group.py
plugins/modules/elb_application_lb_info.py
plugins/modules/elb_classic_lb.py
plugins/modules/elb_instance.py
plugins/modules/elb_target.py
plugins/modules/elb_target_group_info.py
plugins/modules/execute_lambda.py
plugins/modules/iam.py
plugins/modules/iam_cert.py
plugins/modules/iam_managed_policy.py
plugins/modules/iam_mfa_device_info.py
plugins/modules/iam_server_certificate_info.py
plugins/modules/kinesis_stream.py
plugins/modules/lambda_alias.py
plugins/modules/lambda_event.py
plugins/modules/rds.py
plugins/modules/rds_param_group.py
plugins/modules/rds_subnet_group.py
plugins/modules/redshift.py
plugins/modules/redshift_subnet_group.py
plugins/modules/route53.py
plugins/modules/route53_health_check.py
plugins/modules/route53_info.py
plugins/modules/s3_logging.py
plugins/modules/s3_sync.py
plugins/modules/s3_website.py
plugins/modules/sts_session_token.py

##### ADDITIONAL INFORMATION

