### PR TITLE
iam_managed_policy: fix json in documentation

### DIFF
--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -79,7 +79,12 @@ EXAMPLES = '''
 - name: Create IAM Managed Policy
   community.aws.iam_managed_policy:
     policy_name: "ManagedPolicy"
-    policy: "{{ lookup('file', 'managed_policy_update.json') }}"
+    policy:
+      Version: "2012-10-17"
+      Statement:
+      - Effect: "Allow"
+        Action: "logs:CreateLogGroup"
+        Resource: "*"
     make_default: false
     state: present
 
@@ -87,7 +92,15 @@ EXAMPLES = '''
 - name: Create IAM Managed Policy
   community.aws.iam_managed_policy:
     policy_name: "ManagedPolicy"
-    policy: "{ 'Version': '2012-10-17', 'Statement':[{'Effect': 'Allow','Action': '*','Resource': '*'}]}"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement":[{
+          "Effect": "Allow",
+          "Action": "logs:PutRetentionPolicy",
+          "Resource": "*"
+        }]
+      }
     only_version: true
     state: present
 


### PR DESCRIPTION
##### SUMMARY

iam_managed_policy documentation included an example with invalid JSON ( single quotes rather than double quotes ).

fixes: #175 

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

iam_managed_policy

##### ADDITIONAL INFORMATION

Adds an example using dicts for policies.
Fixes the bad example in a more legible manner.