### PR TITLE
[Docs] Updated rds_instance backup_retention_period parameter docs

### DIFF
--- a/docs/community.aws.rds_instance_module.rst
+++ b/docs/community.aws.rds_instance_module.rst
@@ -191,7 +191,9 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The number of days for which automated backups are retained (must be greater or equal to 1). May be used when creating a new cluster, when restoring from S3, or when modifying a cluster.</div>
+                                            <div>The number of days for which automated backups are retained.</div>
+                                            <div>When set to 0, automated backups will be disabled. (Not applicable if the DB instance is a source to read replicas)</div>
+                                            <div>May be used when creating a new cluster, when restoring from S3, or when modifying a cluster.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -99,8 +99,9 @@ options:
         type: str
     backup_retention_period:
         description:
-          - The number of days for which automated backups are retained (must be greater or equal to 1).
-            May be used when creating a new cluster, when restoring from S3, or when modifying a cluster.
+          - The number of days for which automated backups are retained.
+          - When set to C(0), automated backups will be disabled. (Not applicable if the DB instance is a source to read replicas)
+          - May be used when creating a new cluster, when restoring from S3, or when modifying a cluster.
         type: int
     ca_certificate_identifier:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Documentation update:
When using rds_instance module, I noticed that when the backup_retention_period parameter is set to 0,
automated backups are disabled.
Previous documentation mentioned that this parameter should be greater than or equal to 1.
Documentation has been updated to reflect this behavior.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_instance
