### PR TITLE
Correctly handle a situation when a repository has no description

### DIFF
--- a/changelogs/fragments/195-aws_codecommit-empty-description.yaml
+++ b/changelogs/fragments/195-aws_codecommit-empty-description.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_codecommit - fixes issue where module execution would fail if an existing repository has empty description (https://github.com/ansible-collections/community.aws/pull/195)

--- a/plugins/modules/aws_codecommit.py
+++ b/plugins/modules/aws_codecommit.py
@@ -162,6 +162,8 @@ class CodeCommit(object):
                 result['changed'] = True
             else:
                 metadata = self._get_repository()['repositoryMetadata']
+                if not metadata.get('repositoryDescription'):
+                    metadata['repositoryDescription'] = ''
                 if metadata['repositoryDescription'] != self._module.params['description']:
                     if not self._check_mode:
                         self._update_repository()

--- a/tests/integration/targets/aws_codecommit/tasks/main.yml
+++ b/tests/integration/targets/aws_codecommit/tasks/main.yml
@@ -96,6 +96,35 @@
       that:
         - output is not changed
 
+  - name: Create a repository without description
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      state: present
+    register: output
+  - assert:
+      that:
+        - output is changed
+        - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
+
+  - name: No-op update to repository without description
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      state: present
+    register: output
+  - assert:
+      that:
+        - output is not changed
+        - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
+
+  - name: Delete  a repository without description
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      state: absent
+    register: output
+  - assert:
+      that:
+        - output is changed
+
   always:
      ###### TEARDOWN STARTS HERE ######
     - name: Delete  a repository


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If a repository was created without a description, API call response
will not include 'repositoryDescription' attribute:

```
$ aws codecommit get-repository --repository-name test
{
    "repositoryMetadata": {
        "accountId": "123412341234",
        "repositoryId": "abcd1234-abcd-abcd-1234-abcd1234abc",
        "repositoryName": "test",
        "defaultBranch": "master",
        "lastModifiedDate": 1597770987.868,
        "creationDate": 1579544888.152,
        "cloneUrlHttp": "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test",
        "cloneUrlSsh": "ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/test",
        "Arn": "arn:aws:codecommit:us-east-1:123412341234:test"
    }
}
```

The following module execution:

```
- name: Create CodeCommit repository
  community.aws.aws_codecommit:
    name: test
    state: present
```

will fail with the following stacktrace:

```
Traceback (most recent call last):
  File \"/root/.ansible/tmp/ansible-tmp-1597769457.193254-7427-16306174619296/AnsiballZ_aws_codecommit.py\", line 102, in <module>
    _ansiballz_main()
  File \"/root/.ansible/tmp/ansible-tmp-1597769457.193254-7427-16306174619296/AnsiballZ_aws_codecommit.py\", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/root/.ansible/tmp/ansible-tmp-1597769457.193254-7427-16306174619296/AnsiballZ_aws_codecommit.py\", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.aws_codecommit', init_globals=None, run_name='__main__', alter_sys=True)
  File \"/root/.pyenv/versions/3.8.1/lib/python3.8/runpy.py\", line 206, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/root/.pyenv/versions/3.8.1/lib/python3.8/runpy.py\", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File \"/root/.pyenv/versions/3.8.1/lib/python3.8/runpy.py\", line 86, in _run_code
    exec(code, run_globals)
  File \"/tmp/ansible_community.aws.aws_codecommit_payload_0zfnkbv7/ansible_community.aws.aws_codecommit_payload.zip/ansible_collections/community/aws/plugins/modules/aws_codecommit.py\", line 245, in <module>
  File \"/tmp/ansible_community.aws.aws_codecommit_payload_0zfnkbv7/ansible_community.aws.aws_codecommit_payload.zip/ansible_collections/community/aws/plugins/modules/aws_codecommit.py\", line 240, in main
  File \"/tmp/ansible_community.aws.aws_codecommit_payload_0zfnkbv7/ansible_community.aws.aws_codecommit_payload.zip/ansible_collections/community/aws/plugins/modules/aws_codecommit.py\", line 165, in process
KeyError: 'repositoryDescription'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_codecommit.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
