### PR TITLE
ec2_scaling_policy - migrate to boto3

### DIFF
--- a/changelogs/fragments/197-ec2_scaling_policy-boto3.yml
+++ b/changelogs/fragments/197-ec2_scaling_policy-boto3.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_scaling_policy - Migrate from boto to boto3
+- ec2_scaling_policy - Add support for step_adjustments

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -279,14 +279,8 @@ def create_scaling_policy(connection, module):
         params['StepAdjustments'] = []
         for step_adjustment in module.params['step_adjustments']:
             step_adjust_params = dict(ScalingAdjustment=step_adjustment['scaling_adjustment'])
-            # Although empty bounds are allowed, not setting the 0 end of the bound seems
-            # to cause problems in the UI. We'll leave the +/- infinity end unset if not set
-            if not step_adjustment.get('lower_bound') and step_adjustment.get('upper_bound') > 0:
-                step_adjustment['lower_bound'] = 0
             if step_adjustment.get('lower_bound'):
                 step_adjust_params['MetricIntervalLowerBound'] = step_adjustment['lower_bound']
-            if not step_adjustment.get('upper_bound') and step_adjustment.get('lower_bound') < 0:
-                step_adjustment['upper_bound'] = 0
             if step_adjustment.get('upper_bound'):
                 step_adjust_params['MetricIntervalUpperBound'] = step_adjustment['upper_bound']
             params['StepAdjustments'].append(step_adjust_params)

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -88,6 +88,22 @@ options:
         This means that for an alarm threshold of 50, triggering at 75 requires a lower bound of 25.
         See U(http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_StepAdjustment.html).
     elements: dict
+    suboptions:
+      lower_bound:
+        type: int
+        description:
+          - The lower bound for the difference between the alarm threshold and
+            the CloudWatch metric.
+      upper_bound:
+        type: int
+        description:
+          - The upper bound for the difference between the alarm threshold and
+            the CloudWatch metric.
+      scaling_adjustment:
+        type: int
+        description:
+          - The amount by which to scale.
+        required: true
   estimated_instance_warmup:
     type: int
     description:
@@ -132,7 +148,7 @@ RETURN = '''
 adjustment_type:
   description: Scaling policy adjustment type
   returned: always
-  type: string
+  type: str
   sample: PercentChangeInCapacity
 alarms:
   description: Cloudwatch alarms related to the policy
@@ -142,52 +158,52 @@ alarms:
     alarm_name:
       description: name of the Cloudwatch alarm
       returned: always
-      type: string
+      type: str
       sample: cpu-very-high
     alarm_arn:
       description: ARN of the Cloudwatch alarm
       returned: always
-      type: string
+      type: str
       sample: arn:aws:cloudwatch:us-east-2:1234567890:alarm:cpu-very-high
 arn:
   description: ARN of the scaling policy. Provided for backward compatibility, value is the same as I(policy_arn)
   returned: always
-  type: string
+  type: str
   sample: arn:aws:autoscaling:us-east-2:123456789012:scalingPolicy:59e37526-bd27-42cf-adca-5cd3d90bc3b9:autoScalingGroupName/app-asg:policyName/app-policy
 as_name:
   description: Auto Scaling Group name. Provided for backward compatibility, value is the same as I(auto_scaling_group_name)
   returned: always
-  type: string
+  type: str
   sample: app-asg
 auto_scaling_group_name:
   description: Name of Auto Scaling Group
   returned: always
-  type: string
+  type: str
   sample: app-asg
 metric_aggregation_type:
   description: Method used to aggregate metrics
   returned: when I(policy_type) is C(StepScaling)
-  type: string
+  type: str
   sample: Maximum
 name:
   description: Name of the scaling policy. Provided for backward compatibility, value is the same as I(policy_name)
   returned: always
-  type: string
+  type: str
   sample: app-policy
 policy_arn:
   description: ARN of scaling policy.
   returned: always
-  type: string
+  type: str
   sample: arn:aws:autoscaling:us-east-2:123456789012:scalingPolicy:59e37526-bd27-42cf-adca-5cd3d90bc3b9:autoScalingGroupName/app-asg:policyName/app-policy
 policy_name:
   description: Name of scaling policy
   returned: always
-  type: string
+  type: str
   sample: app-policy
 policy_type:
   description: Type of auto scaling policy
   returned: always
-  type: string
+  type: str
   sample: StepScaling
 scaling_adjustment:
   description: Adjustment to make when alarm is triggered
@@ -351,7 +367,7 @@ def main():
         state=dict(default='present', choices=['present', 'absent']),
         metric_aggregation=dict(default='Average', choices=['Minimum', 'Maximum', 'Average']),
         policy_type=dict(default='SimpleScaling', choices=['SimpleScaling', 'StepScaling']),
-        step_adjustments=dict(type='list', options=step_adjustment_spec),
+        step_adjustments=dict(type='list', options=step_adjustment_spec, elements='dict'),
         estimated_instance_warmup=dict(type='int')
     )
 

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -6,178 +6,361 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: ec2_scaling_policy
 short_description: Create or delete AWS scaling policies for Autoscaling groups
 version_added: 1.0.0
 description:
   - Can create or delete scaling policies for autoscaling groups.
   - Referenced autoscaling groups must already exist.
-author: "Zacharie Eakin (@Zeekin)"
+author:
+  - Zacharie Eakin (@zeekin)
+  - Will Thames (@willthames)
 options:
   state:
+    type: str
     description:
       - Register or deregister the policy.
-    default: present
     choices: ['present', 'absent']
-    type: str
+    default: 'present'
   name:
+    type: str
     description:
       - Unique name for the scaling policy.
     required: true
-    type: str
   asg_name:
+    type: str
     description:
       - Name of the associated autoscaling group.
-    required: true
-    type: str
+      - Required if I(state) is C(present).
   adjustment_type:
+    type: str
     description:
       - The type of change in capacity of the autoscaling group.
-    choices: ['ChangeInCapacity','ExactCapacity','PercentChangeInCapacity']
-    type: str
+      - Required if I(state) is C(present).
+    choices:
+      - ChangeInCapacity
+      - ExactCapacity
+      - PercentChangeInCapacity
   scaling_adjustment:
+    type: int
     description:
       - The amount by which the autoscaling group is adjusted by the policy.
-    type: int
+      - A negative number scales the autoscaling group in.
+      - Units are numbers of instances for C(ExactCapacity) or C(ChangeInCapacity) or percent
+        of existing instances for C(PercentChangeInCapacity).
+      - Required when I(policy_type) is C(SimpleScaling).
   min_adjustment_step:
+    type: int
     description:
       - Minimum amount of adjustment when policy is triggered.
-    type: int
+      - Only used when I(adjustment_type) is C(PercentChangeInCapacity).
   cooldown:
-    description:
-      - The minimum period of time (in seconds) between which autoscaling actions can take place.
     type: int
+    description:
+      - The minimum period of time between which autoscaling actions can take place.
+      - Only used when I(policy_type) is C(SimpleScaling).
+  policy_type:
+    type: str
+    description:
+      - Auto scaling adjustment policy.
+    choices:
+      - StepScaling
+      - SimpleScaling
+    default: SimpleScaling
+  metric_aggregation:
+    type: str
+    description:
+      - The aggregation type for the CloudWatch metrics.
+      - Only used when I(policy_type) is not C(SimpleScaling).
+    choices:
+      - Minimum
+      - Maximum
+      - Average
+    default: Average
+  step_adjustments:
+    type: list
+    description:
+      - list of dicts containing I(lower_bound), I(upper_bound) and I(scaling_adjustment)
+      - One item can not have a lower bound, and one item can not have an upper bound.
+      - Intervals must not overlap
+      - The bounds are the amount over the alarm threshold at which the adjustment will trigger.
+        This means that for an alarm threshold of 50, triggering at 75 requires a lower bound of 25.
+        See U(http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_StepAdjustment.html).
+    elements: dict
+  estimated_instance_warmup:
+    type: int
+    description:
+      - The estimated time, in seconds, until a newly launched instance can contribute to the CloudWatch metrics.
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
 '''
-
 EXAMPLES = '''
-- community.aws.ec2_scaling_policy:
+- name: Simple Scale Down policy
+  community.aws.ec2_scaling_policy:
     state: present
     region: US-XXX
     name: "scaledown-policy"
     adjustment_type: "ChangeInCapacity"
-    asg_name: "slave-pool"
+    asg_name: "application-asg"
     scaling_adjustment: -1
     min_adjustment_step: 1
     cooldown: 300
+
+# For an alarm with a breach threshold of 20, the
+# following creates a stepped policy:
+# From 20-40 (0-20 above threshold), increase by 50% of existing capacity
+# From 41-infinity, increase by 100% of existing capacity
+- community.aws.ec2_scaling_policy:
+    state: present
+    region: US-XXX
+    name: "step-scale-up-policy"
+    policy_type: StepScaling
+    metric_aggregation: Maximum
+    step_adjustments:
+      - upper_bound: 20
+        scaling_adjustment: 50
+      - lower_bound: 20
+        scaling_adjustment: 100
+    adjustment_type: "PercentChangeInCapacity"
+    asg_name: "application-asg"
+'''
+
+RETURN = '''
+adjustment_type:
+  description: Scaling policy adjustment type
+  returned: always
+  type: string
+  sample: PercentChangeInCapacity
+alarms:
+  description: Cloudwatch alarms related to the policy
+  returned: always
+  type: complex
+  contains:
+    alarm_name:
+      description: name of the Cloudwatch alarm
+      returned: always
+      type: string
+      sample: cpu-very-high
+    alarm_arn:
+      description: ARN of the Cloudwatch alarm
+      returned: always
+      type: string
+      sample: arn:aws:cloudwatch:us-east-2:1234567890:alarm:cpu-very-high
+arn:
+  description: ARN of the scaling policy. Provided for backward compatibility, value is the same as I(policy_arn)
+  returned: always
+  type: string
+  sample: arn:aws:autoscaling:us-east-2:123456789012:scalingPolicy:59e37526-bd27-42cf-adca-5cd3d90bc3b9:autoScalingGroupName/app-asg:policyName/app-policy
+as_name:
+  description: Auto Scaling Group name. Provided for backward compatibility, value is the same as I(auto_scaling_group_name)
+  returned: always
+  type: string
+  sample: app-asg
+auto_scaling_group_name:
+  description: Name of Auto Scaling Group
+  returned: always
+  type: string
+  sample: app-asg
+metric_aggregation_type:
+  description: Method used to aggregate metrics
+  returned: when I(policy_type) is C(StepScaling)
+  type: string
+  sample: Maximum
+name:
+  description: Name of the scaling policy. Provided for backward compatibility, value is the same as I(policy_name)
+  returned: always
+  type: string
+  sample: app-policy
+policy_arn:
+  description: ARN of scaling policy.
+  returned: always
+  type: string
+  sample: arn:aws:autoscaling:us-east-2:123456789012:scalingPolicy:59e37526-bd27-42cf-adca-5cd3d90bc3b9:autoScalingGroupName/app-asg:policyName/app-policy
+policy_name:
+  description: Name of scaling policy
+  returned: always
+  type: string
+  sample: app-policy
+policy_type:
+  description: Type of auto scaling policy
+  returned: always
+  type: string
+  sample: StepScaling
+scaling_adjustment:
+  description: Adjustment to make when alarm is triggered
+  returned: When I(policy_type) is C(SimpleScaling)
+  type: int
+  sample: 1
+step_adjustments:
+  description: List of step adjustments
+  returned: always
+  type: complex
+  contains:
+    metric_interval_lower_bound:
+      description: Lower bound for metric interval
+      returned: if step has a lower bound
+      type: float
+      sample: 20.0
+    metric_interval_upper_bound:
+      description: Upper bound for metric interval
+      returned: if step has an upper bound
+      type: float
+      sample: 40.0
+    scaling_adjustment:
+      description: Adjustment to make if this step is reached
+      returned: always
+      type: int
+      sample: 50
 '''
 
 try:
-    import boto.ec2.autoscale
-    import boto.exception
-    from boto.ec2.autoscale import ScalingPolicy
-    from boto.exception import BotoServerError
+    import botocore
 except ImportError:
-    pass  # Taken care of by ec2.HAS_BOTO
+    pass  # caught by imported AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def create_scaling_policy(connection, module):
-    sp_name = module.params.get('name')
-    adjustment_type = module.params.get('adjustment_type')
-    asg_name = module.params.get('asg_name')
-    scaling_adjustment = module.params.get('scaling_adjustment')
-    min_adjustment_step = module.params.get('min_adjustment_step')
-    cooldown = module.params.get('cooldown')
+    changed = False
+    asg_name = module.params['asg_name']
+    policy_type = module.params['policy_type']
+    policy_name = module.params['name']
 
-    scalingPolicies = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])
+    params = dict(PolicyName=policy_name,
+                  PolicyType=policy_type,
+                  AutoScalingGroupName=asg_name,
+                  AdjustmentType=module.params['adjustment_type'])
 
-    if not scalingPolicies:
-        sp = ScalingPolicy(
-            name=sp_name,
-            adjustment_type=adjustment_type,
-            as_name=asg_name,
-            scaling_adjustment=scaling_adjustment,
-            min_adjustment_step=min_adjustment_step,
-            cooldown=cooldown)
+    # min_adjustment_step attribute is only relevant if the adjustment_type
+    # is set to percentage change in capacity, so it is a special case
+    if module.params['adjustment_type'] == 'PercentChangeInCapacity':
+        if module.params['min_adjustment_step']:
+            params['MinAdjustmentMagnitude'] = module.params['min_adjustment_step']
 
-        try:
-            connection.create_scaling_policy(sp)
-            policy = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])[0]
-            module.exit_json(changed=True, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment,
-                             cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-        except BotoServerError as e:
-            module.fail_json(msg=str(e))
+    if policy_type == 'SimpleScaling':
+        # can't use required_if because it doesn't allow multiple criteria -
+        # it's only required if policy is SimpleScaling and state is present
+        if not module.params['scaling_adjustment']:
+            module.fail_json(msg='scaling_adjustment is required when policy_type is SimpleScaling '
+                             'and state is present')
+        params['ScalingAdjustment'] = module.params['scaling_adjustment']
+        if module.params['cooldown']:
+            params['Cooldown'] = module.params['cooldown']
+
+    if policy_type == 'StepScaling':
+        if not module.params['step_adjustments']:
+            module.fail_json(msg='step_adjustments is required when policy_type is StepScaling '
+                             'and state is present')
+        params['StepAdjustments'] = []
+        for step_adjustment in module.params['step_adjustments']:
+            step_adjust_params = dict(ScalingAdjustment=step_adjustment['scaling_adjustment'])
+            # Although empty bounds are allowed, not setting the 0 end of the bound seems
+            # to cause problems in the UI. We'll leave the +/- infinity end unset if not set
+            if not step_adjustment.get('lower_bound') and step_adjustment.get('upper_bound') > 0:
+                step_adjustment['lower_bound'] = 0
+            if step_adjustment.get('lower_bound'):
+                step_adjust_params['MetricIntervalLowerBound'] = step_adjustment['lower_bound']
+            if not step_adjustment.get('upper_bound') and step_adjustment.get('lower_bound') < 0:
+                step_adjustment['upper_bound'] = 0
+            if step_adjustment.get('upper_bound'):
+                step_adjust_params['MetricIntervalUpperBound'] = step_adjustment['upper_bound']
+            params['StepAdjustments'].append(step_adjust_params)
+        if module.params['metric_aggregation']:
+            params['MetricAggregationType'] = module.params['metric_aggregation']
+        if module.params['estimated_instance_warmup']:
+            params['EstimatedInstanceWarmup'] = module.params['estimated_instance_warmup']
+
+    try:
+        policies = connection.describe_policies(AutoScalingGroupName=asg_name,
+                                                PolicyNames=[policy_name])['ScalingPolicies']
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to obtain autoscaling policy %s" % policy_name)
+
+    before = after = {}
+    if not policies:
+        changed = True
     else:
-        policy = scalingPolicies[0]
-        changed = False
-
-        # min_adjustment_step attribute is only relevant if the adjustment_type
-        # is set to percentage change in capacity, so it is a special case
-        if getattr(policy, 'adjustment_type') == 'PercentChangeInCapacity':
-            if getattr(policy, 'min_adjustment_step') != module.params.get('min_adjustment_step'):
+        policy = policies[0]
+        for key in params:
+            if params[key] != policy.get(key):
                 changed = True
+                before[key] = params[key]
+                after[key] = policy.get(key)
 
-        # set the min adjustment step in case the user decided to change their
-        # adjustment type to percentage
-        setattr(policy, 'min_adjustment_step', module.params.get('min_adjustment_step'))
-
-        # check the remaining attributes
-        for attr in ('adjustment_type', 'scaling_adjustment', 'cooldown'):
-            if getattr(policy, attr) != module.params.get(attr):
-                changed = True
-                setattr(policy, attr, module.params.get(attr))
-
+    if changed:
         try:
-            if changed:
-                connection.create_scaling_policy(policy)
-                policy = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])[0]
-            module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment,
-                             cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-        except BotoServerError as e:
-            module.fail_json(msg=str(e))
+            connection.put_scaling_policy(**params)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to create autoscaling policy")
+        try:
+            policies = connection.describe_policies(AutoScalingGroupName=asg_name,
+                                                    PolicyNames=[policy_name])['ScalingPolicies']
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(msg="Failed to obtain autoscaling policy %s" % policy_name)
+
+    policy = camel_dict_to_snake_dict(policies[0])
+    # Backward compatible return values
+    policy['arn'] = policy['policy_arn']
+    policy['as_name'] = policy['auto_scaling_group_name']
+    policy['name'] = policy['policy_name']
+
+    if before and after:
+        module.exit_json(changed=changed, diff=dict(before=before, after=after), **policy)
+    else:
+        module.exit_json(changed=changed, **policy)
 
 
 def delete_scaling_policy(connection, module):
-    sp_name = module.params.get('name')
-    asg_name = module.params.get('asg_name')
+    policy_name = module.params.get('name')
 
-    scalingPolicies = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])
+    try:
+        policy = connection.describe_policies(PolicyNames=[policy_name])
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to obtain autoscaling policy %s" % policy_name)
 
-    if scalingPolicies:
+    if policy['ScalingPolicies']:
         try:
-            connection.delete_policy(sp_name, asg_name)
+            connection.delete_policy(AutoScalingGroupName=policy['ScalingPolicies'][0]['AutoScalingGroupName'],
+                                     PolicyName=policy_name)
             module.exit_json(changed=True)
-        except BotoServerError as e:
-            module.exit_json(changed=False, msg=str(e))
-    else:
-        module.exit_json(changed=False)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to delete autoscaling policy")
+
+    module.exit_json(changed=False)
 
 
 def main():
+    step_adjustment_spec = dict(
+        lower_bound=dict(type='int'),
+        upper_bound=dict(type='int'),
+        scaling_adjustment=dict(type='int', required=True))
+
     argument_spec = dict(
-        name=dict(required=True, type='str'),
-        adjustment_type=dict(type='str', choices=['ChangeInCapacity', 'ExactCapacity', 'PercentChangeInCapacity']),
-        asg_name=dict(required=True, type='str'),
+        name=dict(required=True),
+        adjustment_type=dict(choices=['ChangeInCapacity', 'ExactCapacity', 'PercentChangeInCapacity']),
+        asg_name=dict(),
         scaling_adjustment=dict(type='int'),
         min_adjustment_step=dict(type='int'),
         cooldown=dict(type='int'),
         state=dict(default='present', choices=['present', 'absent']),
+        metric_aggregation=dict(default='Average', choices=['Minimum', 'Maximum', 'Average']),
+        policy_type=dict(default='SimpleScaling', choices=['SimpleScaling', 'StepScaling']),
+        step_adjustments=dict(type='list', options=step_adjustment_spec),
+        estimated_instance_warmup=dict(type='int')
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[['state', 'present', ['asg_name', 'adjustment_type']]])
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
-
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    connection = module.client('autoscaling')
 
     state = module.params.get('state')
-
-    try:
-        connection = connect_to_aws(boto.ec2.autoscale, region, **aws_connect_params)
-    except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-        module.fail_json(msg=str(e))
-
     if state == 'present':
         create_scaling_policy(connection, module)
     elif state == 'absent':

--- a/plugins/modules/ec2_scaling_policy.py
+++ b/plugins/modules/ec2_scaling_policy.py
@@ -46,7 +46,7 @@ options:
     type: int
     description:
       - The amount by which the autoscaling group is adjusted by the policy.
-      - A negative number scales the autoscaling group in.
+      - A negative number has the effect of scaling down the ASG.
       - Units are numbers of instances for C(ExactCapacity) or C(ChangeInCapacity) or percent
         of existing instances for C(PercentChangeInCapacity).
       - Required when I(policy_type) is C(SimpleScaling).
@@ -58,7 +58,7 @@ options:
   cooldown:
     type: int
     description:
-      - The minimum period of time between which autoscaling actions can take place.
+      - The minimum period of time (in seconds) between which autoscaling actions can take place.
       - Only used when I(policy_type) is C(SimpleScaling).
   policy_type:
     type: str
@@ -82,8 +82,11 @@ options:
     type: list
     description:
       - list of dicts containing I(lower_bound), I(upper_bound) and I(scaling_adjustment)
-      - One item can not have a lower bound, and one item can not have an upper bound.
-      - Intervals must not overlap
+      - Intervals must not overlap or have a gap between them.
+      - At most, one item can have an undefined I(lower_bound).
+        If any item has a negative lower_bound, then there must be a step adjustment with an undefined I(lower_bound).
+      - At most, one item can have an undefined I(upper_bound).
+        If any item has a positive upper_bound, then there must be a step adjustment with an undefined I(upper_bound).
       - The bounds are the amount over the alarm threshold at which the adjustment will trigger.
         This means that for an alarm threshold of 50, triggering at 75 requires a lower bound of 25.
         See U(http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_StepAdjustment.html).

--- a/tests/integration/targets/ec2_scaling_policy/aliases
+++ b/tests/integration/targets/ec2_scaling_policy/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group3

--- a/tests/integration/targets/ec2_scaling_policy/defaults/main.yml
+++ b/tests/integration/targets/ec2_scaling_policy/defaults/main.yml
@@ -1,0 +1,3 @@
+scaling_policy_lc_name: "{{ resource_prefix }}_lc"
+scaling_policy_asg_name: "{{ resource_prefix }}_asg"
+ec2_ami_name: 'amzn2-ami-hvm-2.*-x86_64-gp2'

--- a/tests/integration/targets/ec2_scaling_policy/meta/main.yml
+++ b/tests/integration/targets/ec2_scaling_policy/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/tests/integration/targets/ec2_scaling_policy/tasks/main.yml
+++ b/tests/integration/targets/ec2_scaling_policy/tasks/main.yml
@@ -1,0 +1,215 @@
+---
+# __Test Outline__
+#
+# __ec2_scaling_policy__
+# create simplescaling scaling policy
+# update simplescaling scaling policy
+# remove simplescaling scaling policy
+# create stepscaling scaling policy
+# update stepscaling scaling policy
+# remove stepscaling scaling policy
+
+- module_defaults:
+    group/aws:
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token | default(omit) }}"
+  collections:
+    - amazon.aws
+  block:
+
+    - name: Find AMI to use
+      ec2_ami_info:
+        owners: 'amazon'
+        filters:
+          name: '{{ ec2_ami_name }}'
+      register: ec2_amis
+
+    - name: Set fact with latest AMI
+      vars:
+        latest_ami: '{{ ec2_amis.images | sort(attribute="creation_date") | last }}'
+      set_fact:
+        scaling_policy_image_id: '{{ latest_ami.image_id }}'
+
+    - name: create trivial launch_configuration
+      ec2_lc:
+        name: "{{ scaling_policy_lc_name }}"
+        state: present
+        instance_type: t3.nano
+        image_id: "{{ scaling_policy_image_id }}"
+
+    - name: create trivial ASG
+      ec2_asg:
+        name: "{{ scaling_policy_asg_name }}"
+        state: present
+        launch_config_name: "{{ scaling_policy_lc_name }}"
+        min_size: 0
+        max_size: 1
+        desired_capacity: 0
+
+    - name: Create Simple Scaling policy using implicit defaults
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: ChangeInCapacity
+        scaling_adjustment: 1
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ resource_prefix }}_simplescaling_policy"
+          - result.changed
+
+    - name: Update Simple Scaling policy using explicit defaults
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: ChangeInCapacity
+        scaling_adjustment: 1
+        policy_type: SimpleScaling
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ resource_prefix }}_simplescaling_policy"
+          - not result.changed
+
+    - name: min_adjustment_step is ignored with ChangeInCapacity
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: ChangeInCapacity
+        scaling_adjustment: 1
+        min_adjustment_step: 1
+        policy_type: SimpleScaling
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ resource_prefix }}_simplescaling_policy"
+          - not result.changed
+          - result.adjustment_type == "ChangeInCapacity"
+
+    - name: Change Simple Scaling policy adjustment_type to PercentChangeInCapacity
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: PercentChangeInCapacity
+        scaling_adjustment: 1
+        min_adjustment_step: 1
+        policy_type: SimpleScaling
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ resource_prefix }}_simplescaling_policy"
+          - result.changed
+          - result.adjustment_type == "PercentChangeInCapacity"
+
+    - name: Remove Simple Scaling policy
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - result.changed
+
+    - name: Create Step Scaling policy
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        policy_type: StepScaling
+        metric_aggregation: Maximum
+        step_adjustments:
+        - upper_bound: 20
+          scaling_adjustment: 50
+        - lower_bound: 20
+          scaling_adjustment: 100
+        adjustment_type: "PercentChangeInCapacity"
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ resource_prefix }}_stepscaling_policy"
+          - result.changed
+
+    - name: Add another step
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        policy_type: StepScaling
+        metric_aggregation: Maximum
+        step_adjustments:
+        - upper_bound: 20
+          scaling_adjustment: 50
+        - lower_bound: 20
+          upper_bound: 40
+          scaling_adjustment: 75
+        - lower_bound: 40
+          scaling_adjustment: 100
+        adjustment_type: "PercentChangeInCapacity"
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ resource_prefix }}_stepscaling_policy"
+          - result.changed
+          - result.adjustment_type == "PercentChangeInCapacity"
+
+    - name: Remove Step Scaling policy
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - result.changed
+
+    - name: Remove Step Scaling policy (idemopotency)
+      ec2_scaling_policy:
+        name: "{{ resource_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result is successful
+
+  always:
+
+    # ============================================================
+    - name: Remove the scaling policies
+      ec2_scaling_policy:
+        name: "{{ item }}"
+        state: absent
+      register: result
+      with_items:
+        - "{{ resource_prefix }}_simplescaling_policy"
+        - "{{ resource_prefix }}_stepscaling_policy"
+      ignore_errors: yes
+
+    - name: remove the ASG
+      ec2_asg:
+        name: "{{ scaling_policy_asg_name }}"
+        state: absent
+      ignore_errors: yes
+
+    - name: remove the Launch Configuration
+      ec2_lc:
+        name: "{{ scaling_policy_lc_name }}"
+        state: absent
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

Based heavily on the work by @willthames : https://github.com/ansible/ansible/pull/26476

- Migrates ec2_scaling_policy to boto3
- Adds initial integration tests
- Adds support for StepScaling policies

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_scaling_policy

##### ADDITIONAL INFORMATION

Todo
- [x] Additional docs cleanup (suboptions)
- [x] Add AWSRetry handlers
- [x] AWS-Terminator policies
- [x] Changelog

Fixes: #152 