### PR TITLE
aws_kms_info - Gracefully Handle Keys That Don't Allow kms:GetKeyRotationStatus API Calls

### DIFF
--- a/changelogs/fragments/198-aws_kms_info-key-rotation-status.yaml
+++ b/changelogs/fragments/198-aws_kms_info-key-rotation-status.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- aws_kms_info - fixes issue where module execution fails because certain AWS KMS keys (e.g. aws/acm) do not allow permissions to call the API kms:GetKeyRotationStatus (example: https://forums.aws.amazon.com/thread.jspa?threadID=312992) (https://github.com/ansible-collections/community.aws/pull/198)

--- a/changelogs/fragments/198-aws_kms_info-key-rotation-status.yaml
+++ b/changelogs/fragments/198-aws_kms_info-key-rotation-status.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_kms_info - fixes issue where module execution fails because certain AWS KMS keys (e.g. aws/acm) do not allow permissions to call the API kms:GetKeyRotationStatus (example: https://forums.aws.amazon.com/thread.jspa?threadID=312992) (https://github.com/ansible-collections/community.aws/pull/198)

--- a/changelogs/fragments/199-aws_kms_info-key-rotation-status.yaml
+++ b/changelogs/fragments/199-aws_kms_info-key-rotation-status.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_kms_info - fixes issue where module execution fails because certain AWS KMS keys (e.g. aws/acm) do not allow permissions to call the API kms:GetKeyRotationStatus (example: https://forums.aws.amazon.com/thread.jspa?threadID=312992) (https://github.com/ansible-collections/community.aws/pull/199)

--- a/changelogs/fragments/199-aws_kms_info-key-rotation-status.yaml
+++ b/changelogs/fragments/199-aws_kms_info-key-rotation-status.yaml
@@ -1,2 +1,5 @@
 bugfixes:
-- aws_kms_info - fixes issue where module execution fails because certain AWS KMS keys (e.g. aws/acm) do not allow permissions to call the API kms:GetKeyRotationStatus (example: https://forums.aws.amazon.com/thread.jspa?threadID=312992) (https://github.com/ansible-collections/community.aws/pull/199)
+- aws_kms_info - fixes issue where module execution fails because certain AWS KMS keys (e.g. aws/acm)
+  do not allow permissions to call the API kms:GetKeyRotationStatus
+  (example - https://forums.aws.amazon.com/thread.jspa?threadID=312992)
+  (https://github.com/ansible-collections/community.aws/pull/199)

--- a/changelogs/fragments/199-aws_kms_info-key-rotation-status.yaml
+++ b/changelogs/fragments/199-aws_kms_info-key-rotation-status.yaml
@@ -1,5 +1,5 @@
 bugfixes:
 - aws_kms_info - fixes issue where module execution fails because certain AWS KMS keys (e.g. aws/acm)
-  do not allow permissions to call the API kms:GetKeyRotationStatus
+  do not permit the calling the API kms:GetKeyRotationStatus
   (example - https://forums.aws.amazon.com/thread.jspa?threadID=312992)
   (https://github.com/ansible-collections/community.aws/pull/199)

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -290,7 +290,12 @@ def get_key_policy_with_backoff(connection, key_id, policy_name):
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def get_enable_key_rotation_with_backoff(connection, key_id):
-    current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
+    try:
+        current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'AccessDeniedException':
+            return True
+
     return current_rotation_status.get('KeyRotationEnabled')
 
 

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -358,7 +358,7 @@
     - name: assert that key rotation status is set to None
       assert:
         that:
-          - update_key.enable_key_rotation == None
+          - update_key.enable_key_rotation is undefined
 
     - name: delete the key
       aws_kms:

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -344,6 +344,22 @@
           - update_key.key_state == "Disabled"
           - update_key.changed
 
+    - name: update policy to remove access to key rotation status
+      aws_kms:
+        alias: "alias/{{ resource_prefix }}-kms"
+        policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') | to_json }}"
+
+    - name: find facts about the key without key rotation status
+      aws_kms_info:
+        filters:
+          alias: "{{ resource_prefix }}-kms"
+      register: update_key
+
+    - name: assert that key rotation status is set to None
+      assert:
+        that:
+          - update_key.enable_key_rotation == None
+
     - name: delete the key
       aws_kms:
         alias: "{{ resource_prefix }}-kms"

--- a/tests/integration/targets/aws_kms/templates/console-policy-no-key-rotation.j2
+++ b/tests/integration/targets/aws_kms/templates/console-policy-no-key-rotation.j2
@@ -1,0 +1,81 @@
+{
+    "Id": "key-consolepolicy-3",
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::{{ aws_caller_info.account }}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow access for Key Administrators",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "{{ aws_caller_info.arn }}"
+            },
+            "Action": [
+                "kms:Create*",
+                "kms:Describe*",
+                "kms:Enable*",
+                "kms:List*",
+                "kms:Put*",
+                "kms:Update*",
+                "kms:Revoke*",
+                "kms:Disable*",
+                "kms:Get*",
+                "kms:Delete*",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "kms:ScheduleKeyDeletion",
+                "kms:CancelKeyDeletion"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow use of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "{{ aws_caller_info.arn }}"
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow attachment of persistent resources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "{{ aws_caller_info.arn }}"
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        },
+        {
+            "Sid": "Disable access to key rotation status",
+            "Effect": "Deny",
+            "Principal": {
+                "AWS": "{{ aws_caller_info.arn }}"
+            },
+            "Action": "kms:GetKeyRotationStatus",
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some AWS KMS keys (e.g. aws/acm) do not allow permissions to call the API
kms:GetKeyRotationStatus. As a result, module execution fails, even if the
user executing it has full admin privileges ([example](https://forums.aws.amazon.com/thread.jspa?threadID=312992)).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_kms_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The following module execution:
```
- community.aws.aws_kms_info:
  filter:
    alias: aws/ebs
```
will fail with the following error:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the GetKeyRotationStatus operation: User: arn:aws:sts::123412341234:assumed-role/MyRole/i-1234abcd1234 is not authorized to perform: kms:GetKeyRotationStatus on resource: arn:aws:kms:us-east-1:123412341234:key/3b5bbd74-1234-abcd-1234-1234abcd1234
```

Key ID `3b5bbd74-1234-abcd-1234-1234abcd1234` in the example above is `aws/acm` key. 