### PR TITLE
aws_kms: Support setting PendingWindowInDays (Deletion Delay) and fix tests

### DIFF
--- a/changelogs/fragments/200-aws_kms-deletion.yaml
+++ b/changelogs/fragments/200-aws_kms-deletion.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- aws_kms - fixes issue where module execution fails without the kms:GetKeyRotationStatus permission.
+minor_changes:
+- aws_kms - add support for setting the deletion window using `pending_window` (PendingWindowInDays).

--- a/changelogs/fragments/200-aws_kms-deletion.yaml
+++ b/changelogs/fragments/200-aws_kms-deletion.yaml
@@ -1,4 +1,6 @@
 bugfixes:
-- aws_kms - fixes issue where module execution fails without the kms:GetKeyRotationStatus permission.
+- aws_kms - fixes issue where module execution fails without the kms:GetKeyRotationStatus permission. (https://github.com/ansible-collections/community.aws/pull/200).
+- aws_kms_info - ensure that searching by tag works when tag only exists on some CMKs (https://github.com/ansible-collections/community.aws/issues/276).
 minor_changes:
-- aws_kms - add support for setting the deletion window using `pending_window` (PendingWindowInDays).
+- aws_kms - add support for setting the deletion window using `pending_window` (PendingWindowInDays) (https://github.com/ansible-collections/community.aws/pull/200).
+- aws_kms_info - Add ``key_id`` and ``alias`` parameters to support fetching a single key (https://github.com/ansible-collections/community.aws/pull/200).

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -125,6 +125,7 @@ options:
     - 'See also: U(https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html#KMS-ScheduleKeyDeletion-request-PendingWindowInDays)'
     type: int
     aliases: ['deletion_delay']
+    version_added: 1.3.0
   purge_tags:
     description: Whether the I(tags) argument should cause tags not in the list to
       be removed

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -414,6 +414,7 @@ statement_label = {
 }
 
 import json
+import re
 
 try:
     import botocore
@@ -910,8 +911,10 @@ def _clean_statement_principals(statement, clean_invalid_entries):
     if not isinstance(statement['Principal'].get('AWS'), list):
         statement['Principal']['AWS'] = list()
 
-    invalid_entries = [item for item in statement['Principal']['AWS'] if not item.startswith('arn:aws:iam::')]
-    valid_entries = [item for item in statement['Principal']['AWS'] if item.startswith('arn:aws:iam::')]
+    valid_princ = re.compile('^arn:aws:(iam|sts)::')
+
+    invalid_entries = [item for item in statement['Principal']['AWS'] if not valid_princ.match(item)]
+    valid_entries = [item for item in statement['Principal']['AWS'] if valid_princ.match(item)]
 
     if bool(invalid_entries) and clean_invalid_entries:
         statement['Principal']['AWS'] = valid_entries

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -413,18 +413,23 @@ statement_label = {
     'admin': 'Allow access for Key Administrators'
 }
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags, compare_policies
-from ansible.module_utils.six import string_types
-
 import json
 
 try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.six import string_types
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -794,11 +794,16 @@ def update_key_rotation(connection, module, key, enable_key_rotation):
             return False
     except is_boto3_error_code('AccessDeniedException'):
         pass
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Unable to get current key rotation status")
 
-    if enable_key_rotation:
-        connection.enable_key_rotation(KeyId=key_id)
-    else:
-        connection.disable_key_rotation(KeyId=key_id)
+    try:
+      if enable_key_rotation:
+          connection.enable_key_rotation(KeyId=key_id)
+      else:
+          connection.disable_key_rotation(KeyId=key_id)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to enable/disable key rotation")
     return True
 
 

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -551,7 +551,7 @@ def get_key_details(connection, module, key_id):
     try:
         current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
         result['enable_key_rotation'] = current_rotation_status.get('KeyRotationEnabled')
-    except is_boto3_error_code('AccessDeniedException') as e:
+    except is_boto3_error_code(['AccessDeniedException', 'UnsupportedOperationException']) as e:
         result['enable_key_rotation'] = None
     result['aliases'] = aliases.get(result['KeyId'], [])
 

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -125,7 +125,7 @@ options:
     - 'See also: U(https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html#KMS-ScheduleKeyDeletion-request-PendingWindowInDays)'
     type: int
     aliases: ['deletion_delay']
-    version_added: 1.5.0
+    version_added: 1.4.0
   purge_tags:
     description: Whether the I(tags) argument should cause tags not in the list to
       be removed

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -796,14 +796,14 @@ def update_key_rotation(connection, module, key, enable_key_rotation):
             return False
     except is_boto3_error_code('AccessDeniedException'):
         pass
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to get current key rotation status")
 
     try:
-      if enable_key_rotation:
-          connection.enable_key_rotation(KeyId=key_id)
-      else:
-          connection.disable_key_rotation(KeyId=key_id)
+        if enable_key_rotation:
+            connection.enable_key_rotation(KeyId=key_id)
+        else:
+            connection.disable_key_rotation(KeyId=key_id)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to enable/disable key rotation")
     return True

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -125,7 +125,7 @@ options:
     - 'See also: U(https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html#KMS-ScheduleKeyDeletion-request-PendingWindowInDays)'
     type: int
     aliases: ['deletion_delay']
-    version_added: 1.3.0
+    version_added: 1.5.0
   purge_tags:
     description: Whether the I(tags) argument should cause tags not in the list to
       be removed

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -387,7 +387,7 @@ def get_key_details(connection, module, key_id, tokens=None):
         key_id = result['Arn']
     except is_boto3_error_code('NotFoundException'):
         return None
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed to obtain key metadata")
     result['KeyArn'] = result.pop('Arn')
 
@@ -448,7 +448,7 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
-                              mutually_exclusive=[['name', 'filters', 'key_id']],
+                              mutually_exclusive=[['alias', 'filters', 'key_id']],
                               supports_check_mode=True)
     if module._name == 'aws_kms_facts':
         module.deprecate("The 'aws_kms_facts' module has been renamed to 'aws_kms_info'", date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -24,7 +24,7 @@ options:
     aliases:
       - key_alias
     type: str
-    version_added: 1.3.0
+    version_added: 1.4.0
   key_id:
     description:
       - Key ID or ARN of the key.
@@ -33,7 +33,7 @@ options:
     aliases:
       - key_arn
     type: str
-    version_added: 1.3.0
+    version_added: 1.4.0
   filters:
     description:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -16,12 +16,31 @@ description:
     - This module was called C(aws_kms_facts) before Ansible 2.9. The usage did not change.
 author: "Will Thames (@willthames)"
 options:
+  alias:
+    description:
+      - Alias for key.
+      - Mutually exclusive with I(key_id) and I(filters).
+    required: false
+    aliases:
+      - key_alias
+    type: str
+    version_added: 1.3.0
+  key_id:
+    description:
+      - Key ID or ARN of the key.
+      - Mutually exclusive with I(alias) and I(filters).
+    required: false
+    aliases:
+      - key_arn
+    type: str
+    version_added: 1.3.0
   filters:
     description:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
         The filters aren't natively supported by boto3, but are supported to provide similar
         functionality to other modules. Standard tag filters (C(tag-key), C(tag-value) and
         C(tag:tagName)) are available, as are C(key-id) and C(alias)
+      - Mutually exclusive with I(alias) and I(key_id).
     type: dict
   pending_deletion:
     description: Whether to get full details (tags, grants etc.) of keys pending deletion
@@ -422,8 +441,8 @@ def get_kms_info(connection, module):
 
 def main():
     argument_spec = dict(
-        alias=dict(),
-        key_id=dict(),
+        alias=dict(aliases=['key_alias']),
+        key_id=dict(aliases=['key_arn']),
         filters=dict(type='dict'),
         pending_deletion=dict(type='bool', default=False),
     )

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -346,7 +346,10 @@ def key_matches_filter(key, filtr):
     if filtr[0] == 'alias':
         return filtr[1] in key['aliases']
     if filtr[0].startswith('tag:'):
-        return key['tags'][filtr[0][4:]] == filtr[1]
+        tag_key = filtr[0][4:]
+        if tag_key not in key['tags']:
+            return False
+        return key['tags'].get(tag_key) == filtr[1]
 
 
 def key_matches_filters(key, filters):

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 aws_kms_info
-unsupported
+shippable/aws/group2

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,3 +1,5 @@
 cloud/aws
 aws_kms_info
 shippable/aws/group2
+# Various race conditions - likely needs waiters
+unstable

--- a/tests/integration/targets/aws_kms/defaults/main.yml
+++ b/tests/integration/targets/aws_kms/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+kms_role_name: 'ansible-test-{{ resource_prefix }}-kms'

--- a/tests/integration/targets/aws_kms/defaults/main.yml
+++ b/tests/integration/targets/aws_kms/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 kms_role_name: 'ansible-test-{{ resource_prefix }}-kms'
+kms_key_alias: '{{ resource_prefix }}-kms'

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -109,7 +109,7 @@
         that:
           - new_key["keys"]|length == 1
           - new_key["keys"][0]["enable_key_rotation"] == true
-          - new_key["keys"][0]["key_state"] != PendingDeletion
+          - new_key["keys"][0]["key_state"] != "PendingDeletion"
 
     - name: Update Policy on key to match AWS Console generate policy
       aws_kms:

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -438,9 +438,11 @@
         alias: "{{ resource_prefix }}-kms"
         pending_window: 7
       register: destroy_result
+      ignore_errors: True
 
     - name: remove the IAM role
       iam_role:
         name: "{{ resource_prefix }}-kms-role"
         state: absent
       register: iam_role_result
+      ignore_errors: True

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -433,7 +433,9 @@
         that:
           - delete_kms.key_state == "PendingDeletion"
           - delete_kms.changed
-          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days == 30
+          # Times won't be perfect, allow a 24 hour window
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 30
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
 
     - name: re-delete the key
       aws_kms:
@@ -486,7 +488,9 @@
         that:
           - delete_kms.key_state == "PendingDeletion"
           - delete_kms.changed
-          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days == 7
+          # Times won't be perfect, allow a 24 hour window
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 7
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 6
 
   always:
     # ============================================================

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -21,7 +21,7 @@
     # to ensure it exists when we need it for updating the policies
     - name: create an IAM role that can do nothing
       iam_role:
-        name: "{{ resource_prefix }}-kms-role"
+        name: '{{ kms_role_name }}'
         state: present
         assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect": "Deny"} }'
       register: iam_role_result
@@ -137,7 +137,7 @@
       aws_kms:
         mode: grant
         alias: "alias/{{ resource_prefix }}-kms"
-        role_name: "{{ resource_prefix }}-kms-role"
+        role_name: '{{ kms_role_name }}'
         grant_types: "role,role grant"
 
     - name: find facts about the key
@@ -442,7 +442,7 @@
 
     - name: remove the IAM role
       iam_role:
-        name: "{{ resource_prefix }}-kms-role"
+        name: '{{ kms_role_name }}'
         state: absent
       register: iam_role_result
       ignore_errors: True

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -25,17 +25,17 @@
         state: present
         assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect": "Deny"} }'
       register: iam_role_result
+
     # ============================================================
     #   TESTS
     - name: See whether key exists and its current state
       aws_kms_info:
-        filters:
-          alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
 
     - name: create a key in check mode
       check_mode: yes
       aws_kms:
-        alias: "{{ resource_prefix }}-kms-check"
+        alias: '{{ kms_key_alias }}-check'
         tags:
           Hello: World
         state: present
@@ -44,8 +44,7 @@
 
     - name: find facts about the check mode key
       aws_kms_info:
-        filters:
-          alias: "{{ resource_prefix }}-kms-check"
+        alias: '{{ kms_key_alias }}-check'
       register: check_key
 
     - name: ensure that check mode worked as expected
@@ -56,7 +55,7 @@
 
     - name: create a key
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -66,13 +65,24 @@
     - name: assert that state is enabled
       assert:
         that:
+          - '"key_id" in create_kms'
+          - create_kms.key_id | length >= 36
+          - not create_kms.key_id.startswith("arn:aws")
+          - '"key_arn" in create_kms'
+          - create_kms.key_arn.endswith(create_kms.key_id)
+          - create_kms.key_arn.startswith("arn:aws")
           - create_kms.key_state == "Enabled"
           - create_kms.tags['Hello'] == 'World'
           - create_kms.enable_key_rotation == false
 
+    - name: Save IDs for later
+      set_fact:
+        kms_key_id: '{{ create_kms.key_id }}'
+        kms_key_arn: '{{ create_kms.key_arn }}'
+
     - name: enable key rotation
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -90,7 +100,7 @@
     - name: delete the key in check mode
       check_mode: yes
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: delete_kms_check
 
@@ -98,10 +108,9 @@
         that:
           - delete_kms_check is changed
 
-    - name: find facts about the key
+    - name: find facts about the key (by ID)
       aws_kms_info:
-        filters:
-          alias: "{{ resource_prefix }}-kms"
+        key_id: '{{ kms_key_id }}'
       register: new_key
 
     - name: check that a key was found
@@ -113,7 +122,7 @@
 
     - name: Update Policy on key to match AWS Console generate policy
       aws_kms:
-        key_id: '{{ new_key["keys"][0]["key_id"] }}'
+        key_id: '{{ kms_key_id }}'
         policy: "{{ lookup('template', 'console-policy.j2') | to_json }}"
       register: kms_policy_changed
 
@@ -124,7 +133,7 @@
 
     - name: Attempt to re-assert the same policy
       aws_kms:
-        alias: "alias/{{ resource_prefix }}-kms"
+        alias: "alias/{{ kms_key_alias }}"
         policy: "{{ lookup('template', 'console-policy.j2') | to_json }}"
       register: kms_policy_changed
 
@@ -136,31 +145,29 @@
     - name: grant user-style access to production secrets
       aws_kms:
         mode: grant
-        alias: "alias/{{ resource_prefix }}-kms"
+        alias: "alias/{{ kms_key_alias }}"
         role_name: '{{ kms_role_name }}'
         grant_types: "role,role grant"
 
-    - name: find facts about the key
+    - name: find facts about the key (by ARN)
       aws_kms_info:
-        filters:
-          alias: "{{ resource_prefix }}-kms"
+        key_id: '{{ kms_key_arn }}'
       register: new_key
 
     - name: remove access to production secrets from role
       aws_kms:
         mode: deny
-        alias: "alias/{{ resource_prefix }}-kms"
+        alias: "alias/{{ kms_key_alias }}"
         role_arn: "{{ iam_role_result.iam_role.arn }}"
 
-    - name: find facts about the key
+    - name: find facts about the key (by alias)
       aws_kms_info:
-        filters:
-          alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
       register: new_key
 
     - name: Allow the IAM role to use a specific Encryption Context
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         purge_tags: yes
@@ -185,7 +192,7 @@
 
     - name: Add a second grant
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         grants:
           - name: another_grant
@@ -208,7 +215,7 @@
 
     - name: Add a second grant again
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         grants:
           - name: another_grant
@@ -231,7 +238,7 @@
 
     - name: Update the grants with purge_grants set
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         grants:
@@ -255,7 +262,7 @@
 
     - name: update third grant to change encryption context equals to subset
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         grants:
           - name: third_grant
@@ -280,7 +287,7 @@
 
     - name: tag encryption key
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         tags:
           tag_one: tag_one
@@ -297,12 +304,12 @@
 
     - name: add, replace, remove tags
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_tags: yes
         tags:
           tag_two: tag_two_updated
-          tag_three: tag_three
+          Tag Three: '{{ resource_prefix }}'
       register: tag_kms_update
 
     - name: assert tags correctly changed
@@ -312,12 +319,15 @@
           - "'tag_one' not in tag_kms_update.tags"
           - "'tag_two' in tag_kms_update.tags"
           - "tag_kms_update.tags.tag_two == 'tag_two_updated'"
-          - "'tag_three' in tag_kms_update.tags"
+          - "'Tag Three' in tag_kms_update.tags"
+          - "tag_kms_update.tags['Tag Three'] == resource_prefix"
 
     - name: make no real tag change
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
+        tags:
+          Tag Three: '{{ resource_prefix }}'
       register: tag_kms_no_update
 
     - name: assert no change to tags
@@ -327,11 +337,12 @@
           - "'tag_one' not in tag_kms_no_update.tags"
           - "'tag_two' in tag_kms_no_update.tags"
           - "tag_kms_no_update.tags.tag_two == 'tag_two_updated'"
-          - "'tag_three' in tag_kms_no_update.tags"
+          - "'Tag Three' in tag_kms_update.tags"
+          - "tag_kms_update.tags['Tag Three'] == resource_prefix"
 
     - name: update the key's description and disable it
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
         enabled: no
@@ -346,23 +357,71 @@
 
     - name: update policy to remove access to key rotation status
       aws_kms:
-        alias: "alias/{{ resource_prefix }}-kms"
+        alias: 'alias/{{ kms_key_alias }}'
         policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') | to_json }}"
+      register: update_key
 
     - name: find facts about the key without key rotation status
       aws_kms_info:
-        filters:
-          alias: "{{ resource_prefix }}-kms"
-      register: update_key
+        alias: '{{ kms_key_alias }}'
+      register: updated_key
 
     - name: assert that key rotation status is set to None
       assert:
         that:
-          - update_key.enable_key_rotation is undefined
+          - update_key.enable_key_rotation is none
+
+    - name: Perform a search for key by tag
+      aws_kms_info:
+        filters:
+          "tag:Tag Three": "{{ resource_prefix }}"
+      register: info_tag_filtered
+
+    - name: Verify all expected attributes
+      vars:
+        tagged_key: '{{ info_tag_filtered["keys"][0] }}'
+      assert:
+        that:
+          - "'keys' in info_tag_filtered"
+          - info_tag_filtered["keys"] | length == 1
+          - "'aliases' in tagged_key"
+          - kms_key_alias in tagged_key.aliases
+          - "'aws_account_id' in tagged_key"
+          - tagged_key.aws_account_id == aws_caller_info.account
+          - "'creation_date' in tagged_key"
+          - "'customer_master_key_spec' in tagged_key"
+          - tagged_key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - "'description' in tagged_key"
+          - tagged_key.description == 'test key for testing'
+          - "'enable_key_rotation' in tagged_key"
+          - "'enabled' in tagged_key"
+          - tagged_key.enabled == True
+          - "'encryption_algorithms' in tagged_key"
+          - "'SYMMETRIC_DEFAULT' in tagged_key.encryption_algorithms"
+          - "'grants' in tagged_key"
+          - "'key_arn' in tagged_key"
+          - tagged_key.key_arn == kms_key_arn
+          - "'key_id' in tagged_key"
+          - tagged_key.key_id == kms_key_id
+          - "'key_manager' in tagged_key"
+          - tagged_key.key_manager == 'CUSTOMER'
+          - "'key_state' in tagged_key"
+          - tagged_key.key_state == 'Enabled'
+          - "'key_usage' in tagged_key"
+          - tagged_key.key_usage == 'ENCRYPT_DECRYPT'
+          - "'origin' in tagged_key"
+          - tagged_key.origin == "AWS_KMS"
+          - "'policies' in tagged_key"
+          - tagged_key.policies | length == 1
+          - "'tags' in tagged_key"
+          - "'Tag Three' in tagged_key.tags"
+          - tagged_key.tags['Tag Three'] == resource_prefix
+          - "'tag_two' in tagged_key.tags"
+          - tagged_key.tags['tag_two'] == 'tag_two_updated'
 
     - name: delete the key
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: delete_kms
 
@@ -378,7 +437,7 @@
 
     - name: re-delete the key
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: delete_kms
 
@@ -390,7 +449,7 @@
 
     - name: undelete and enable the key
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: present
         enabled: yes
       register: undelete_kms
@@ -414,7 +473,7 @@
 
     - name: delete the key with a specific deletion window
       aws_kms:
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
         state: absent
         pending_window: 7
       register: delete_kms
@@ -435,7 +494,16 @@
     - name: finish off by deleting key
       aws_kms:
         state: absent
-        alias: "{{ resource_prefix }}-kms"
+        alias: '{{ kms_key_alias }}'
+        pending_window: 7
+      register: destroy_result
+      ignore_errors: True
+
+    # Should never exist, but just in case
+    - name: finish off by deleting key
+      aws_kms:
+        state: absent
+        alias: '{{ kms_key_alias }}-check'
         pending_window: 7
       register: destroy_result
       ignore_errors: True

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -367,10 +367,14 @@
       register: delete_kms
 
     - name: assert that state is pending deletion
+      vars:
+        now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
+        deletion_time: '{{ delete_kms.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
       assert:
         that:
           - delete_kms.key_state == "PendingDeletion"
           - delete_kms.changed
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days == 30
 
     - name: re-delete the key
       aws_kms:
@@ -408,6 +412,23 @@
         that:
           - delete_kms is not changed
 
+    - name: delete the key with a specific deletion window
+      aws_kms:
+        alias: "{{ resource_prefix }}-kms"
+        state: absent
+        pending_window: 7
+      register: delete_kms
+
+    - name: assert that state is pending deletion
+      vars:
+        now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
+        deletion_time: '{{ delete_kms.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
+      assert:
+        that:
+          - delete_kms.key_state == "PendingDeletion"
+          - delete_kms.changed
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days == 7
+
   always:
     # ============================================================
     #   CLEAN-UP
@@ -415,6 +436,7 @@
       aws_kms:
         state: absent
         alias: "{{ resource_prefix }}-kms"
+        pending_window: 7
       register: destroy_result
 
     - name: remove the IAM role


### PR DESCRIPTION
##### SUMMARY

Adds support for setting `pending_window` (the number of days a CMK will sit waiting to be deleted.
Fixes failures when we don't have the GetKeyRotationStatus permission
Fixes integration tests and marks them supported

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

aws_kms

##### ADDITIONAL INFORMATION

Writing tests for #199 highlighted that aws_kms also handled missing 'Get' permissions poorly, follow up and handle them better.

Pending mattclay/aws-terminator#106 for CI permissions