### PR TITLE
Fix false positive no_log warning in iam module.

### DIFF
--- a/changelogs/fragments/iam_no_log.yml
+++ b/changelogs/fragments/iam_no_log.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iam - Fix false positive warning regarding use of ``no_log`` on ``update_password``

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -622,7 +622,8 @@ def main():
         groups=dict(type='list', default=None, required=False, elements='str'),
         state=dict(required=True, choices=['present', 'absent', 'update']),
         password=dict(default=None, required=False, no_log=True),
-        update_password=dict(default='always', required=False, choices=['always', 'on_create']),
+        # setting no_log=False on update_password avoids a false positive warning about not setting no_log
+        update_password=dict(default='always', required=False, choices=['always', 'on_create'], no_log=False),
         access_key_state=dict(default=None, required=False, choices=[
             'active', 'inactive', 'create', 'remove',
             'Active', 'Inactive', 'Create', 'Remove']),


### PR DESCRIPTION
##### SUMMARY

Fix false positive `no_log` warning in `iam` module.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

iam module

##### ADDITIONAL INFORMATION

Without this fix, use of the `iam` module results in the following warning:

```
[WARNING]: Module did not set no_log for update_password
```

This is due to a false positive in the warning logic in Ansible here:

https://github.com/ansible/ansible/blob/9792d631b1b92356d41e9a792de4b2479a1bce44/lib/ansible/module_utils/basic.py#L2058-L2060

It is caused by the argument containing the phrase `password` while not setting `no_log`.