### PR TITLE
[WIP] update lamba_alias and lambda_event to use AWSModule.client()

### DIFF
--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -307,7 +307,7 @@ def lambda_alias(module, aws):
                     try:
                         results = client.update_alias(**api_params)
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                        module.fail_json(msg='Error updating function alias: {0}'.format(e))
+                        module.fail_json_aws(e, msg='Error updating function alias')
 
         else:
             # create new function alias
@@ -318,7 +318,7 @@ def lambda_alias(module, aws):
                     results = client.create_alias(**api_params)
                 changed = True
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json(msg='Error creating function alias: {0}'.format(e))
+                module.fail_json_aws(e, msg='Error creating function alias')
 
     else:  # state = 'absent'
         if current_state == 'present':
@@ -330,7 +330,7 @@ def lambda_alias(module, aws):
                     results = client.delete_alias(**api_params)
                 changed = True
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json(msg='Error deleting function alias: {0}'.format(e))
+                module.fail_json_aws(e, msg='Error deleting function alias')
 
     return dict(changed=changed, **dict(results or facts))
 

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -117,6 +117,7 @@ lambda_stream_events:
 import re
 
 try:
+    import botocore
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
@@ -124,8 +125,6 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 # ---------------------------------------------------------------------------------------------------
@@ -143,7 +142,7 @@ class AWSConnection:
     def __init__(self, ansible_obj, resources, use_boto3=True):
 
         try:
-            self.region, self.endpoint, aws_connect_kwargs = get_aws_connection_info(ansible_obj, boto3=use_boto3)
+            self.region = ansible_obj.region
 
             self.resource_client = dict()
             if not resources:
@@ -152,19 +151,14 @@ class AWSConnection:
             resources.append('iam')
 
             for resource in resources:
-                aws_connect_kwargs.update(dict(region=self.region,
-                                               endpoint=self.endpoint,
-                                               conn_type='client',
-                                               resource=resource
-                                               ))
-                self.resource_client[resource] = boto3_conn(ansible_obj, **aws_connect_kwargs)
+                self.resource_client[resource] = ansible_obj.client(resource)
 
             # if region is not provided, then get default profile/session region
             if not self.region:
                 self.region = self.resource_client['lambda'].meta.region_name
 
-        except (ClientError, ParamValidationError, MissingParametersError) as e:
-            ansible_obj.fail_json(msg="Unable to connect, authorize or access resource: {0}".format(e))
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            ansible_obj.fail_json_aws(e, msg='Failed to connect to AWS')
 
         # set account ID
         try:


### PR DESCRIPTION
##### SUMMARY

Follow up to #188 as discussed with @jillr 

Updates lamba_alias and lambda_event to use the AWSModule.client helper to get boto3 clients.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lamba_alias
lambda_event

##### ADDITIONAL INFORMATION

No tests available and the modules do something 'clever' - investigate adding Integration tests