### PR TITLE
ec2_metrics_alarm test - Create the instance in the subnet we just created

### DIFF
--- a/tests/integration/targets/ec2_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/ec2_metric_alarm/tasks/main.yml
@@ -46,6 +46,7 @@
         tags:
           TestId: "{{ resource_prefix }}"
         security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
         instance_type: t2.micro
         wait: true
       register: ec2_instance_results


### PR DESCRIPTION
##### SUMMARY

#22 exposed a bug in the test - we were silently ignoring that the SG couldn't be attached.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_metrics_alarm

##### ADDITIONAL INFORMATION

https://app.shippable.com/github/ansible-collections/community.aws/runs/655/37/console