### PR TITLE
ec2_instance - Use shared module implementation of get_ec2_security_group_ids_from_names

### DIFF
--- a/changelogs/fragments/214-get_ec2_security_group_ids_from_names.yml
+++ b/changelogs/fragments/214-get_ec2_security_group_ids_from_names.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- ec2_instance - migrate to shared implementation of get_ec2_security_group_ids_from_names.
+  The module will now return an error if the subnet provided isn't in the requested VPC.
+  (https://github.com/ansible-collections/community.aws/pull/214)


### PR DESCRIPTION
#### SUMMARY
Fixes: #213

While working on #212 we spent a lot of time trying to  debug the code in discover_security_groups.  The bulk of this code is duplicated by module_utils.ec2.get_ec2_security_group_ids_from_names().  Let's use the shared code so we'll only need to test and debug one location in future.

Side effect: Where you have a mismatch between the security groups and the VPC of the selected subnets, this will now error with a warning like "Security group sg-0d67d5f78de12f7ce and subnet subnet-3f9eb911 belong to different networks." instead of silently dropping the security group on the floor.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_instance

##### ADDITIONAL INFORMATION