### PR TITLE
aws_ssm connection plugin: add STS token parameters.

### DIFF
--- a/changelogs/fragments/25-add-sts-token-to-aws-ssm-conn-plugin.yaml
+++ b/changelogs/fragments/25-add-sts-token-to-aws-ssm-conn-plugin.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - add STS token options to aws_ssm connection plugin.
+  - aws_ssm connection plugin - add STS token options to aws_ssm connection plugin.

--- a/changelogs/fragments/25-add-sts-token-to-aws-ssm-conn-plugin.yaml
+++ b/changelogs/fragments/25-add-sts-token-to-aws-ssm-conn-plugin.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add STS token options to aws_ssm connection plugin.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #24 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add the following parameters to aws_ssm.py connection plugin:
* ansible_aws_ssm_access_key_id
* ansible_aws_ssm_secret_access_key
* ansible_aws_ssm_session_token
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
This implements some basic STS token management, that can be passed as parameters to the task when the aws_ssm connection plugin is involved, the parameters are scoped to the plugin namespace.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
If you have a role that you allowed to assume in a target account, you would need to assume such role in the target account before invoking the task; this example comes from an invocation by using ansible APIs, where even assuming the role in the target account, the connection plugin was still executing under the controller-node account session.
```paste below
flavioel/.virtualenvs/ansible_ssm/lib/python3.6/site-packages/botocore/client.py\", line 626, in _make_api_call\n    raise error_class(parsed_response, operation_name)\nbotocore.errorfactor
y.TargetNotConnected: An error occurred (TargetNotConnected) when calling the StartSession operation: i-01234567890123456 is not connected.\n",
```
By implementing the changes in this PR I am able to pass an STS token as a parameter to the task, letting it execute under the target account context.

This change also allows for backward compatibility as if nothing is specified (no OS environment variables, no parameters) the boto3 client will automatically select the `default` profile configured on the controller.