### PR TITLE
Type conversion issue for creating read replicas

### DIFF
--- a/changelogs/fragments/229-fix-type-conversion-for-creating-read-replicas.yaml
+++ b/changelogs/fragments/229-fix-type-conversion-for-creating-read-replicas.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rds_instance - fixed tag type conversion issue for creating read replicas.

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -842,8 +842,10 @@ def get_parameters(client, module, parameters, method_name):
     if parameters.get('ProcessorFeatures') == [] and not method_name == 'modify_db_instance':
         parameters.pop('ProcessorFeatures')
 
-    if method_name == 'create_db_instance' and parameters.get('Tags'):
-        parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
+    if method_name == 'create_db_instance' or method_name == 'create_db_instance_read_replica':
+        if parameters.get('Tags'):
+            parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
+        
     if method_name == 'modify_db_instance':
         parameters = get_options_with_changing_values(client, module, parameters)
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -845,7 +845,7 @@ def get_parameters(client, module, parameters, method_name):
     if method_name == 'create_db_instance' or method_name == 'create_db_instance_read_replica':
         if parameters.get('Tags'):
             parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
-        
+
     if method_name == 'modify_db_instance':
         parameters = get_options_with_changing_values(client, module, parameters)
 

--- a/tests/integration/targets/rds_instance/tasks/test_read_replica.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_read_replica.yml
@@ -39,6 +39,9 @@
           db_instance_class: "{{ db_instance_class }}"
           allocated_storage: "{{ allocated_storage }}"
           region: "{{ region_src }}"
+          tags:
+            Name: "{{ instance_id }}"
+            Created_by: Ansible rds_instance tests
           <<: *aws_connection_info
         register: source_db
 
@@ -59,8 +62,19 @@
           db_instance_class: "{{ db_instance_class }}"
           allocated_storage: "{{ allocated_storage }}"
           region: "{{ region_dest }}"
+          tags:
+            Name: "{{ instance_id }}"
+            Created_by: Ansible rds_instance tests
           <<: *aws_connection_info
         register: result
+
+      - assert:
+        that:
+          - result.changed
+          - "result.db_instance_identifier == '{{ instance_id }}'"
+          - "result.tags | length == 2"
+          - "result.tags.Name == '{{ instance_id }}'"
+          - "result.tags.Created_by == 'Ansible rds_instance tests'"
 
       - name: Test idempotence with a read replica
         rds_instance:
@@ -73,6 +87,9 @@
           db_instance_class: "{{ db_instance_class }}"
           allocated_storage: "{{ allocated_storage }}"
           region: "{{ region_dest }}"
+          tags:
+            Name: "{{ instance_id }}"
+            Created_by: Ansible rds_instance tests
           <<: *aws_connection_info
         register: result
 
@@ -92,6 +109,9 @@
           db_instance_class: "{{ db_instance_class }}"
           allocated_storage: "{{ allocated_storage }}"
           region: "{{ region_dest }}"
+          tags:
+            Name: "{{ instance_id }}"
+            Created_by: Ansible rds_instance tests
           <<: *aws_connection_info
         register: result
 

--- a/tests/integration/targets/rds_instance/tasks/test_read_replica.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_read_replica.yml
@@ -71,7 +71,7 @@
       - assert:
         that:
           - result.changed
-          - "result.db_instance_identifier == '{{ instance_id }}'"
+          - "result.db_instance_identifier == '{{ instance_id }}-replica'"
           - "result.tags | length == 2"
           - "result.tags.Name == '{{ instance_id }}'"
           - "result.tags.Created_by == 'Ansible rds_instance tests'"


### PR DESCRIPTION
##### SUMMARY

When create_db_instance is called, it converts the dict to a tag list, but this is not happening when create_db_instance_read_replica is called, which causes:
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Tags, value: **TAGS LISTED HERE**, type: <class 'dict'>, valid types: <class 'list'>, <class 'tuple'>
```
This patch just calls the same date type conversion in both cases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/rds_instance.py

##### ADDITIONAL INFORMATION
Steps to reproduce:

1. Create a postgres RDS instance, with tags using the module.
2. Create second read_replica RDS instance using the module.
