### PR TITLE
Fully support mixed instance policy

### DIFF
--- a/changelogs/fragments/232-fully-support-mixed-instances-policy.yaml
+++ b/changelogs/fragments/232-fully-support-mixed-instances-policy.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_asg module - add support for all mixed_instances_policy parameters (https://github.com/ansible-collections/community.aws/issues/231).

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -610,7 +610,6 @@ metrics_collection:
 '''
 
 import time
-import traceback
 
 try:
     import botocore
@@ -623,6 +622,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 ASG_ATTRIBUTES = ('AvailabilityZones', 'DefaultCooldown', 'DesiredCapacity',
                   'HealthCheckGracePeriod', 'HealthCheckType', 'LaunchConfigurationName',

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -620,6 +620,7 @@ from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.core import scrub_none_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -891,12 +892,7 @@ def get_launch_object(connection, ec2_connection):
                     instance_type_dict = {'InstanceType': instance_type}
                     policy['LaunchTemplate']['Overrides'].append(instance_type_dict)
             if instances_distribution:
-                instances_distribution_params = dict(
-                    (key, value)
-                    for key, value
-                    in instances_distribution.items()
-                    if value is not None
-                )
+                instances_distribution_params = scrub_none_parameters(instances_distribution)
                 policy['InstancesDistribution'] = snake_dict_to_camel_dict(instances_distribution_params, capitalize_first=True)
             launch_object['MixedInstancesPolicy'] = policy
         return launch_object

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -103,12 +103,14 @@ options:
           - 'See also U(https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html)'
         required: false
         type: dict
+        version_added: 1.5.0
         suboptions:
           on_demand_allocation_strategy:
             description:
               - Indicates how to allocate instance types to fulfill On-Demand capacity.
             type: str
             required: false
+            version_added: 1.5.0
           on_demand_base_capacity:
             description:
               - >-
@@ -119,6 +121,7 @@ options:
                 percentage of the Auto Scaling group's desired capacity, per the OnDemandPercentageAboveBaseCapacity setting.
             type: int
             required: false
+            version_added: 1.5.0
           on_demand_percentage_above_base_capacity:
             description:
               - Controls the percentages of On-Demand Instances and Spot Instances for your additional capacity beyond OnDemandBaseCapacity.
@@ -126,11 +129,13 @@ options:
               - 'Valid range: 0 to 100'
             type: int
             required: false
+            version_added: 1.5.0
           spot_allocation_strategy:
             description:
               - Indicates how to allocate instances across Spot Instance pools.
             type: str
             required: false
+            version_added: 1.5.0
           spot_instance_pools:
             description:
               - >-
@@ -140,6 +145,7 @@ options:
               - 'Valid Range: Minimum value of 1. Maximum value of 20.'
             type: int
             required: false
+            version_added: 1.5.0
           spot_max_price:
             description:
               - The maximum price per unit hour that you are willing to pay for a Spot Instance.
@@ -147,6 +153,7 @@ options:
               - To remove a value that you previously set, include the parameter but leave the value blank.
             type: str
             required: false
+            version_added: 1.5.0
     type: dict
   placement_group:
     description:

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -505,12 +505,12 @@ min_size:
     type: int
     sample: 1
 mixed_instances_policy:
-    description: Returns the list of instance types if a mixed instance policy is set.
+    description: Returns the list of instance types if a mixed instances policy is set.
     returned: success
     type: list
     sample: ["t3.micro", "t3a.micro"]
 mixed_instances_policy_full:
-    description: Returns the full dictionary representation of the mixed instances policy.
+    description: Returns the full dictionary representation of the mixed instances policy if a mixed instances policy is set.
     returned: success
     type: dict
     sample: {
@@ -827,8 +827,8 @@ def get_properties(autoscaling_group):
     properties['target_group_arns'] = autoscaling_group.get('TargetGroupARNs')
     properties['vpc_zone_identifier'] = autoscaling_group.get('VPCZoneIdentifier')
     raw_mixed_instance_object = autoscaling_group.get('MixedInstancesPolicy')
-    properties['mixed_instances_policy_full'] = camel_dict_to_snake_dict(autoscaling_group.get('MixedInstancesPolicy'))
     if raw_mixed_instance_object:
+        properties['mixed_instances_policy_full'] = camel_dict_to_snake_dict(raw_mixed_instance_object)
         properties['mixed_instances_policy'] = [x['InstanceType'] for x in raw_mixed_instance_object.get('LaunchTemplate').get('Overrides')]
 
     metrics = autoscaling_group.get('EnabledMetrics')

--- a/tests/integration/targets/ec2_asg/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg/tasks/main.yml
@@ -629,7 +629,7 @@
       until: status is finished
       retries: 200
       delay: 15
-    
+
     # we need a launch template, otherwise we cannot test the mixed instance policy
     - name: create launch template for autoscaling group to test its mixed instance policy
       ec2_launch_template:
@@ -648,7 +648,7 @@
     - name: update autoscaling group with mixed-instance policy
       ec2_asg:
         name: "{{ resource_prefix }}-asg"
-        launch_template: 
+        launch_template:
           launch_template_name: "{{ resource_prefix }}-lt"
         desired_capacity: 1
         min_size: 1
@@ -659,14 +659,18 @@
           instance_types:
             - t3.micro
             - t3a.micro
+          instances_distribution:
+            on_demand_percentage_above_base_capacity: 0
+            spot_allocation_strategy: capacity-optimized
         wait_for_instances: yes
       register: output
 
     - assert:
         that:
-          - "output.mixed_instances_policy | length == 2"
-          - "output.mixed_instances_policy[0] == 't3.micro'"
-          - "output.mixed_instances_policy[1] == 't3a.micro'"
+          - "output.mixed_instances_policy['LaunchTemplate']['Overrides'][0]['InstanceType'] == 't3.micro'"
+          - "output.mixed_instances_policy['LaunchTemplate']['Overrides'][1]['InstanceType'] == 't3a.micro'"
+          - "output.mixed_instances_policy['InstancesDistribution']['OnDemandPercentageAboveBaseCapacity'] == 0"
+          - "output.mixed_instances_policy['InstancesDistribution']['SpotallocationStrategy'] == 'capacity-optimized'"
 
 # ============================================================
 

--- a/tests/integration/targets/ec2_asg/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg/tasks/main.yml
@@ -631,7 +631,7 @@
       delay: 15
 
     # we need a launch template, otherwise we cannot test the mixed instance policy
-    - name: create launch template for autoscaling group to test its mixed instance policy
+    - name: create launch template for autoscaling group to test its mixed instances policy
       ec2_launch_template:
         template_name: "{{ resource_prefix }}-lt"
         image_id: "{{ ec2_ami_image }}"
@@ -645,7 +645,30 @@
             groups:
               - "{{ sg.group_id }}"
 
-    - name: update autoscaling group with mixed-instance policy
+    - name: update autoscaling group with mixed-instances policy with mixed instances types
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        mixed_instances_policy:
+          instance_types:
+            - t3.micro
+            - t3a.micro
+        wait_for_instances: yes
+      register: output
+
+    - assert:
+        that:
+          - "output.mixed_instances_policy | length == 2"
+          - "output.mixed_instances_policy[0] == 't3.micro'"
+          - "output.mixed_instances_policy[1] == 't3a.micro'"
+
+    - name: update autoscaling group with mixed-instances policy with instances_distribution
       ec2_asg:
         name: "{{ resource_prefix }}-asg"
         launch_template:
@@ -667,10 +690,10 @@
 
     - assert:
         that:
-          - "output.mixed_instances_policy['LaunchTemplate']['Overrides'][0]['InstanceType'] == 't3.micro'"
-          - "output.mixed_instances_policy['LaunchTemplate']['Overrides'][1]['InstanceType'] == 't3a.micro'"
-          - "output.mixed_instances_policy['InstancesDistribution']['OnDemandPercentageAboveBaseCapacity'] == 0"
-          - "output.mixed_instances_policy['InstancesDistribution']['SpotallocationStrategy'] == 'capacity-optimized'"
+          - "output.mixed_instances_policy_full['launch_template']['overrides'][0]['instance_type'] == 't3.micro'"
+          - "output.mixed_instances_policy_full['launch_template']['overrides'][1]['instance_type'] == 't3a.micro'"
+          - "output.mixed_instances_policy_full['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0"
+          - "output.mixed_instances_policy_full['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'"
 
 # ============================================================
 


### PR DESCRIPTION
##### SUMMARY

Previously, setting instances_distribution was not supported.
instances_distribution should be supported, to allow users to enable
spot instances within their mixed instance ASGs.

Note: The type and significance of the mixed_instance_policy has
changed. It now captures all of the mixed_instance_policy configuration
parameters, rather than just a list of instance types.

Fixes #231


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ec2_asg
