### PR TITLE
Fix timeout and Windows AMI in aws_ssm

### DIFF
--- a/changelogs/fragments/234-fix_ssm_inventory_plugin_timeout_var.yaml
+++ b/changelogs/fragments/234-fix_ssm_inventory_plugin_timeout_var.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_ssm connection plugin - Change the (internal) variable name from timeout to plugin_timeout to avoid conflicts with ansible/ansible default timeout (#69284, #71722). Developers subclassing this plugin will need to update accordingly.

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -59,7 +59,7 @@ options:
     type: integer
     vars:
     - name: ansible_aws_ssm_retries
-  timeout:
+  ssm_timeout:
     description: Connection timeout seconds.
     default: 60
     type: integer
@@ -373,7 +373,7 @@ class Connection(ConnectionBase):
         stdout = ''
         win_line = ''
         begin = False
-        stop_time = int(round(time.time())) + self.get_option('timeout')
+        stop_time = int(round(time.time())) + self.get_option('ssm_timeout')
         while session.poll() is None:
             remaining = stop_time - int(round(time.time()))
             if remaining < 1:

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/defaults/main.yml
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 instance_type: t2.micro
 linux_ami_name: amzn-ami-hvm-2018.03.0.20190611-x86_64-ebs
-windows_ami_name: Windows_Server-2019-English-Full-Base-2019.11.13
+# Windows AMIs get replaced every few months, don't be too specific
+windows_ami_name: Windows_Server-2019-English-Full-Base-*


### PR DESCRIPTION
##### SUMMARY

Windows AMIs get replaced every few months, don't be specific with image name

Task timeout feature in ansible-base (#69284) resulted in timeout key not being
properly passed to plugins. This was fixed in (#71722). The intent for the
timeout option in this plugin is to not use Ansible's default timeout however,
but to defer to the inventory var:
https://github.com/ansible/ansible/pull/49652/commits/44f1427507d588d2748c7db34e590234de661564
Rename this internal value from `timeout` to `plugin_timeout`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ssm
