### PR TITLE
 aws_ssm: Namespace S3 buckets and delete transferred files

### DIFF
--- a/changelogs/fragments/221_222_ssm_bucket_operations.yaml
+++ b/changelogs/fragments/221_222_ssm_bucket_operations.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm connection plugin - namespace file uploads to S3 into unique folders per host, to prevent name collisions. Also deletes files from S3 to ensure temp files are not left behind. (https://github.com/ansible-collections/community.aws/issues/221, https://github.com/ansible-collections/community.aws/issues/222)

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -522,7 +522,8 @@ class Connection(ConnectionBase):
     def _file_transport_command(self, in_path, out_path, ssm_action):
         ''' transfer a file from using an intermediate S3 bucket '''
 
-        s3_path = out_path.replace('\\', '/')
+        path_unescaped = "{0}/{1}".format(self.instance_id, out_path)
+        s3_path = path_unescaped.replace('\\', '/')
         bucket_url = 's3://%s/%s' % (self.get_option('bucket_name'), s3_path)
 
         if self.is_windows:
@@ -545,6 +546,9 @@ class Connection(ConnectionBase):
             with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as data:
                 client.upload_fileobj(data, self.get_option('bucket_name'), s3_path)
             (returncode, stdout, stderr) = self.exec_command(get_command, in_data=None, sudoable=False)
+
+        # Remove the files from the bucket after they've been transferred
+        client.delete_object(Bucket=self.get_option('bucket_name'), Key=s3_path)
 
         # Check the return code
         if returncode == 0:


### PR DESCRIPTION
##### SUMMARY

Files transferred to instances via the SSM connection plugin should use folders within the bucket that are namespaced per-host, to prevent collisions. Files should also be deleted from buckets when they are no longer required.
    
Fixes: #221
Fixes: #222
    
Based on work by @abeluck

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/aws_ssm.py