### PR TITLE
ecs_taskdefitinion: Fix wrong element type

### DIFF
--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -47,7 +47,7 @@ options:
             - A list of containers definitions.
         required: False
         type: list
-        elements: str
+        elements: dict
     network_mode:
         description:
             - The Docker networking mode to use for the containers in the task.
@@ -321,7 +321,7 @@ def main():
         family=dict(required=False, type='str'),
         revision=dict(required=False, type='int'),
         force_create=dict(required=False, default=False, type='bool'),
-        containers=dict(required=False, type='list', elements='str'),
+        containers=dict(required=False, type='list', elements='dict'),
         network_mode=dict(required=False, default='bridge', choices=['default', 'bridge', 'host', 'none', 'awsvpc'], type='str'),
         task_role_arn=dict(required=False, default='', type='str'),
         execution_role_arn=dict(required=False, default='', type='str'),

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -45,6 +45,8 @@ options:
     containers:
         description:
             - A list of containers definitions.
+            - 'A full list of options can be found in the boto3 docs in the containerDefinitions argument to register_task_definition:
+              U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.register_task_definition)'
         required: False
         type: list
         elements: dict


### PR DESCRIPTION
##### SUMMARY

- `ecs_taskdefitinion` does not work after merged #133 
- `containers` element type shold `dict`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ecs_taskdefinition`

##### ADDITIONAL INFORMATION

error when run `ecs_taskdefinition`

```console
TASK [deploy/webapp : create task definition] ******************************************************
task path: /path/to/deploy/webapp/tasks/www.yml:10

...

The full traceback is:
Traceback (most recent call last):
  File "/Users/<user>/.ansible/tmp/ansible-tmp-1600850639.118408-95080-187819148890793/AnsiballZ_ecs_taskdefinition.py", line 102, in <module>
    _ansiballz_main()
  File "/Users/<user>/.ansible/tmp/ansible-tmp-1600850639.118408-95080-187819148890793/AnsiballZ_ecs_taskdefinition.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/Users/<user>/.ansible/tmp/ansible-tmp-1600850639.118408-95080-187819148890793/AnsiballZ_ecs_taskdefinition.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.ecs_taskdefinition', init_globals=None, run_name='__main__', alter_sys=True)
  File "/opt/homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/opt/homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/opt/homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/var/folders/20/brt9b12j21z5bxhcwfxkz3zc0000gp/T/ansible_ecs_taskdefinition_payload_ul4226u4/ansible_ecs_taskdefinition_payload.zip/ansible_collections/community/aws/plugins/modules/ecs_taskdefinition.py", line 517, in <module>
  File "/var/folders/20/brt9b12j21z5bxhcwfxkz3zc0000gp/T/ansible_ecs_taskdefinition_payload_ul4226u4/ansible_ecs_taskdefinition_payload.zip/ansible_collections/community/aws/plugins/modules/ecs_taskdefinition.py", line 353, in main
AttributeError: 'str' object has no attribute 'get'
fatal: [localhost]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/Users/<user>/.ansible/tmp/ansible-tmp-1600850639.118408-95080-187819148890793/AnsiballZ_ecs_taskdefinition.py", line 102, in <module>
        _ansiballz_main()
      File "/Users/<user>/.ansible/tmp/ansible-tmp-1600850639.118408-95080-187819148890793/AnsiballZ_ecs_taskdefinition.py", line 94, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/<user>/.ansible/tmp/ansible-tmp-1600850639.118408-95080-187819148890793/AnsiballZ_ecs_taskdefinition.py", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.ecs_taskdefinition', init_globals=None, run_name='__main__', alter_sys=True)
      File "/opt/homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 207, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/opt/homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/opt/homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/var/folders/20/brt9b12j21z5bxhcwfxkz3zc0000gp/T/ansible_ecs_taskdefinition_payload_ul4226u4/ansible_ecs_taskdefinition_payload.zip/ansible_collections/community/aws/plugins/modules/ecs_taskdefinition.py", line 517, in <module>
      File "/var/folders/20/brt9b12j21z5bxhcwfxkz3zc0000gp/T/ansible_ecs_taskdefinition_payload_ul4226u4/ansible_ecs_taskdefinition_payload.zip/ansible_collections/community/aws/plugins/modules/ecs_taskdefinition.py", line 353, in main
    AttributeError: 'str' object has no attribute 'get'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```
