### PR TITLE
Add source_version param to ec2_launch_template module

### DIFF
--- a/changelogs/fragments/239-launch_template-source-version.yml
+++ b/changelogs/fragments/239-launch_template-source-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_launch_template - Adds support for specifying the ``source_version`` upon which template updates are based (https://github.com/ansible-collections/community.aws/pull/239).

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -313,6 +313,13 @@ options:
       For any VPC other than Default, you must use I(security_group_ids).
     type: list
     elements: str
+  source_version:
+    description: >
+      The version number of the launch template version on which to base the new version.
+      The new version inherits the same launch parameters as the source version, except for parameters that you explicity specify.
+      Snapshots applied to the block device mapping are ignored when creating a new version unless they are explicitly included.
+    type: str
+    default: latest
   tags:
     type: dict
     description:

--- a/tests/integration/targets/ec2_launch_template/tasks/versions.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/versions.yml
@@ -51,6 +51,24 @@
         - lt.default_version == 3
         - lt.latest_version == 3
 
+  - name: create new template version based on an old version
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-simple"
+      cpu_options:
+          core_count: 1
+          threads_per_core: 1
+      source_version: 1
+    register: lt
+
+  - name: instance with cpu_options created with the right options
+    assert:
+      that:
+        - lt is success
+        - lt is changed
+        - lt.default_version == 4
+        - lt.latest_version == 4
+        - lt.latest_template.launch_template_data.instance_type == "c4.large"
+
   always:
   - name: delete the template
     ec2_launch_template:


### PR DESCRIPTION
##### SUMMARY
Add support for Boto3.create_launch_template_version's source_version parameter.

Accepted values:

- int (specific version) : Creates a new launch template using this version as the base, hence keeping all its parameters
- string ( 'latest') : Uses the latest found in list template_versions

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

ec2_launch_template.py

##### ADDITIONAL INFORMATION

Sanity tests passed for this module.
