### PR TITLE
rds_instance: Set no_log=False on force_update_password

### DIFF
--- a/changelogs/fragments/244-rds_instance-no_log.yml
+++ b/changelogs/fragments/244-rds_instance-no_log.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- rds_instance - set ``no_log=False`` on ``force_update_password`` to clear warning (https://github.com/ansible-collections/community.aws/issues/241)
+- rds_instance - set ``no_log=False`` on ``force_update_password`` to clear warning (https://github.com/ansible-collections/community.aws/issues/241).

--- a/changelogs/fragments/244-rds_instance-no_log.yml
+++ b/changelogs/fragments/244-rds_instance-no_log.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- rds_instance - set ``no_log=False`` on ``force_update_password`` to clear warning (https://github.com/ansible-collections/community.aws/issues/241)

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1078,7 +1078,7 @@ def main():
     arg_spec = dict(
         state=dict(choices=['present', 'absent', 'terminated', 'running', 'started', 'stopped', 'rebooted', 'restarted'], default='present'),
         creation_source=dict(choices=['snapshot', 's3', 'instance']),
-        force_update_password=dict(type='bool', default=False),
+        force_update_password=dict(type='bool', default=False, no_log=False),
         purge_cloudwatch_logs_exports=dict(type='bool', default=True),
         purge_tags=dict(type='bool', default=True),
         read_replica=dict(type='bool'),


### PR DESCRIPTION
##### SUMMARY

Because force_update_password doesn't contain sensitive information (but matches the pattern "password") we need to explicitly set no_log=False to avoid a warning for users.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rds_instance

##### ADDITIONAL INFORMATION

fixes: #241 