### PR TITLE
Fix container param typing

### DIFF
--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -44,10 +44,10 @@ options:
         type: bool
     containers:
         description:
-            - A list of containers definitions.
+            - A list of containers definitions.  You can find the full list of options in the boto3 docs.
         required: False
         type: list
-        elements: str
+        elements: dict
     network_mode:
         description:
             - The Docker networking mode to use for the containers in the task.
@@ -321,7 +321,7 @@ def main():
         family=dict(required=False, type='str'),
         revision=dict(required=False, type='int'),
         force_create=dict(required=False, default=False, type='bool'),
-        containers=dict(required=False, type='list', elements='str'),
+        containers=dict(required=False, type='list', elements='dict'),
         network_mode=dict(required=False, default='bridge', choices=['default', 'bridge', 'host', 'none', 'awsvpc'], type='str'),
         task_role_arn=dict(required=False, default='', type='str'),
         execution_role_arn=dict(required=False, default='', type='str'),


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The container param was incorrectly set as a STR.  Updated to correct type of DICT.
Additionally added some additional text to docs to assist in finding potential container options

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_taskdefinition

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
- name: Deploy taskdef
  hosts: localhost
  tasks:
    - name: Create task definition
      run_once: true
      ecs_taskdefinition:
        force_create: true
        family: nginx
        state: present
        launch_type: FARGATE
        cpu: 2048
        memory: 4096
        network_mode: awsvpc
        containers:
          - name: nginx
            essential: true
            image: "nginx"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'str' object has no attribute 'get'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "rc": 1
}

MSG:

MODULE FAILURE
See stdout/stderr for the exact error


MODULE_STDERR:

Traceback (most recent call last):
  File "<stdin>", line 102, in <module>
  File "<stdin>", line 94, in _ansiballz_main
  File "<stdin>", line 40, in invoke_module
  File "/Users/user/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/Users/user/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/Users/user/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/var/folders/ky/_q58mhx922v_6h35pl4p57bc0000gn/T/ansible_ecs_taskdefinition_payload_7kb3qm_a/ansible_ecs_taskdefinition_payload.zip/ansible_collections/community/aws/plugins/modules/ecs_taskdefinition.py", line 517, in <module>
  File "/var/folders/ky/_q58mhx922v_6h35pl4p57bc0000gn/T/ansible_ecs_taskdefinition_payload_7kb3qm_a/ansible_ecs_taskdefinition_payload.zip/ansible_collections/community/aws/plugins/modules/ecs_taskdefinition.py", line 353, in main
AttributeError: 'str' object has no attribute 'get'

```

After applying fix, error resolved and taskdef was corrected successfully