### PR TITLE
Add test requirement for botocore 1.13.3, to support ECR scanning

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,4 @@
 # netaddr is needed for ansible.netcommon.ipv6
 netaddr
 virtualenv
+botocore >= 1.13.3 ; python_version >= '2.7' # adds support for ECR image scanning


### PR DESCRIPTION
##### SUMMARY
Add integration test requirement for botocore 1.13.3; container image for testing 2.9 does not have a new enough boto for #248

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/requirements.txt
