### PR TITLE
Extending aws_s3_bucket_info module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,4 +387,7 @@ $RECYCLE.BIN/
 # Antsibull-changelog
 changelogs/.plugin-cache.yaml
 
+# Visual Studio Code
+.vscode/*
+
 # End of https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -804,3 +804,5 @@ releases:
       name: s3_metrics_configuration
       namespace: ''
     release_date: '2020-12-10'
+      minor_changes:
+      - aws_s3_bucket_info - new module options ``name:``, ``name_filter``, ``bucket_facts`` and ``transform_location`` (https://github.com/ansible-collections/community.aws/pull/260).

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -775,7 +775,7 @@ releases:
         behavior (https://github.com/ansible-collections/community.aws/pull/318).
       minor_changes:
       - ec2_vpc_igw - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
-      - ec2_vpc_igw - Add ``purge_tags`` parameter so that tags can be added without
+      - ec2_vpc_igw - Add ``purge_tagsminor_changes:`` parameter so that tags can be added without
         purging existing tags to match the collection standard tagging behaviour (https://github.com/ansible-collections/community.aws/pull/318).
       - ec2_vpc_igw_info - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
       - ec2_vpc_igw_info - Add ``convert_tags`` parameter so that tags can be returned
@@ -785,8 +785,6 @@ releases:
       - redshift - add support for setting tags.
       - s3_lifecycle - Add support for intelligent tiering and deep archive storage
         classes (https://github.com/ansible-collections/community.aws/issues/270)
-      - aws_s3_bucket_info - new module options ``name:``, ``name_filter``, ``bucket_facts`` and ``transform_location`` 
-        (https://github.com/ansible-collections/community.aws/pull/260).
     fragments:
     - 244-rds_instance-no_log.yml
     - 264-fix-elemt-type-for-containers-in-ecs_taskdefinition.yml

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -785,7 +785,8 @@ releases:
       - redshift - add support for setting tags.
       - s3_lifecycle - Add support for intelligent tiering and deep archive storage
         classes (https://github.com/ansible-collections/community.aws/issues/270)
-      - aws_s3_bucket_info - new module options ``name:``, ``name_filter``, ``bucket_facts`` and ``transform_location`` (https://github.com/ansible-collections/community.aws/pull/260).
+      - aws_s3_bucket_info - new module options ``name:``, ``name_filter``, ``bucket_facts`` and ``transform_location`` 
+        (https://github.com/ansible-collections/community.aws/pull/260).
     fragments:
     - 244-rds_instance-no_log.yml
     - 264-fix-elemt-type-for-containers-in-ecs_taskdefinition.yml

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -785,6 +785,7 @@ releases:
       - redshift - add support for setting tags.
       - s3_lifecycle - Add support for intelligent tiering and deep archive storage
         classes (https://github.com/ansible-collections/community.aws/issues/270)
+      - aws_s3_bucket_info - new module options ``name:``, ``name_filter``, ``bucket_facts`` and ``transform_location`` (https://github.com/ansible-collections/community.aws/pull/260).
     fragments:
     - 244-rds_instance-no_log.yml
     - 264-fix-elemt-type-for-containers-in-ecs_taskdefinition.yml

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -775,7 +775,7 @@ releases:
         behavior (https://github.com/ansible-collections/community.aws/pull/318).
       minor_changes:
       - ec2_vpc_igw - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
-      - ec2_vpc_igw - Add ``purge_tags:`` parameter so that tags can be added without
+      - ec2_vpc_igw - Add ``purge_tags`` parameter so that tags can be added without
         purging existing tags to match the collection standard tagging behaviour (https://github.com/ansible-collections/community.aws/pull/318).
       - ec2_vpc_igw_info - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
       - ec2_vpc_igw_info - Add ``convert_tags`` parameter so that tags can be returned

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -804,5 +804,3 @@ releases:
       name: s3_metrics_configuration
       namespace: ''
     release_date: '2020-12-10'
-      minor_changes:
-      - aws_s3_bucket_info - new module options ``name:``, ``name_filter``, ``bucket_facts`` and ``transform_location`` (https://github.com/ansible-collections/community.aws/pull/260).

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -775,7 +775,7 @@ releases:
         behavior (https://github.com/ansible-collections/community.aws/pull/318).
       minor_changes:
       - ec2_vpc_igw - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
-      - ec2_vpc_igw - Add ``purge_tagsminor_changes:`` parameter so that tags can be added without
+      - ec2_vpc_igw - Add ``purge_tags:`` parameter so that tags can be added without
         purging existing tags to match the collection standard tagging behaviour (https://github.com/ansible-collections/community.aws/pull/318).
       - ec2_vpc_igw_info - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
       - ec2_vpc_igw_info - Add ``convert_tags`` parameter so that tags can be returned

--- a/changelogs/fragments/260-extending-s3_bucket_info-module.yml
+++ b/changelogs/fragments/260-extending-s3_bucket_info-module.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - aws_s3_bucket_info - new module options ``name``, ``name_filter``, ``bucket_facts`` and ``transform_location``
+    (https://github.com/ansible-collections/community.aws/pull/260).

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
-# Copyright (c) 2017 Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Copyright (c) 2017 Ansible Project
+GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -10,6 +12,7 @@ DOCUMENTATION = '''
 ---
 module: aws_s3_bucket_info
 version_added: 1.0.0
+author: "Gerben Geijteman (@hyperized)"
 short_description: Lists S3 buckets in AWS
 requirements:
   - boto3 >= 1.4.4
@@ -18,7 +21,101 @@ description:
     - Lists S3 buckets in AWS
     - This module was called C(aws_s3_bucket_facts) before Ansible 2.9, returning C(ansible_facts).
       Note that the M(community.aws.aws_s3_bucket_info) module no longer returns C(ansible_facts)!
-author: "Gerben Geijteman (@hyperized)"
+options:
+  name:
+    description:
+      - Get info about specified bucket
+    type: str
+    default: ""
+  name_filter:
+    description:
+      - Get info about buckets name matching defined string
+    type: str
+    default: ""
+  bucket_facts:
+    description:
+      - Retrieve requested S3 bucket detailed information
+    suboptions:
+      bucket_accelerate_configuration:
+        description: Retrive S3 bucket accelerate configuration
+        type: bool
+        default: False
+      bucket_location:
+        description: Retrive S3 bucket location
+        type: bool
+        default: False
+      bucket_replication:
+        description: Retrive S3 bucket replication
+        type: bool
+        default: False
+      bucket_acl:
+        description: Retrive S3 bucket ACLs
+        type: bool
+        default: False
+      bucket_logging:
+        description: Retrive S3 bucket logging
+        type: bool
+        default: False
+      bucket_request_payment:
+        description: Retrive S3 bucket request payment
+        type: bool
+        default: False
+      bucket_analytics_configuration:
+        description: Retrive S3 bucket analytics configuration
+        type: bool
+        default: False
+      bucket_metrics_configuration:
+        description: Retrive S3 bucket metrics configuration
+        type: bool
+        default: False
+      bucket_tagging:
+        description: Retrive S3 bucket tagging
+        type: bool
+        default: False
+      bucket_cors:
+        description: Retrive S3 bucket CORS configuration
+        type: bool
+        default: False
+      bucket_notification_configuration:
+        description: Retrive S3 bucket notification configuration
+        type: bool
+        default: False
+      bucket_encryption:
+        description: Retrive S3 bucket encryption
+        type: bool
+        default: False
+      bucket_ownership_controls:
+        description: Retrive S3 ownership controls
+        type: bool
+        default: False
+      bucket_website:
+        description: Retrive S3 bucket website
+        type: bool
+        default: False
+      bucket_inventory_configuration:
+        description: Retrive S3 bucket inventory configuration
+        type: bool
+        default: False
+      bucket_policy:
+        description: Retrive S3 bucket policy
+        type: bool
+        default: False
+      bucket_policy_status:
+        description: Retrive S3 bucket policy status
+        type: bool
+        default: False
+      bucket_lifecycle_configuration:
+        description: Retrive S3 bucket lifecycle configuration
+        type: bool
+        default: False
+    type: dict
+  transform_location:
+    description:
+      - S3 bucket location for default us-east-1 is normally reported as 'null'
+      - setting this option to 'true' will return 'us-east-1' instead
+    type: bool
+    default: False
+
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -59,19 +156,109 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
 
-def get_bucket_list(module, connection):
+def get_bucket_list(module, connection, name="", name_filter=""):
     """
     Return result of list_buckets json encoded
+    Filter only buckets matching 'name' or name_filter if defined
     :param module:
     :param connection:
     :return:
     """
+    buckets = []
+    filtered_buckets = []
+    final_buckets = []
+    # Get all buckets
     try:
         buckets = camel_dict_to_snake_dict(connection.list_buckets())['buckets']
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to list buckets")
 
-    return buckets
+    # Filter buckets if requested
+    if name_filter:
+        for bucket in buckets:
+            if name_filter in bucket['name']:
+                filtered_buckets.append(bucket)
+    elif name:
+        for bucket in buckets:
+            if name == bucket['name']:
+                filtered_buckets.append(bucket)
+
+    # Return proper list (filtered or all)
+    if filtered_buckets:
+        final_buckets = filtered_buckets
+    else:
+        final_buckets = buckets
+    return(final_buckets)
+
+
+def get_buckets_facts(connection, buckets, requested_facts, transform_location):
+    """
+    Retrive additional information about S3 buckets
+    """
+    full_bucket_list = []
+    # Iterate over all buckets and append retrived facts to bucket
+    for bucket in buckets:
+        bucket.update(get_bucket_details(connection, bucket['name'], requested_facts, transform_location))
+        full_bucket_list.append(bucket)
+
+    return(full_bucket_list)
+
+
+def get_bucket_details(connection, name, requested_facts, transform_location):
+    """
+    Execute all enabled S3API get calls for selected bucket
+    """
+    all_facts = {}
+
+    for key in requested_facts:
+        if requested_facts[key]:
+            if key == 'bucket_location':
+                all_facts[key] = get_bucket_location(name, connection, transform_location)
+            else:
+                all_facts[key] = get_bucket_property(name, connection, key)
+
+    return(all_facts)
+
+
+def get_bucket_location(name, connection, transform_location=False):
+    """
+    Get bucket location and optionally transform 'null' to 'us-east-1'
+    """
+    try:
+        data = connection.get_bucket_location(Bucket=name)
+    except botocore.exceptions.ClientError as err_msg:
+        data = {'error': err_msg}
+
+    if transform_location:
+        try:
+            if not data['LocationConstraint']:
+                data['LocationConstraint'] = 'us-east-1'
+        except KeyError:
+            data['transform_failed'] = True
+
+    try:
+        data.pop('ResponseMetadata')
+        return(data)
+    except KeyError:
+        return(data)
+
+
+def get_bucket_property(name, connection, get_api_name):
+    """
+    Get bucket property
+    """
+    api_call = "get_" + get_api_name
+    api_function = getattr(connection, api_call)
+    try:
+        data = api_function(Bucket=name)
+    except botocore.exceptions.ClientError as err_msg:
+        data = {'error': err_msg}
+
+    try:
+        data.pop('ResponseMetadata')
+        return(data)
+    except KeyError:
+        return(data)
 
 
 def main():
@@ -80,24 +267,65 @@ def main():
     :return:
     """
 
+    argument_spec = dict(
+        name=dict(type=str, default=""),
+        name_filter=dict(type=str, default=""),
+        bucket_facts=dict(type='dict', options=dict(
+            bucket_accelerate_configuration=dict(type=bool, default=False),
+            bucket_acl=dict(type=bool, default=False),
+            bucket_analytics_configuration=dict(type=bool, default=False),
+            bucket_cors=dict(type=bool, default=False),
+            bucket_encryption=dict(type=bool, default=False),
+            bucket_inventory_configuration=dict(type=bool, default=False),
+            bucket_lifecycle_configuration=dict(type=bool, default=False),
+            bucket_location=dict(type=bool, default=False),
+            bucket_logging=dict(type=bool, default=False),
+            bucket_metrics_configuration=dict(type=bool, default=False),
+            bucket_notification_configuration=dict(type=bool, default=False),
+            bucket_ownership_controls=dict(type=bool, default=False),
+            bucket_policy=dict(type=bool, default=False),
+            bucket_policy_status=dict(type=bool, default=False),
+            bucket_replication=dict(type=bool, default=False),
+            bucket_request_payment=dict(type=bool, default=False),
+            bucket_tagging=dict(type=bool, default=False),
+            bucket_website=dict(type=bool, default=False),
+            )),
+        transform_location=dict(type='bool', default=False)
+    )
+
+
     # Ensure we have an empty dict
     result = {}
 
     # Including ec2 argument spec
-    module = AnsibleAWSModule(argument_spec={}, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
                          "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
 
+    # Get parameters
+    name = module.params.get("name")
+    name_filter = module.params.get("name_filter")
+    requested_facts = module.params.get("bucket_facts")
+    transform_location = module.params.get("bucket_facts")
+
     # Set up connection
+    connection = {}
     try:
         connection = module.client('s3')
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    except (connection.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Failed to connect to AWS')
 
-    # Gather results
-    result['buckets'] = get_bucket_list(module, connection)
+    # Get basic bucket list (name + creation date)
+    bucket_list = get_bucket_list(module, connection, name, name_filter)
+
+    # Gather detailed information about buckets if requested
+    bucket_facts = module.params.get("bucket_facts")
+    if bucket_facts:
+        result['buckets'] = get_buckets_facts(connection, bucket_list, requested_facts, transform_location)
+    else:
+        result['buckets'] = bucket_list
 
     # Send exit
     if is_old_facts:

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -312,8 +312,8 @@ def main():
     :return:
     """
     argument_spec = dict(
-        name=dict(type=str, default=""),
-        name_filter=dict(type=str, default=""),
+        name=dict(type='str', default=""),
+        name_filter=dict(type='str', default=""),
         bucket_facts=dict(type='dict', options=dict(
             bucket_accelerate_configuration=dict(type='bool', default=False),
             bucket_acl=dict(type='bool', default=False),

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -252,151 +252,151 @@ bucket_list:
               returned: when encryption is enabled on the bucket
               type: list
               sample: { "ApplyServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" }, "BucketKeyEnabled": False }
-      bucket_lifecycle_configuration:
-        description: Bucket lifecycle configuration settings.
-        returned: when I(bucket_facts=true) and I(bucket_lifecycle_configuration=true)
-        type: complex
-        contains:
-          Rules:
-            description: List of lifecycle management rules.
-            returned: when lifecycle configuration is present
-            type: list
-            sample: [{ "Status": "Enabled", "ID": "example-rule" }]
-      bucket_location:
-        description: Bucket location.
-        returned: when I(bucket_facts=true) and I(bucket_location=true)
-        type: complex
-        contains:
-          LocationConstraint:
-            description: AWS region.
-            returned: always
-            type: str
-            sample: us-east-2
-      bucket_logging:
-        description: Server access logging configuration.
-        returned: when I(bucket_facts=true) and I(bucket_logging=true)
-        type: complex
-        contains:
-          LoggingEnabled:
-            description: Server access logging configuration.
-            returned: when server access logging is defined for the bucket
-            type: complex
-            contains:
-              TargetBucket:
-                description: Target bucket name.
-                returned: always
-                type: str
-                sample: logging-bucket-name
-              TargetPrefix:
-                description: Prefix in target bucket.
-                returned: always
-                type: str
-                sample: ""
-      bucket_notification_configuration:
-        description: Bucket notification settings.
-        returned: when I(bucket_facts=true) and I(bucket_notification_configuration=true)
-        type: complex
-        contains:
-          TopicConfigurations:
-            description: List of notification events configurations.
-            returned: when at least one notification is configured
-            type: list
-            sample: []
-      bucket_ownership_controls:
-        description: Preffered object ownership settings.
-        returned: when I(bucket_facts=true) and I(bucket_ownership_controls=true)
-        type: complex
-        contains:
-          OwnershipControls:
-            description: Object ownership settings.
-            returned: when ownership controls are defined for the bucket
-            type: complex
-            contains:
-              Rules:
-                description: List of ownership rules.
-                returned: when ownership rule is defined
-                type: list
-                sample: [{ "ObjectOwnership:": "ObjectWriter" }]
-      bucket_policy:
-        description: Bucket policy contents.
-        returned: when I(bucket_facts=true) and I(bucket_policy=true)
-        type: str
-        sample: '{"Version":"2012-10-17","Statement":[{"Sid":"AddCannedAcl","Effect":"Allow",..}}]}'
-      bucket_policy_status:
-        description: Status of bucket policy.
-        returned: when I(bucket_facts=true) and I(bucket_policy_status=true)
-        type: complex
-        contains:
-          PolicyStatus:
-            description: Status of bucket policy.
-            returned: when bucket policy is present
-            type: complex
-            contains:
-              IsPublic:
-                description: Report bucket policy public status.
-                returned: when bucket policy is present
-                type: bool
-                sample: True
-      bucket_replication:
-        description: Replication configuration settings.
-        returned: when I(bucket_facts=true) and I(bucket_replication=true)
-        type: complex
-        contains:
-          Role:
-            description: IAM role used for replication.
-            returned: when replication rule is defined
-            type: str
-            sample: "arn:aws:iam::123:role/example-role"
-          Rules:
-            description: List of replication rules.
-            returned: when replication rule is defined
-            type: list
-            sample: [{ "ID": "rule-1", "Filter": "{}" }]
-      bucket_request_payment:
-        description: Requester pays setting.
-        returned: when I(bucket_facts=true) and I(bucket_request_payment=true)
-        type: complex
-        contains:
-          Payer:
-            description: Current payer.
-            returned: always
-            type: str
-            sample: BucketOwner
-      bucket_tagging:
-        description: Bucket tags.
-        returned: when I(bucket_facts=true) and I(bucket_tagging=true)
-        type: dict
-        sample: { "Tag1": "Value1", "Tag2": "Value2" }
-      bucket_website:
-        description: Static website hosting.
-        returned: when I(bucket_facts=true) and I(bucket_website=true)
-        type: complex
-        contains:
-          ErrorDocument:
-            description: Object serving as HTTP error page.
-            returned: when static website hosting is enabled
-            type: dict
-            sample: { "Key": "error.html" }
-          IndexDocument:
-            description: Object serving as HTTP index page.
-            returned: when static website hosting is enabled
-            type: dict
-            sample: { "Suffix": "error.html" }
-          RedirectAllRequestsTo:
-            description: Website redict settings.
-            returned: when redirect requests is configured
-            type: complex
-            contains:
-              HostName:
-                description: Hostname to redirect.
-                returned: always
-                type: str
-                sample: www.example.com
-              Protocol:
-                description: Protocol used for redirect.
-                returned: always
-                type: str
-                sample: https
+    bucket_lifecycle_configuration:
+      description: Bucket lifecycle configuration settings.
+      returned: when I(bucket_facts=true) and I(bucket_lifecycle_configuration=true)
+      type: complex
+      contains:
+        Rules:
+          description: List of lifecycle management rules.
+          returned: when lifecycle configuration is present
+          type: list
+          sample: [{ "Status": "Enabled", "ID": "example-rule" }]
+    bucket_location:
+      description: Bucket location.
+      returned: when I(bucket_facts=true) and I(bucket_location=true)
+      type: complex
+      contains:
+        LocationConstraint:
+          description: AWS region.
+          returned: always
+          type: str
+          sample: us-east-2
+    bucket_logging:
+      description: Server access logging configuration.
+      returned: when I(bucket_facts=true) and I(bucket_logging=true)
+      type: complex
+      contains:
+        LoggingEnabled:
+          description: Server access logging configuration.
+          returned: when server access logging is defined for the bucket
+          type: complex
+          contains:
+            TargetBucket:
+              description: Target bucket name.
+              returned: always
+              type: str
+              sample: logging-bucket-name
+            TargetPrefix:
+              description: Prefix in target bucket.
+              returned: always
+              type: str
+              sample: ""
+    bucket_notification_configuration:
+      description: Bucket notification settings.
+      returned: when I(bucket_facts=true) and I(bucket_notification_configuration=true)
+      type: complex
+      contains:
+        TopicConfigurations:
+          description: List of notification events configurations.
+          returned: when at least one notification is configured
+          type: list
+          sample: []
+    bucket_ownership_controls:
+      description: Preffered object ownership settings.
+      returned: when I(bucket_facts=true) and I(bucket_ownership_controls=true)
+      type: complex
+      contains:
+        OwnershipControls:
+          description: Object ownership settings.
+          returned: when ownership controls are defined for the bucket
+          type: complex
+          contains:
+            Rules:
+              description: List of ownership rules.
+              returned: when ownership rule is defined
+              type: list
+              sample: [{ "ObjectOwnership:": "ObjectWriter" }]
+    bucket_policy:
+      description: Bucket policy contents.
+      returned: when I(bucket_facts=true) and I(bucket_policy=true)
+      type: str
+      sample: '{"Version":"2012-10-17","Statement":[{"Sid":"AddCannedAcl","Effect":"Allow",..}}]}'
+    bucket_policy_status:
+      description: Status of bucket policy.
+      returned: when I(bucket_facts=true) and I(bucket_policy_status=true)
+      type: complex
+      contains:
+        PolicyStatus:
+          description: Status of bucket policy.
+          returned: when bucket policy is present
+          type: complex
+          contains:
+            IsPublic:
+              description: Report bucket policy public status.
+              returned: when bucket policy is present
+              type: bool
+              sample: True
+    bucket_replication:
+      description: Replication configuration settings.
+      returned: when I(bucket_facts=true) and I(bucket_replication=true)
+      type: complex
+      contains:
+        Role:
+          description: IAM role used for replication.
+          returned: when replication rule is defined
+          type: str
+          sample: "arn:aws:iam::123:role/example-role"
+        Rules:
+          description: List of replication rules.
+          returned: when replication rule is defined
+          type: list
+          sample: [{ "ID": "rule-1", "Filter": "{}" }]
+    bucket_request_payment:
+      description: Requester pays setting.
+      returned: when I(bucket_facts=true) and I(bucket_request_payment=true)
+      type: complex
+      contains:
+        Payer:
+          description: Current payer.
+          returned: always
+          type: str
+          sample: BucketOwner
+    bucket_tagging:
+      description: Bucket tags.
+      returned: when I(bucket_facts=true) and I(bucket_tagging=true)
+      type: dict
+      sample: { "Tag1": "Value1", "Tag2": "Value2" }
+    bucket_website:
+      description: Static website hosting.
+      returned: when I(bucket_facts=true) and I(bucket_website=true)
+      type: complex
+      contains:
+        ErrorDocument:
+          description: Object serving as HTTP error page.
+          returned: when static website hosting is enabled
+          type: dict
+          sample: { "Key": "error.html" }
+        IndexDocument:
+          description: Object serving as HTTP index page.
+          returned: when static website hosting is enabled
+          type: dict
+          sample: { "Suffix": "error.html" }
+        RedirectAllRequestsTo:
+          description: Website redict settings.
+          returned: when redirect requests is configured
+          type: complex
+          contains:
+            HostName:
+              description: Hostname to redirect.
+              returned: always
+              type: str
+              sample: www.example.com
+            Protocol:
+              description: Protocol used for redirect.
+              returned: always
+              type: str
+              sample: https
 '''
 
 try:

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -112,7 +112,7 @@ options:
       - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
-    version_added: 1.3.0
+    version_added: 1.4.0
 
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -330,8 +330,8 @@ def main():
     :return:
     """
     argument_spec = dict(
-        name=dict(type=str, default=""),
-        name_filter=dict(type=str, default=""),
+        name=dict(type='str', default=""),
+        name_filter=dict(type='str', default=""),
         bucket_facts=dict(type='dict', options=dict(
             bucket_accelerate_configuration=dict(type='bool', default=False),
             bucket_acl=dict(type='bool', default=False),

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -29,7 +29,7 @@ options:
     default: ""
   name_filter:
     description:
-      - Get info only about buckets name matching defined string
+      - Get information only about buckets name containing a string.
     type: str
     default: ""
     version_added: 1.3.0

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -112,7 +112,11 @@ options:
       - Setting this option to C(true) will return C(us-east-1) instead.
       - Affects only queries with I(bucket_facts=true) and I(bucket_location=true).
     type: bool
-    default: FalseBucket public access block configuration
+    default: False
+version_added: 1.4.0
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -24,7 +24,7 @@ description:
 options:
   name:
     description:
-      - Get info only about specified bucket
+      - Name of bucket to query.
     type: str
     default: ""
   name_filter:

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -24,22 +24,20 @@ description:
 options:
   name:
     description:
-      - Get info about specified bucket
+      - Get info only about specified bucket
     type: str
     default: ""
   name_filter:
     description:
-      - Get info about buckets name matching defined string
+      - Get info only about buckets name matching defined string
     type: str
     default: ""
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
+      - Each bucket_X option executes one API call, hence many options=true will case slower module execution
+      - You can limit buckets by using I(name) or I(name_filter) option 
     suboptions:
-      bucket_accelerate_configuration:
-        description: Retrive S3 bucket accelerate configuration
-        type: bool
-        default: False
       bucket_location:
         description: Retrive S3 bucket location
         type: bool
@@ -62,10 +60,6 @@ options:
         default: False
       bucket_analytics_configuration:
         description: Retrive S3 bucket analytics configuration
-        type: bool
-        default: False
-      bucket_metrics_configuration:
-        description: Retrive S3 bucket metrics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -92,10 +86,6 @@ options:
         description: Retrive S3 bucket website
         type: bool
         default: False
-      bucket_inventory_configuration:
-        description: Retrive S3 bucket inventory configuration
-        type: bool
-        default: False
       bucket_policy:
         description: Retrive S3 bucket policy
         type: bool
@@ -108,11 +98,16 @@ options:
         description: Retrive S3 bucket lifecycle configuration
         type: bool
         default: False
+      public_access_block:
+        description: Retrive S3 bucket public access block
+        type: bool
+        default: False
     type: dict
   transform_location:
     description:
       - S3 bucket location for default us-east-1 is normally reported as 'null'
       - setting this option to 'true' will return 'us-east-1' instead
+      - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
 
@@ -173,7 +168,16 @@ buckets:
       bucket_location: dictionary data
       bucket_cors: dictionary data
       # ...etc
-  type: list
+
+# if name options was specified
+bucket_name: 
+  description: "Name of the bucket requested"
+  sample: "my_bucket"
+
+# if name_filter was specified
+bucket_name_filter: 
+  description: "String to match bucket name"
+  sample: "buckets_prefix"
 '''
 
 try:
@@ -232,7 +236,7 @@ def get_bucket_list(module, connection, name="", name_filter=""):
                 filtered_buckets.append(bucket)
 
     # Return proper list (filtered or all)
-    if filtered_buckets:
+    if name or name_filter:
         final_buckets = filtered_buckets
     else:
         final_buckets = buckets
@@ -261,47 +265,53 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
     for key in requested_facts:
         if requested_facts[key]:
             if key == 'bucket_location':
-                all_facts[key] = get_bucket_location(name, connection, transform_location)
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_location(name, connection, transform_location)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
             else:
-                all_facts[key] = get_bucket_property(name, connection, key)
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_property(name, connection, key)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
 
     return(all_facts)
 
-
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
     Get bucket location and optionally transform 'null' to 'us-east-1'
     """
-    try:
-        data = connection.get_bucket_location(Bucket=name)
-    except botocore.exceptions.ClientError as err_msg:
-        data = {'error': err_msg}
+    data = connection.get_bucket_location(Bucket=name)
 
+    # Replace 'null' with 'us-east-1'?
     if transform_location:
         try:
             if not data['LocationConstraint']:
                 data['LocationConstraint'] = 'us-east-1'
         except KeyError:
-            data['transform_failed'] = True
-
+            pass
+    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
     except KeyError:
         return(data)
 
-
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
     """
     Get bucket property
     """
     api_call = "get_" + get_api_name
     api_function = getattr(connection, api_call)
-    try:
-        data = api_function(Bucket=name)
-    except botocore.exceptions.ClientError as err_msg:
-        data = {'error': err_msg}
+    data = api_function(Bucket=name)
 
+    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -315,44 +325,17 @@ def main():
     :return:
     """
     argument_spec = dict(
-        name=dict(type='str', default=""),
-        name_filter=dict(type='str', default=""),
-        bucket_facts=dict(type='dict', options=dict(
-            bucket_accelerate_configuration=dict(type='bool', default=False),
-            bucket_acl=dict(type='bool', default=False),
-            bucket_cors=dict(type='bool', default=False),
-            bucket_encryption=dict(type='bool', default=False),
-            bucket_lifecycle_configuration=dict(type='bool', default=False),
-            bucket_location=dict(type='bool', default=False),
-            bucket_logging=dict(type='bool', default=False),
-            bucket_notification_configuration=dict(type='bool', default=False),
-            bucket_ownership_controls=dict(type='bool', default=False),
-            bucket_policy=dict(type='bool', default=False),
-            bucket_policy_status=dict(type='bool', default=False),
-            bucket_replication=dict(type='bool', default=False),
-            bucket_request_payment=dict(type='bool', default=False),
-            bucket_tagging=dict(type='bool', default=False),
-            bucket_website=dict(type='bool', default=False),
-            public_access_block=dict(type='bool', default=False),
-        )),
-        transform_location=dict(type='bool', default=False)
-    )
-
-    argument_spec = dict(
         name=dict(type=str, default=""),
         name_filter=dict(type=str, default=""),
         bucket_facts=dict(type='dict', options=dict(
             bucket_accelerate_configuration=dict(type=bool, default=False),
             bucket_acl=dict(type=bool, default=False),
-            bucket_analytics_configuration=dict(type=bool, default=False),
             bucket_cors=dict(type=bool, default=False),
             bucket_encryption=dict(type=bool, default=False),
-            bucket_inventory_configuration=dict(type=bool, default=False),
             bucket_lifecycle_configuration=dict(type=bool, default=False),
+            bucket_notification_configuration=dict(type=bool, default=False),
             bucket_location=dict(type=bool, default=False),
             bucket_logging=dict(type=bool, default=False),
-            bucket_metrics_configuration=dict(type=bool, default=False),
-            bucket_notification_configuration=dict(type=bool, default=False),
             bucket_ownership_controls=dict(type=bool, default=False),
             bucket_policy=dict(type=bool, default=False),
             bucket_policy_status=dict(type=bool, default=False),
@@ -360,10 +343,10 @@ def main():
             bucket_request_payment=dict(type=bool, default=False),
             bucket_tagging=dict(type=bool, default=False),
             bucket_website=dict(type=bool, default=False),
+            public_access_block=dict(type=bool, default=False),
             )),
         transform_location=dict(type='bool', default=False)
     )
-
 
     # Ensure we have an empty dict
     result = {}
@@ -396,6 +379,12 @@ def main():
     # Get basic bucket list (name + creation date)
     bucket_list = get_bucket_list(module, connection, name, name_filter)
 
+    # Add information about name/name_filter to result
+    if name:
+        result['bucket_name'] = name
+    elif name_filter:
+        result['bucket_name_filter'] = name_filter
+
     # Gather detailed information about buckets if requested
     bucket_facts = module.params.get("bucket_facts")
     if bucket_facts:
@@ -409,7 +398,6 @@ def main():
     else:
         module.exit_json(msg="Retrieved s3 info.", **result)
 
-
-# MAIN
+## MAIN ##
 if __name__ == '__main__':
     main()

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -13,12 +13,12 @@ DOCUMENTATION = '''
 module: aws_s3_bucket_info
 version_added: 1.0.0
 author: "Gerben Geijteman (@hyperized)"
-short_description: Lists S3 buckets in AWS
+short_description: lists S3 buckets in AWS
 requirements:
   - boto3 >= 1.4.4
   - python >= 2.6
 description:
-    - Lists S3 buckets in AWS
+    - Lists S3 buckets and details about those buckets.
     - This module was called C(aws_s3_bucket_facts) before Ansible 2.9, returning C(ansible_facts).
       Note that the M(community.aws.aws_s3_bucket_info) module no longer returns C(ansible_facts)!
 options:
@@ -30,95 +30,89 @@ options:
     version_added: 1.4.0
   name_filter:
     description:
-      - Get information only about buckets name containing a string.
+      - Limits buckets to only buckets who's name contain the string in I(name_filter).
     type: str
     default: ""
     version_added: 1.4.0
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
-      - Each bucket_X option executes one API call, hence many options=true will case slower module execution
-      - You can limit buckets by using I(name) or I(name_filter) option
+      - Each bucket_X option executes one API call, hence many options being set to C(true) will cause slower module execution.
+      - You can limit buckets by using the I(name) or I(name_filter) option.
     suboptions:
       bucket_accelerate_configuration:
-        description: Retrive S3 accelerate configuration
+        description: Retrive S3 accelerate configuration.
         type: bool
         default: False
       bucket_location:
-        description: Retrive S3 bucket location
+        description: Retrive S3 bucket location.
         type: bool
         default: False
       bucket_replication:
-        description: Retrive S3 bucket replication
+        description: Retrive S3 bucket replication.
         type: bool
         default: False
       bucket_acl:
-        description: Retrive S3 bucket ACLs
+        description: Retrive S3 bucket ACLs.
         type: bool
         default: False
       bucket_logging:
-        description: Retrive S3 bucket logging
+        description: Retrive S3 bucket logging.
         type: bool
         default: False
       bucket_request_payment:
-        description: Retrive S3 bucket request payment
+        description: Retrive S3 bucket request payment.
         type: bool
         default: False
       bucket_tagging:
-        description: Retrive S3 bucket tagging
+        description: Retrive S3 bucket tagging.
         type: bool
         default: False
       bucket_cors:
-        description: Retrive S3 bucket CORS configuration
+        description: Retrive S3 bucket CORS configuration.
         type: bool
         default: False
       bucket_notification_configuration:
-        description: Retrive S3 bucket notification configuration
+        description: Retrive S3 bucket notification configuration.
         type: bool
         default: False
       bucket_encryption:
-        description: Retrive S3 bucket encryption
+        description: Retrive S3 bucket encryption.
         type: bool
         default: False
       bucket_ownership_controls:
-        description: Retrive S3 ownership controls
+        description: Retrive S3 ownership controls.
         type: bool
         default: False
       bucket_website:
-        description: Retrive S3 bucket website
+        description: Retrive S3 bucket website.
         type: bool
         default: False
       bucket_policy:
-        description: Retrive S3 bucket policy
+        description: Retrive S3 bucket policy.
         type: bool
         default: False
       bucket_policy_status:
-        description: Retrive S3 bucket policy status
+        description: Retrive S3 bucket policy status.
         type: bool
         default: False
       bucket_lifecycle_configuration:
-        description: Retrive S3 bucket lifecycle configuration
+        description: Retrive S3 bucket lifecycle configuration.
         type: bool
         default: False
       public_access_block:
-        description: Retrive S3 bucket public access block
+        description: Retrive S3 bucket public access block.
         type: bool
         default: False
     type: dict
     version_added: 1.4.0
   transform_location:
     description:
-      - S3 bucket location for default us-east-1 is normally reported as 'null'
-      - setting this option to 'true' will return 'us-east-1' instead
-      - affects only queries with I(bucket_facts) > I(bucket_location) = true
+      - S3 bucket location for default us-east-1 is normally reported as C(null).
+      - Setting this option to C(true) will return C(us-east-1) instead.
+      - Affects only queries with I(bucket_facts=true) and I(bucket_location=true).
     type: bool
-    default: False
-    version_added: 1.4.0
-
-extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+    default: FalseBucket public access block configuration
 '''
 
 EXAMPLES = '''
@@ -162,17 +156,243 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-buckets:
+bucket_list:
   description: "List of buckets"
   returned: always
-  sample:
-    - creation_date: '2017-07-06 15:05:12 +00:00'
-      name: my_bucket
-      # bucket facts if requested
-      bucket_location: dictionary data
-      bucket_cors: dictionary data
-      # ...etc
-  type: list
+  type: complex
+  contains:
+    name:
+      description: Bucket name.
+      returned: always
+      type: str
+      sample: a-testing-bucket-name
+    creation_date:
+      description: Bucket creation date timestamp.
+      returned: always
+      type: str
+      sample: "2021-01-21T12:44:10+00:00"
+    public_access_block:
+      description: Bucket public access block configuration.
+      returned: when I(bucket_facts=true) and I(public_access_block=true)
+      type: complex
+      contains:
+        PublicAccessBlockConfiguration:
+          description: PublicAccessBlockConfiguration data.
+          returned: when PublicAccessBlockConfiguration is defined for the bucket
+          type: complex
+          contains:
+            BlockPublicAcls:
+              description: BlockPublicAcls setting value.
+              type: bool
+              sample: true
+            BlockPublicPolicy:
+              description: BlockPublicPolicy setting value.
+              type: bool
+              sample: true
+            IgnorePublicAcls:
+              description: IgnorePublicAcls setting value.
+              type: bool
+              sample: true
+            RestrictPublicBuckets:
+              description: RestrictPublicBuckets setting value.
+              type: bool
+              sample: true
+    bucket_name_filter:
+      description: String used to limit buckets. See I(name_filter).
+      returned: when I(name_filter) is defined
+      type: str
+      sample: filter-by-this-string
+    bucket_acl:
+      description: Bucket ACL configuration.
+      returned: when I(bucket_facts=true) and I(bucket_acl=true)
+      type: complex
+      contains:
+        Grants:
+          description: List of ACL grants.
+          type: list
+          sample: []
+        Owner:
+          description: Bucket owner information.
+          type: complex
+          contains:
+            DisplayName:
+              description: Bucket owner user display name.
+              returned: str
+              sample: username
+            ID:
+              description: Bucket owner user ID.
+              returned: str
+              sample: 123894e509349etc
+    bucket_cors:
+      description: Bucket CORS configuration.
+      returned: when I(bucket_facts=true) and I(bucket_cors=true)
+      type: complex
+      contains:
+        CORSRules:
+          description: Bucket CORS configuration.
+          returned: when CORS rules are defined for the bucket
+          type: list
+          sample: []
+    bucket_encryption:
+      description: Bucket encryption configuration.
+      returned: when I(bucket_facts=true) and I(bucket_encryption=true)
+      type: complex
+      contains:
+        ServerSideEncryptionConfiguration:
+          description: ServerSideEncryptionConfiguration configuration.
+          returned: when encryption is enabled on the bucket
+          type: complex
+          contains:
+            Rules:
+              description: List of applied encryptio rules.
+              returned: when encryption is enabled on the bucket
+              type: list
+              sample: { "ApplyServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" }, "BucketKeyEnabled": False }
+      bucket_lifecycle_configuration:
+        description: Bucket lifecycle configuration settings.
+        returned: when I(bucket_facts=true) and I(bucket_lifecycle_configuration=true)
+        type: complex
+        contains:
+          Rules:
+            description: List of lifecycle management rules.
+            returned: when lifecycle configuration is present
+            type: list
+            sample: [{ "Status": "Enabled", "ID": "example-rule" }]
+      bucket_location:
+        description: Bucket location.
+        returned: when I(bucket_facts=true) and I(bucket_location=true)
+        type: complex
+        contains:
+          LocationConstraint:
+            description: AWS region.
+            returned: always
+            type: str
+            sample: us-east-2
+      bucket_logging:
+        description: Server access logging configuration.
+        returned: when I(bucket_facts=true) and I(bucket_logging=true)
+        type: complex
+        contains:
+          LoggingEnabled:
+            description: Server access logging configuration.
+            returned: when server access logging is defined for the bucket
+            type: complex
+            contains:
+              TargetBucket:
+                description: Target bucket name.
+                returned: always
+                type: str
+                sample: logging-bucket-name
+              TargetPrefix:
+                description: Prefix in target bucket.
+                returned: always
+                type: str
+                sample: ""
+      bucket_notification_configuration:
+        description: Bucket notification settings.
+        returned: when I(bucket_facts=true) and I(bucket_notification_configuration=true)
+        type: complex
+        contains:
+          TopicConfigurations:
+            description: List of notification events configurations.
+            returned: when at least one notification is configured
+            type: list
+            sample: []
+      bucket_ownership_controls:
+        description: Preffered object ownership settings.
+        returned: when I(bucket_facts=true) and I(bucket_ownership_controls=true)
+        type: complex
+        contains:
+          OwnershipControls:
+            description: Object ownership settings.
+            returned: when ownership controls are defined for the bucket
+            type: complex
+            contains:
+              Rules:
+                description: List of ownership rules.
+                returned: when ownership rule is defined
+                type: list
+                sample: [{ "ObjectOwnership:": "ObjectWriter" }]
+      bucket_policy:
+        description: Bucket policy contents.
+        returned: when I(bucket_facts=true) and I(bucket_policy=true)
+        type: str
+        sample: '{"Version":"2012-10-17","Statement":[{"Sid":"AddCannedAcl","Effect":"Allow",..}}]}'
+      bucket_policy_status:
+        description: Status of bucket policy.
+        returned: when I(bucket_facts=true) and I(bucket_policy_status=true)
+        type: complex
+        contains:
+          PolicyStatus:
+            description: Status of bucket policy.
+            returned: when bucket policy is present
+            type: complex
+            contains:
+              IsPublic:
+                description: Report bucket policy public status.
+                returned: when bucket policy is present
+                type: bool
+                sample: True
+      bucket_replication:
+        description: Replication configuration settings.
+        returned: when I(bucket_facts=true) and I(bucket_replication=true)
+        type: complex
+        contains:
+          Role:
+            description: IAM role used for replication.
+            returned: when replication rule is defined
+            type: str
+            sample: "arn:aws:iam::123:role/example-role"
+          Rules:
+            description: List of replication rules.
+            returned: when replication rule is defined
+            type: list
+            sample: [{ "ID": "rule-1", "Filter": "{}" }]
+      bucket_request_payment:
+        description: Requester pays setting.
+        returned: when I(bucket_facts=true) and I(bucket_request_payment=true)
+        type: complex
+        contains:
+          Payer:
+            description: Current payer.
+            returned: always
+            type: str
+            sample: BucketOwner
+      bucket_tagging:
+        description: Bucket tags.
+        returned: when I(bucket_facts=true) and I(bucket_tagging=true)
+        type: dict
+        sample: { "Tag1": "Value1", "Tag2": "Value2" }
+      bucket_website:
+        description: Static website hosting.
+        returned: when I(bucket_facts=true) and I(bucket_website=true)
+        type: complex
+        contains:
+          ErrorDocument:
+            description: Object serving as HTTP error page.
+            returned: when static website hosting is enabled
+            type: dict
+            sample: { "Key": "error.html" }
+          IndexDocument:
+            description: Object serving as HTTP index page.
+            returned: when static website hosting is enabled
+            type: dict
+            sample: { "Suffix": "error.html" }
+          RedirectAllRequestsTo:
+            description: Website redict settings.
+            returned: when redirect requests is configured
+            type: complex
+            contains:
+              HostName:
+                description: Hostname to redirect.
+                returned: always
+                type: str
+                sample: www.example.com
+              Protocol:
+                description: Protocol used for redirect.
+                returned: always
+                type: str
+                sample: https
 '''
 
 try:

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -195,29 +195,12 @@ def get_bucket_list(module, connection, name="", name_filter=""):
     buckets = []
     filtered_buckets = []
     final_buckets = []
+
     # Get all buckets
     try:
         buckets = camel_dict_to_snake_dict(connection.list_buckets())['buckets']
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to list buckets")
-
-    # Filter buckets if requested
-    if name_filter:
-        for bucket in buckets:
-            if name_filter in bucket['name']:
-                filtered_buckets.append(bucket)
-    elif name:
-        for bucket in buckets:
-            if name == bucket['name']:
-                filtered_buckets.append(bucket)
-
-    # Return proper list (filtered or all)
-    if name or name_filter:
-        final_buckets = filtered_buckets
-    else:
-        final_buckets = buckets
-    return(final_buckets)
-
 
     # Filter buckets if requested
     if name_filter:
@@ -265,6 +248,13 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
                 # we just pass on error - error means that resources is undefined
                 except botocore.exceptions.ClientError:
                     pass
+            elif key == 'bucket_tagging':
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_tagging(name, connection)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
             else:
                 all_facts[key] = {}
                 try:
@@ -296,6 +286,25 @@ def get_bucket_location(name, connection, transform_location=False):
         return(data)
     except KeyError:
         return(data)
+
+
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
+def get_bucket_tagging(name, connection):
+    """
+    Get bucket tags and transform them using `boto3_tag_list_to_ansible_dict` function
+    """
+    data = connection.get_bucket_tagging(Bucket=name)
+
+    try:
+        bucket_tags = boto3_tag_list_to_ansible_dict(data['TagSet'])
+        return(bucket_tags)
+    except KeyError:
+        # Strip response metadata (not needed)
+        try:
+            data.pop('ResponseMetadata')
+            return(data)
+        except KeyError:
+            return(data)
 
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
@@ -369,8 +378,8 @@ def main():
     connection = {}
     try:
         connection = module.client('s3')
-    except (connection.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg='Failed to connect to AWS')
+    except (connection.exceptions.ClientError, botocore.exceptions.BotoCoreError) as err_code:
+        module.fail_json_aws(err_code, msg='Failed to connect to AWS')
 
     # Get basic bucket list (name + creation date)
     bucket_list = get_bucket_list(module, connection, name, name_filter)

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -113,7 +113,7 @@ options:
       - Affects only queries with I(bucket_facts=true) and I(bucket_location=true).
     type: bool
     default: False
-version_added: 1.4.0
+    version_added: 1.4.0
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -24,22 +24,20 @@ description:
 options:
   name:
     description:
-      - Get info about specified bucket
+      - Get info only about specified bucket
     type: str
     default: ""
   name_filter:
     description:
-      - Get info about buckets name matching defined string
+      - Get info only about buckets name matching defined string
     type: str
     default: ""
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
+      - Each bucket_X option executes one API call, hence many options=true will case slower module execution
+      - You can limit buckets by using I(name) or I(name_filter) option 
     suboptions:
-      bucket_accelerate_configuration:
-        description: Retrive S3 bucket accelerate configuration
-        type: bool
-        default: False
       bucket_location:
         description: Retrive S3 bucket location
         type: bool
@@ -62,10 +60,6 @@ options:
         default: False
       bucket_analytics_configuration:
         description: Retrive S3 bucket analytics configuration
-        type: bool
-        default: False
-      bucket_metrics_configuration:
-        description: Retrive S3 bucket metrics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -92,10 +86,6 @@ options:
         description: Retrive S3 bucket website
         type: bool
         default: False
-      bucket_inventory_configuration:
-        description: Retrive S3 bucket inventory configuration
-        type: bool
-        default: False
       bucket_policy:
         description: Retrive S3 bucket policy
         type: bool
@@ -108,11 +98,16 @@ options:
         description: Retrive S3 bucket lifecycle configuration
         type: bool
         default: False
+      public_access_block:
+        description: Retrive S3 bucket public access block
+        type: bool
+        default: False
     type: dict
   transform_location:
     description:
       - S3 bucket location for default us-east-1 is normally reported as 'null'
       - setting this option to 'true' will return 'us-east-1' instead
+      - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
 
@@ -173,7 +168,16 @@ buckets:
       bucket_location: dictionary data
       bucket_cors: dictionary data
       # ...etc
-  type: list
+
+# if name options was specified
+bucket_name: 
+  description: "Name of the bucket requested"
+  sample: "my_bucket"
+
+# if name_filter was specified
+bucket_name_filter: 
+  description: "String to match bucket name"
+  sample: "buckets_prefix"
 '''
 
 try:
@@ -232,7 +236,7 @@ def get_bucket_list(module, connection, name="", name_filter=""):
                 filtered_buckets.append(bucket)
 
     # Return proper list (filtered or all)
-    if filtered_buckets:
+    if name or name_filter:
         final_buckets = filtered_buckets
     else:
         final_buckets = buckets
@@ -261,47 +265,53 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
     for key in requested_facts:
         if requested_facts[key]:
             if key == 'bucket_location':
-                all_facts[key] = get_bucket_location(name, connection, transform_location)
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_location(name, connection, transform_location)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
             else:
-                all_facts[key] = get_bucket_property(name, connection, key)
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_property(name, connection, key)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
 
     return(all_facts)
 
-
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
     Get bucket location and optionally transform 'null' to 'us-east-1'
     """
-    try:
-        data = connection.get_bucket_location(Bucket=name)
-    except botocore.exceptions.ClientError as err_msg:
-        data = {'error': err_msg}
+    data = connection.get_bucket_location(Bucket=name)
 
+    # Replace 'null' with 'us-east-1'?
     if transform_location:
         try:
             if not data['LocationConstraint']:
                 data['LocationConstraint'] = 'us-east-1'
         except KeyError:
-            data['transform_failed'] = True
-
+            pass
+    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
     except KeyError:
         return(data)
 
-
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
     """
     Get bucket property
     """
     api_call = "get_" + get_api_name
     api_function = getattr(connection, api_call)
-    try:
-        data = api_function(Bucket=name)
-    except botocore.exceptions.ClientError as err_msg:
-        data = {'error': err_msg}
+    data = api_function(Bucket=name)
 
+    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -315,44 +325,17 @@ def main():
     :return:
     """
     argument_spec = dict(
-        name=dict(type='str', default=""),
-        name_filter=dict(type='str', default=""),
-        bucket_facts=dict(type='dict', options=dict(
-            bucket_accelerate_configuration=dict(type='bool', default=False),
-            bucket_acl=dict(type='bool', default=False),
-            bucket_cors=dict(type='bool', default=False),
-            bucket_encryption=dict(type='bool', default=False),
-            bucket_lifecycle_configuration=dict(type='bool', default=False),
-            bucket_location=dict(type='bool', default=False),
-            bucket_logging=dict(type='bool', default=False),
-            bucket_notification_configuration=dict(type='bool', default=False),
-            bucket_ownership_controls=dict(type='bool', default=False),
-            bucket_policy=dict(type='bool', default=False),
-            bucket_policy_status=dict(type='bool', default=False),
-            bucket_replication=dict(type='bool', default=False),
-            bucket_request_payment=dict(type='bool', default=False),
-            bucket_tagging=dict(type='bool', default=False),
-            bucket_website=dict(type='bool', default=False),
-            public_access_block=dict(type='bool', default=False),
-        )),
-        transform_location=dict(type='bool', default=False)
-    )
-
-    argument_spec = dict(
         name=dict(type=str, default=""),
         name_filter=dict(type=str, default=""),
         bucket_facts=dict(type='dict', options=dict(
             bucket_accelerate_configuration=dict(type=bool, default=False),
             bucket_acl=dict(type=bool, default=False),
-            bucket_analytics_configuration=dict(type=bool, default=False),
             bucket_cors=dict(type=bool, default=False),
             bucket_encryption=dict(type=bool, default=False),
-            bucket_inventory_configuration=dict(type=bool, default=False),
             bucket_lifecycle_configuration=dict(type=bool, default=False),
+            bucket_notification_configuration=dict(type=bool, default=False),
             bucket_location=dict(type=bool, default=False),
             bucket_logging=dict(type=bool, default=False),
-            bucket_metrics_configuration=dict(type=bool, default=False),
-            bucket_notification_configuration=dict(type=bool, default=False),
             bucket_ownership_controls=dict(type=bool, default=False),
             bucket_policy=dict(type=bool, default=False),
             bucket_policy_status=dict(type=bool, default=False),
@@ -360,10 +343,10 @@ def main():
             bucket_request_payment=dict(type=bool, default=False),
             bucket_tagging=dict(type=bool, default=False),
             bucket_website=dict(type=bool, default=False),
+            public_access_block=dict(type=bool, default=False),
             )),
         transform_location=dict(type='bool', default=False)
     )
-
 
     # Ensure we have an empty dict
     result = {}
@@ -374,7 +357,7 @@ def main():
     ]
 
     # Including ec2 argument spec
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, mutually_exclusive=mutually_exclusive)
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
@@ -396,6 +379,12 @@ def main():
     # Get basic bucket list (name + creation date)
     bucket_list = get_bucket_list(module, connection, name, name_filter)
 
+    # Add information about name/name_filter to result
+    if name:
+        result['bucket_name'] = name
+    elif name_filter:
+        result['bucket_name_filter'] = name_filter
+
     # Gather detailed information about buckets if requested
     bucket_facts = module.params.get("bucket_facts")
     if bucket_facts:
@@ -409,7 +398,6 @@ def main():
     else:
         module.exit_json(msg="Retrieved s3 info.", **result)
 
-
-# MAIN
+## MAIN ##
 if __name__ == '__main__':
     main()

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -221,11 +221,13 @@ bucket_list:
           contains:
             DisplayName:
               description: Bucket owner user display name.
-              returned: str
+              returned: always
+              type: str
               sample: username
             ID:
               description: Bucket owner user ID.
-              returned: str
+              returned: always
+              type: str
               sample: 123894e509349etc
     bucket_cors:
       description: Bucket CORS configuration.

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -32,6 +32,7 @@ options:
       - Get info only about buckets name matching defined string
     type: str
     default: ""
+    version_added: 1.3.0
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
@@ -103,6 +104,7 @@ options:
         type: bool
         default: False
     type: dict
+    version_added: 1.3.0
   transform_location:
     description:
       - S3 bucket location for default us-east-1 is normally reported as 'null'
@@ -110,6 +112,7 @@ options:
       - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
+    version_added: 1.3.0
 
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -36,8 +36,12 @@ options:
     description:
       - Retrieve requested S3 bucket detailed information
       - Each bucket_X option executes one API call, hence many options=true will case slower module execution
-      - You can limit buckets by using I(name) or I(name_filter) option 
+      - You can limit buckets by using I(name) or I(name_filter) option
     suboptions:
+      bucket_accelerate_configuration:
+        description: Retrive S3 accelerate configuration
+        type: bool
+        default: False
       bucket_location:
         description: Retrive S3 bucket location
         type: bool
@@ -56,10 +60,6 @@ options:
         default: False
       bucket_request_payment:
         description: Retrive S3 bucket request payment
-        type: bool
-        default: False
-      bucket_analytics_configuration:
-        description: Retrive S3 bucket analytics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -168,16 +168,19 @@ buckets:
       bucket_location: dictionary data
       bucket_cors: dictionary data
       # ...etc
+  type: list
 
 # if name options was specified
-bucket_name: 
+bucket_name:
   description: "Name of the bucket requested"
   sample: "my_bucket"
+  type: str
 
 # if name_filter was specified
-bucket_name_filter: 
+bucket_name_filter:
   description: "String to match bucket name"
   sample: "buckets_prefix"
+  type: str
 '''
 
 try:
@@ -281,6 +284,7 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
 
     return(all_facts)
 
+
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
@@ -301,6 +305,7 @@ def get_bucket_location(name, connection, transform_location=False):
         return(data)
     except KeyError:
         return(data)
+
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
@@ -328,23 +333,23 @@ def main():
         name=dict(type=str, default=""),
         name_filter=dict(type=str, default=""),
         bucket_facts=dict(type='dict', options=dict(
-            bucket_accelerate_configuration=dict(type=bool, default=False),
-            bucket_acl=dict(type=bool, default=False),
-            bucket_cors=dict(type=bool, default=False),
-            bucket_encryption=dict(type=bool, default=False),
-            bucket_lifecycle_configuration=dict(type=bool, default=False),
-            bucket_notification_configuration=dict(type=bool, default=False),
-            bucket_location=dict(type=bool, default=False),
-            bucket_logging=dict(type=bool, default=False),
-            bucket_ownership_controls=dict(type=bool, default=False),
-            bucket_policy=dict(type=bool, default=False),
-            bucket_policy_status=dict(type=bool, default=False),
-            bucket_replication=dict(type=bool, default=False),
-            bucket_request_payment=dict(type=bool, default=False),
-            bucket_tagging=dict(type=bool, default=False),
-            bucket_website=dict(type=bool, default=False),
-            public_access_block=dict(type=bool, default=False),
-            )),
+            bucket_accelerate_configuration=dict(type='bool', default=False),
+            bucket_acl=dict(type='bool', default=False),
+            bucket_cors=dict(type='bool', default=False),
+            bucket_encryption=dict(type='bool', default=False),
+            bucket_lifecycle_configuration=dict(type='bool', default=False),
+            bucket_location=dict(type='bool', default=False),
+            bucket_logging=dict(type='bool', default=False),
+            bucket_notification_configuration=dict(type='bool', default=False),
+            bucket_ownership_controls=dict(type='bool', default=False),
+            bucket_policy=dict(type='bool', default=False),
+            bucket_policy_status=dict(type='bool', default=False),
+            bucket_replication=dict(type='bool', default=False),
+            bucket_request_payment=dict(type='bool', default=False),
+            bucket_tagging=dict(type='bool', default=False),
+            bucket_website=dict(type='bool', default=False),
+            public_access_block=dict(type='bool', default=False),
+        )),
         transform_location=dict(type='bool', default=False)
     )
 
@@ -398,6 +403,7 @@ def main():
     else:
         module.exit_json(msg="Retrieved s3 info.", **result)
 
-## MAIN ##
+
+# MAIN
 if __name__ == '__main__':
     main()

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -195,29 +195,12 @@ def get_bucket_list(module, connection, name="", name_filter=""):
     buckets = []
     filtered_buckets = []
     final_buckets = []
+
     # Get all buckets
     try:
         buckets = camel_dict_to_snake_dict(connection.list_buckets())['buckets']
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to list buckets")
-
-    # Filter buckets if requested
-    if name_filter:
-        for bucket in buckets:
-            if name_filter in bucket['name']:
-                filtered_buckets.append(bucket)
-    elif name:
-        for bucket in buckets:
-            if name == bucket['name']:
-                filtered_buckets.append(bucket)
-
-    # Return proper list (filtered or all)
-    if name or name_filter:
-        final_buckets = filtered_buckets
-    else:
-        final_buckets = buckets
-    return(final_buckets)
-
 
     # Filter buckets if requested
     if name_filter:
@@ -265,6 +248,13 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
                 # we just pass on error - error means that resources is undefined
                 except botocore.exceptions.ClientError:
                     pass
+            elif key == 'bucket_tagging':
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_tagging(name, connection)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
             else:
                 all_facts[key] = {}
                 try:
@@ -296,6 +286,25 @@ def get_bucket_location(name, connection, transform_location=False):
         return(data)
     except KeyError:
         return(data)
+
+
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
+def get_bucket_tagging(name, connection):
+    """
+    Get bucket tags and transform them using `boto3_tag_list_to_ansible_dict` function
+    """
+    data = connection.get_bucket_tagging(Bucket=name)
+
+    try:
+        bucket_tags = boto3_tag_list_to_ansible_dict(data['TagSet'])
+        return(bucket_tags)
+    except KeyError:
+        # Strip response metadata (not needed)
+        try:
+            data.pop('ResponseMetadata')
+            return(data)
+        except KeyError:
+            return(data)
 
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -24,22 +24,20 @@ description:
 options:
   name:
     description:
-      - Get info about specified bucket
+      - Get info only about specified bucket
     type: str
     default: ""
   name_filter:
     description:
-      - Get info about buckets name matching defined string
+      - Get info only about buckets name matching defined string
     type: str
     default: ""
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
+      - Each bucket_X option executes one API call, hence many options=true will case slower module execution
+      - You can limit buckets by using I(name) or I(name_filter) option 
     suboptions:
-      bucket_accelerate_configuration:
-        description: Retrive S3 bucket accelerate configuration
-        type: bool
-        default: False
       bucket_location:
         description: Retrive S3 bucket location
         type: bool
@@ -62,10 +60,6 @@ options:
         default: False
       bucket_analytics_configuration:
         description: Retrive S3 bucket analytics configuration
-        type: bool
-        default: False
-      bucket_metrics_configuration:
-        description: Retrive S3 bucket metrics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -92,10 +86,6 @@ options:
         description: Retrive S3 bucket website
         type: bool
         default: False
-      bucket_inventory_configuration:
-        description: Retrive S3 bucket inventory configuration
-        type: bool
-        default: False
       bucket_policy:
         description: Retrive S3 bucket policy
         type: bool
@@ -108,11 +98,16 @@ options:
         description: Retrive S3 bucket lifecycle configuration
         type: bool
         default: False
+      public_access_block:
+        description: Retrive S3 bucket public access block
+        type: bool
+        default: False
     type: dict
   transform_location:
     description:
       - S3 bucket location for default us-east-1 is normally reported as 'null'
       - setting this option to 'true' will return 'us-east-1' instead
+      - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
 
@@ -131,6 +126,32 @@ EXAMPLES = '''
 - community.aws.aws_s3_bucket_info:
   register: result
 
+# Retrieve detailed bucket information
+- community.aws.aws_s3_bucket_info:
+    # Show only buckets with name matching
+    name_filter: your.testing
+    # Choose facts to retrieve
+    bucket_facts:
+      # bucket_accelerate_configuration: true
+      bucket_acl: true
+      bucket_cors: true
+      bucket_encryption: true
+      # bucket_lifecycle_configuration: true
+      bucket_location: true
+      # bucket_logging: true
+      # bucket_notification_configuration: true
+      # bucket_ownership_controls: true
+      # bucket_policy: true
+      # bucket_policy_status: true
+      # bucket_replication: true
+      # bucket_request_payment: true
+      # bucket_tagging: true
+      # bucket_website: true
+      # public_access_block: true
+    transform_location: true
+    register: result
+
+# Print out result
 - name: List buckets
   ansible.builtin.debug:
     msg: "{{ result['buckets'] }}"
@@ -143,7 +164,20 @@ buckets:
   sample:
     - creation_date: '2017-07-06 15:05:12 +00:00'
       name: my_bucket
-  type: list
+      # bucket facts if requested
+      bucket_location: dictionary data
+      bucket_cors: dictionary data
+      # ...etc
+
+# if name options was specified
+bucket_name: 
+  description: "Name of the bucket requested"
+  sample: "my_bucket"
+
+# if name_filter was specified
+bucket_name_filter: 
+  description: "String to match bucket name"
+  sample: "buckets_prefix"
 '''
 
 try:
@@ -184,7 +218,7 @@ def get_bucket_list(module, connection, name="", name_filter=""):
                 filtered_buckets.append(bucket)
 
     # Return proper list (filtered or all)
-    if filtered_buckets:
+    if name or name_filter:
         final_buckets = filtered_buckets
     else:
         final_buckets = buckets
@@ -213,47 +247,53 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
     for key in requested_facts:
         if requested_facts[key]:
             if key == 'bucket_location':
-                all_facts[key] = get_bucket_location(name, connection, transform_location)
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_location(name, connection, transform_location)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
             else:
-                all_facts[key] = get_bucket_property(name, connection, key)
+                all_facts[key] = {}
+                try:
+                    all_facts[key] = get_bucket_property(name, connection, key)
+                # we just pass on error - error means that resources is undefined
+                except botocore.exceptions.ClientError:
+                    pass
 
     return(all_facts)
 
-
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
     Get bucket location and optionally transform 'null' to 'us-east-1'
     """
-    try:
-        data = connection.get_bucket_location(Bucket=name)
-    except botocore.exceptions.ClientError as err_msg:
-        data = {'error': err_msg}
+    data = connection.get_bucket_location(Bucket=name)
 
+    # Replace 'null' with 'us-east-1'?
     if transform_location:
         try:
             if not data['LocationConstraint']:
                 data['LocationConstraint'] = 'us-east-1'
         except KeyError:
-            data['transform_failed'] = True
-
+            pass
+    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
     except KeyError:
         return(data)
 
-
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
     """
     Get bucket property
     """
     api_call = "get_" + get_api_name
     api_function = getattr(connection, api_call)
-    try:
-        data = api_function(Bucket=name)
-    except botocore.exceptions.ClientError as err_msg:
-        data = {'error': err_msg}
+    data = api_function(Bucket=name)
 
+    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -266,22 +306,18 @@ def main():
     Get list of S3 buckets
     :return:
     """
-
     argument_spec = dict(
         name=dict(type=str, default=""),
         name_filter=dict(type=str, default=""),
         bucket_facts=dict(type='dict', options=dict(
             bucket_accelerate_configuration=dict(type=bool, default=False),
             bucket_acl=dict(type=bool, default=False),
-            bucket_analytics_configuration=dict(type=bool, default=False),
             bucket_cors=dict(type=bool, default=False),
             bucket_encryption=dict(type=bool, default=False),
-            bucket_inventory_configuration=dict(type=bool, default=False),
             bucket_lifecycle_configuration=dict(type=bool, default=False),
+            bucket_notification_configuration=dict(type=bool, default=False),
             bucket_location=dict(type=bool, default=False),
             bucket_logging=dict(type=bool, default=False),
-            bucket_metrics_configuration=dict(type=bool, default=False),
-            bucket_notification_configuration=dict(type=bool, default=False),
             bucket_ownership_controls=dict(type=bool, default=False),
             bucket_policy=dict(type=bool, default=False),
             bucket_policy_status=dict(type=bool, default=False),
@@ -289,16 +325,21 @@ def main():
             bucket_request_payment=dict(type=bool, default=False),
             bucket_tagging=dict(type=bool, default=False),
             bucket_website=dict(type=bool, default=False),
+            public_access_block=dict(type=bool, default=False),
             )),
         transform_location=dict(type='bool', default=False)
     )
 
-
     # Ensure we have an empty dict
     result = {}
 
+    # Define mutually exclusive options
+    mutually_exclusive = [
+        ['name', 'name_filter']
+    ]
+
     # Including ec2 argument spec
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, mutually_exclusive=mutually_exclusive)
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
@@ -320,6 +361,12 @@ def main():
     # Get basic bucket list (name + creation date)
     bucket_list = get_bucket_list(module, connection, name, name_filter)
 
+    # Add information about name/name_filter to result
+    if name:
+        result['bucket_name'] = name
+    elif name_filter:
+        result['bucket_name_filter'] = name_filter
+
     # Gather detailed information about buckets if requested
     bucket_facts = module.params.get("bucket_facts")
     if bucket_facts:
@@ -333,6 +380,6 @@ def main():
     else:
         module.exit_json(msg="Retrieved s3 info.", **result)
 
-
+## MAIN ##
 if __name__ == '__main__':
     main()

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -36,8 +36,12 @@ options:
     description:
       - Retrieve requested S3 bucket detailed information
       - Each bucket_X option executes one API call, hence many options=true will case slower module execution
-      - You can limit buckets by using I(name) or I(name_filter) option 
+      - You can limit buckets by using I(name) or I(name_filter) option
     suboptions:
+      bucket_accelerate_configuration:
+        description: Retrive S3 accelerate configuration
+        type: bool
+        default: False
       bucket_location:
         description: Retrive S3 bucket location
         type: bool
@@ -56,10 +60,6 @@ options:
         default: False
       bucket_request_payment:
         description: Retrive S3 bucket request payment
-        type: bool
-        default: False
-      bucket_analytics_configuration:
-        description: Retrive S3 bucket analytics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -168,16 +168,19 @@ buckets:
       bucket_location: dictionary data
       bucket_cors: dictionary data
       # ...etc
+  type: list
 
 # if name options was specified
-bucket_name: 
+bucket_name:
   description: "Name of the bucket requested"
   sample: "my_bucket"
+  type: str
 
 # if name_filter was specified
-bucket_name_filter: 
+bucket_name_filter:
   description: "String to match bucket name"
   sample: "buckets_prefix"
+  type: str
 '''
 
 try:
@@ -263,6 +266,7 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
 
     return(all_facts)
 
+
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
@@ -283,6 +287,7 @@ def get_bucket_location(name, connection, transform_location=False):
         return(data)
     except KeyError:
         return(data)
+
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
@@ -310,23 +315,23 @@ def main():
         name=dict(type=str, default=""),
         name_filter=dict(type=str, default=""),
         bucket_facts=dict(type='dict', options=dict(
-            bucket_accelerate_configuration=dict(type=bool, default=False),
-            bucket_acl=dict(type=bool, default=False),
-            bucket_cors=dict(type=bool, default=False),
-            bucket_encryption=dict(type=bool, default=False),
-            bucket_lifecycle_configuration=dict(type=bool, default=False),
-            bucket_notification_configuration=dict(type=bool, default=False),
-            bucket_location=dict(type=bool, default=False),
-            bucket_logging=dict(type=bool, default=False),
-            bucket_ownership_controls=dict(type=bool, default=False),
-            bucket_policy=dict(type=bool, default=False),
-            bucket_policy_status=dict(type=bool, default=False),
-            bucket_replication=dict(type=bool, default=False),
-            bucket_request_payment=dict(type=bool, default=False),
-            bucket_tagging=dict(type=bool, default=False),
-            bucket_website=dict(type=bool, default=False),
-            public_access_block=dict(type=bool, default=False),
-            )),
+            bucket_accelerate_configuration=dict(type='bool', default=False),
+            bucket_acl=dict(type='bool', default=False),
+            bucket_cors=dict(type='bool', default=False),
+            bucket_encryption=dict(type='bool', default=False),
+            bucket_lifecycle_configuration=dict(type='bool', default=False),
+            bucket_location=dict(type='bool', default=False),
+            bucket_logging=dict(type='bool', default=False),
+            bucket_notification_configuration=dict(type='bool', default=False),
+            bucket_ownership_controls=dict(type='bool', default=False),
+            bucket_policy=dict(type='bool', default=False),
+            bucket_policy_status=dict(type='bool', default=False),
+            bucket_replication=dict(type='bool', default=False),
+            bucket_request_payment=dict(type='bool', default=False),
+            bucket_tagging=dict(type='bool', default=False),
+            bucket_website=dict(type='bool', default=False),
+            public_access_block=dict(type='bool', default=False),
+        )),
         transform_location=dict(type='bool', default=False)
     )
 
@@ -380,6 +385,7 @@ def main():
     else:
         module.exit_json(msg="Retrieved s3 info.", **result)
 
-## MAIN ##
+
+# MAIN
 if __name__ == '__main__':
     main()

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -24,23 +24,20 @@ description:
 options:
   name:
     description:
-      - Get info only about specified bucket
+      - Get info about specified bucket
     type: str
     default: ""
   name_filter:
     description:
-      - Get info only about buckets name matching defined string
+      - Get info about buckets name matching defined string
     type: str
     default: ""
-    version_added: 1.3.0
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
-      - Each bucket_X option executes one API call, hence many options=true will case slower module execution
-      - You can limit buckets by using I(name) or I(name_filter) option
     suboptions:
       bucket_accelerate_configuration:
-        description: Retrive S3 accelerate configuration
+        description: Retrive S3 bucket accelerate configuration
         type: bool
         default: False
       bucket_location:
@@ -61,6 +58,14 @@ options:
         default: False
       bucket_request_payment:
         description: Retrive S3 bucket request payment
+        type: bool
+        default: False
+      bucket_analytics_configuration:
+        description: Retrive S3 bucket analytics configuration
+        type: bool
+        default: False
+      bucket_metrics_configuration:
+        description: Retrive S3 bucket metrics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -87,6 +92,10 @@ options:
         description: Retrive S3 bucket website
         type: bool
         default: False
+      bucket_inventory_configuration:
+        description: Retrive S3 bucket inventory configuration
+        type: bool
+        default: False
       bucket_policy:
         description: Retrive S3 bucket policy
         type: bool
@@ -99,20 +108,13 @@ options:
         description: Retrive S3 bucket lifecycle configuration
         type: bool
         default: False
-      public_access_block:
-        description: Retrive S3 bucket public access block
-        type: bool
-        default: False
     type: dict
-    version_added: 1.3.0
   transform_location:
     description:
       - S3 bucket location for default us-east-1 is normally reported as 'null'
       - setting this option to 'true' will return 'us-east-1' instead
-      - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
-    version_added: 1.3.0
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -195,7 +197,6 @@ def get_bucket_list(module, connection, name="", name_filter=""):
     buckets = []
     filtered_buckets = []
     final_buckets = []
-
     # Get all buckets
     try:
         buckets = camel_dict_to_snake_dict(connection.list_buckets())['buckets']
@@ -214,6 +215,24 @@ def get_bucket_list(module, connection, name="", name_filter=""):
 
     # Return proper list (filtered or all)
     if name or name_filter:
+        final_buckets = filtered_buckets
+    else:
+        final_buckets = buckets
+    return(final_buckets)
+
+
+    # Filter buckets if requested
+    if name_filter:
+        for bucket in buckets:
+            if name_filter in bucket['name']:
+                filtered_buckets.append(bucket)
+    elif name:
+        for bucket in buckets:
+            if name == bucket['name']:
+                filtered_buckets.append(bucket)
+
+    # Return proper list (filtered or all)
+    if filtered_buckets:
         final_buckets = filtered_buckets
     else:
         final_buckets = buckets
@@ -242,45 +261,29 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
     for key in requested_facts:
         if requested_facts[key]:
             if key == 'bucket_location':
-                all_facts[key] = {}
-                try:
-                    all_facts[key] = get_bucket_location(name, connection, transform_location)
-                # we just pass on error - error means that resources is undefined
-                except botocore.exceptions.ClientError:
-                    pass
-            elif key == 'bucket_tagging':
-                all_facts[key] = {}
-                try:
-                    all_facts[key] = get_bucket_tagging(name, connection)
-                # we just pass on error - error means that resources is undefined
-                except botocore.exceptions.ClientError:
-                    pass
+                all_facts[key] = get_bucket_location(name, connection, transform_location)
             else:
-                all_facts[key] = {}
-                try:
-                    all_facts[key] = get_bucket_property(name, connection, key)
-                # we just pass on error - error means that resources is undefined
-                except botocore.exceptions.ClientError:
-                    pass
+                all_facts[key] = get_bucket_property(name, connection, key)
 
     return(all_facts)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
     Get bucket location and optionally transform 'null' to 'us-east-1'
     """
-    data = connection.get_bucket_location(Bucket=name)
+    try:
+        data = connection.get_bucket_location(Bucket=name)
+    except botocore.exceptions.ClientError as err_msg:
+        data = {'error': err_msg}
 
-    # Replace 'null' with 'us-east-1'?
     if transform_location:
         try:
             if not data['LocationConstraint']:
                 data['LocationConstraint'] = 'us-east-1'
         except KeyError:
-            pass
-    # Strip response metadata (not needed)
+            data['transform_failed'] = True
+
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -288,35 +291,17 @@ def get_bucket_location(name, connection, transform_location=False):
         return(data)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
-def get_bucket_tagging(name, connection):
-    """
-    Get bucket tags and transform them using `boto3_tag_list_to_ansible_dict` function
-    """
-    data = connection.get_bucket_tagging(Bucket=name)
-
-    try:
-        bucket_tags = boto3_tag_list_to_ansible_dict(data['TagSet'])
-        return(bucket_tags)
-    except KeyError:
-        # Strip response metadata (not needed)
-        try:
-            data.pop('ResponseMetadata')
-            return(data)
-        except KeyError:
-            return(data)
-
-
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
     """
     Get bucket property
     """
     api_call = "get_" + get_api_name
     api_function = getattr(connection, api_call)
-    data = api_function(Bucket=name)
+    try:
+        data = api_function(Bucket=name)
+    except botocore.exceptions.ClientError as err_msg:
+        data = {'error': err_msg}
 
-    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -353,6 +338,33 @@ def main():
         transform_location=dict(type='bool', default=False)
     )
 
+    argument_spec = dict(
+        name=dict(type=str, default=""),
+        name_filter=dict(type=str, default=""),
+        bucket_facts=dict(type='dict', options=dict(
+            bucket_accelerate_configuration=dict(type=bool, default=False),
+            bucket_acl=dict(type=bool, default=False),
+            bucket_analytics_configuration=dict(type=bool, default=False),
+            bucket_cors=dict(type=bool, default=False),
+            bucket_encryption=dict(type=bool, default=False),
+            bucket_inventory_configuration=dict(type=bool, default=False),
+            bucket_lifecycle_configuration=dict(type=bool, default=False),
+            bucket_location=dict(type=bool, default=False),
+            bucket_logging=dict(type=bool, default=False),
+            bucket_metrics_configuration=dict(type=bool, default=False),
+            bucket_notification_configuration=dict(type=bool, default=False),
+            bucket_ownership_controls=dict(type=bool, default=False),
+            bucket_policy=dict(type=bool, default=False),
+            bucket_policy_status=dict(type=bool, default=False),
+            bucket_replication=dict(type=bool, default=False),
+            bucket_request_payment=dict(type=bool, default=False),
+            bucket_tagging=dict(type=bool, default=False),
+            bucket_website=dict(type=bool, default=False),
+            )),
+        transform_location=dict(type='bool', default=False)
+    )
+
+
     # Ensure we have an empty dict
     result = {}
 
@@ -362,7 +374,7 @@ def main():
     ]
 
     # Including ec2 argument spec
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, mutually_exclusive=mutually_exclusive)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     is_old_facts = module._name == 'aws_s3_bucket_facts'
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
@@ -378,17 +390,11 @@ def main():
     connection = {}
     try:
         connection = module.client('s3')
-    except (connection.exceptions.ClientError, botocore.exceptions.BotoCoreError) as err_code:
-        module.fail_json_aws(err_code, msg='Failed to connect to AWS')
+    except (connection.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Failed to connect to AWS')
 
     # Get basic bucket list (name + creation date)
     bucket_list = get_bucket_list(module, connection, name, name_filter)
-
-    # Add information about name/name_filter to result
-    if name:
-        result['bucket_name'] = name
-    elif name_filter:
-        result['bucket_name_filter'] = name_filter
 
     # Gather detailed information about buckets if requested
     bucket_facts = module.params.get("bucket_facts")

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -24,23 +24,20 @@ description:
 options:
   name:
     description:
-      - Get info only about specified bucket
+      - Get info about specified bucket
     type: str
     default: ""
   name_filter:
     description:
-      - Get info only about buckets name matching defined string
+      - Get info about buckets name matching defined string
     type: str
     default: ""
-    version_added: 1.3.0
   bucket_facts:
     description:
       - Retrieve requested S3 bucket detailed information
-      - Each bucket_X option executes one API call, hence many options=true will case slower module execution
-      - You can limit buckets by using I(name) or I(name_filter) option
     suboptions:
       bucket_accelerate_configuration:
-        description: Retrive S3 accelerate configuration
+        description: Retrive S3 bucket accelerate configuration
         type: bool
         default: False
       bucket_location:
@@ -61,6 +58,14 @@ options:
         default: False
       bucket_request_payment:
         description: Retrive S3 bucket request payment
+        type: bool
+        default: False
+      bucket_analytics_configuration:
+        description: Retrive S3 bucket analytics configuration
+        type: bool
+        default: False
+      bucket_metrics_configuration:
+        description: Retrive S3 bucket metrics configuration
         type: bool
         default: False
       bucket_tagging:
@@ -87,6 +92,10 @@ options:
         description: Retrive S3 bucket website
         type: bool
         default: False
+      bucket_inventory_configuration:
+        description: Retrive S3 bucket inventory configuration
+        type: bool
+        default: False
       bucket_policy:
         description: Retrive S3 bucket policy
         type: bool
@@ -99,20 +108,13 @@ options:
         description: Retrive S3 bucket lifecycle configuration
         type: bool
         default: False
-      public_access_block:
-        description: Retrive S3 bucket public access block
-        type: bool
-        default: False
     type: dict
-    version_added: 1.3.0
   transform_location:
     description:
       - S3 bucket location for default us-east-1 is normally reported as 'null'
       - setting this option to 'true' will return 'us-east-1' instead
-      - affects only queries with I(bucket_facts) > I(bucket_location) = true
     type: bool
     default: False
-    version_added: 1.3.0
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -195,7 +197,6 @@ def get_bucket_list(module, connection, name="", name_filter=""):
     buckets = []
     filtered_buckets = []
     final_buckets = []
-
     # Get all buckets
     try:
         buckets = camel_dict_to_snake_dict(connection.list_buckets())['buckets']
@@ -214,6 +215,24 @@ def get_bucket_list(module, connection, name="", name_filter=""):
 
     # Return proper list (filtered or all)
     if name or name_filter:
+        final_buckets = filtered_buckets
+    else:
+        final_buckets = buckets
+    return(final_buckets)
+
+
+    # Filter buckets if requested
+    if name_filter:
+        for bucket in buckets:
+            if name_filter in bucket['name']:
+                filtered_buckets.append(bucket)
+    elif name:
+        for bucket in buckets:
+            if name == bucket['name']:
+                filtered_buckets.append(bucket)
+
+    # Return proper list (filtered or all)
+    if filtered_buckets:
         final_buckets = filtered_buckets
     else:
         final_buckets = buckets
@@ -242,45 +261,29 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
     for key in requested_facts:
         if requested_facts[key]:
             if key == 'bucket_location':
-                all_facts[key] = {}
-                try:
-                    all_facts[key] = get_bucket_location(name, connection, transform_location)
-                # we just pass on error - error means that resources is undefined
-                except botocore.exceptions.ClientError:
-                    pass
-            elif key == 'bucket_tagging':
-                all_facts[key] = {}
-                try:
-                    all_facts[key] = get_bucket_tagging(name, connection)
-                # we just pass on error - error means that resources is undefined
-                except botocore.exceptions.ClientError:
-                    pass
+                all_facts[key] = get_bucket_location(name, connection, transform_location)
             else:
-                all_facts[key] = {}
-                try:
-                    all_facts[key] = get_bucket_property(name, connection, key)
-                # we just pass on error - error means that resources is undefined
-                except botocore.exceptions.ClientError:
-                    pass
+                all_facts[key] = get_bucket_property(name, connection, key)
 
     return(all_facts)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_location(name, connection, transform_location=False):
     """
     Get bucket location and optionally transform 'null' to 'us-east-1'
     """
-    data = connection.get_bucket_location(Bucket=name)
+    try:
+        data = connection.get_bucket_location(Bucket=name)
+    except botocore.exceptions.ClientError as err_msg:
+        data = {'error': err_msg}
 
-    # Replace 'null' with 'us-east-1'?
     if transform_location:
         try:
             if not data['LocationConstraint']:
                 data['LocationConstraint'] = 'us-east-1'
         except KeyError:
-            pass
-    # Strip response metadata (not needed)
+            data['transform_failed'] = True
+
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -288,35 +291,17 @@ def get_bucket_location(name, connection, transform_location=False):
         return(data)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
-def get_bucket_tagging(name, connection):
-    """
-    Get bucket tags and transform them using `boto3_tag_list_to_ansible_dict` function
-    """
-    data = connection.get_bucket_tagging(Bucket=name)
-
-    try:
-        bucket_tags = boto3_tag_list_to_ansible_dict(data['TagSet'])
-        return(bucket_tags)
-    except KeyError:
-        # Strip response metadata (not needed)
-        try:
-            data.pop('ResponseMetadata')
-            return(data)
-        except KeyError:
-            return(data)
-
-
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_property(name, connection, get_api_name):
     """
     Get bucket property
     """
     api_call = "get_" + get_api_name
     api_function = getattr(connection, api_call)
-    data = api_function(Bucket=name)
+    try:
+        data = api_function(Bucket=name)
+    except botocore.exceptions.ClientError as err_msg:
+        data = {'error': err_msg}
 
-    # Strip response metadata (not needed)
     try:
         data.pop('ResponseMetadata')
         return(data)
@@ -353,6 +338,33 @@ def main():
         transform_location=dict(type='bool', default=False)
     )
 
+    argument_spec = dict(
+        name=dict(type=str, default=""),
+        name_filter=dict(type=str, default=""),
+        bucket_facts=dict(type='dict', options=dict(
+            bucket_accelerate_configuration=dict(type=bool, default=False),
+            bucket_acl=dict(type=bool, default=False),
+            bucket_analytics_configuration=dict(type=bool, default=False),
+            bucket_cors=dict(type=bool, default=False),
+            bucket_encryption=dict(type=bool, default=False),
+            bucket_inventory_configuration=dict(type=bool, default=False),
+            bucket_lifecycle_configuration=dict(type=bool, default=False),
+            bucket_location=dict(type=bool, default=False),
+            bucket_logging=dict(type=bool, default=False),
+            bucket_metrics_configuration=dict(type=bool, default=False),
+            bucket_notification_configuration=dict(type=bool, default=False),
+            bucket_ownership_controls=dict(type=bool, default=False),
+            bucket_policy=dict(type=bool, default=False),
+            bucket_policy_status=dict(type=bool, default=False),
+            bucket_replication=dict(type=bool, default=False),
+            bucket_request_payment=dict(type=bool, default=False),
+            bucket_tagging=dict(type=bool, default=False),
+            bucket_website=dict(type=bool, default=False),
+            )),
+        transform_location=dict(type='bool', default=False)
+    )
+
+
     # Ensure we have an empty dict
     result = {}
 
@@ -383,12 +395,6 @@ def main():
 
     # Get basic bucket list (name + creation date)
     bucket_list = get_bucket_list(module, connection, name, name_filter)
-
-    # Add information about name/name_filter to result
-    if name:
-        result['bucket_name'] = name
-    elif name_filter:
-        result['bucket_name_filter'] = name_filter
 
     # Gather detailed information about buckets if requested
     bucket_facts = module.params.get("bucket_facts")

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -169,18 +169,6 @@ buckets:
       bucket_cors: dictionary data
       # ...etc
   type: list
-
-# if name options was specified
-bucket_name:
-  description: "Name of the bucket requested"
-  sample: "my_bucket"
-  type: str
-
-# if name_filter was specified
-bucket_name_filter:
-  description: "String to match bucket name"
-  sample: "buckets_prefix"
-  type: str
 '''
 
 try:

--- a/tests/integration/targets/aws_s3_bucket_info/aliases
+++ b/tests/integration/targets/aws_s3_bucket_info/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/tests/integration/targets/aws_s3_bucket_info/defaults/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+name_pattern: "testbucket-ansible-integration"
+
+testing_buckets:
+  - "{{ resource_prefix }}-{{ name_pattern }}-1"
+  - "{{ resource_prefix }}-{{ name_pattern }}-2"

--- a/tests/integration/targets/aws_s3_bucket_info/meta/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -89,5 +89,5 @@
     - name: Delete simple s3_buckets
       s3_bucket:
         name: "{{ item }}"
-        state: present
+        state: absent
       loop: "{{ testing_buckets }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -88,6 +88,7 @@
           - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
           - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
           - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
+          - item.bucket_location.LocationConstraint == aws_region
       loop: "{{ bucket_list.buckets }}"
       loop_control:
         label: "{{ item.name }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -11,9 +11,6 @@
       s3_bucket:
         name: "{{ item }}"
         state: present
-        tags:
-          integration: "verified"
-          facts: "defined"
       register: output
       loop: "{{ testing_buckets }}"
 
@@ -50,7 +47,7 @@
         transform_location: true
       register: bucket_list
 
-    - name: Assert that buckets list contains requested bucket facts
+    - name: Assert that buckets list contains requested facts
       assert:
         that:
           - item.name is search(name_pattern)
@@ -71,22 +68,10 @@
           - item.bucket_website is defined
           - item.public_access_block is defined
       loop: "{{ bucket_list.buckets }}"
-      loop_control:
-        label: "{{ item.name }}"
-
-    - name: Assert that retrieved bucket facts contains valid data
-      assert:
-        that:
-          - item.bucket_acl.Owner is defined
-          - item.bucket_tagging.facts is defined
-          - item.bucket_tagging.integration is defined
-      loop: "{{ bucket_list.buckets }}"
-      loop_control:
-        label: "{{ item.name }}"
 
   always:
     - name: Delete simple s3_buckets
       s3_bucket:
         name: "{{ item }}"
-        state: absent
+        state: present
       loop: "{{ testing_buckets }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -78,9 +78,9 @@
       assert:
         that:
           - item.bucket_acl.Owner is defined
-          - item.bucket_location.LocationConstraint is search(aws_region)
-          - item.bucket_tagging.facts is search("defined")
-          - item.bucket_tagging.integration is search("verified")
+          - item.bucket_location.LocationConstraint is defined
+          - item.bucket_tagging.facts is defined
+          - item.bucket_tagging.integration is defined
       loop: "{{ bucket_list.buckets }}"
       loop_control:
         label: "{{ item.name }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -11,6 +11,9 @@
       s3_bucket:
         name: "{{ item }}"
         state: present
+        tags:
+          integration: "verified"
+          facts: "defined"
       register: output
       loop: "{{ testing_buckets }}"
 
@@ -47,7 +50,7 @@
         transform_location: true
       register: bucket_list
 
-    - name: Assert that buckets list contains requested facts
+    - name: Assert that buckets list contains requested bucket facts
       assert:
         that:
           - item.name is search(name_pattern)
@@ -68,6 +71,20 @@
           - item.bucket_website is defined
           - item.public_access_block is defined
       loop: "{{ bucket_list.buckets }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Assert that retrieved bucket facts contains valid data
+      assert:
+        that:
+          - item.bucket_acl.Owner is defined
+          - item.bucket_location.LocationConstraint is search(aws_region)
+          - item.bucket_tagging.TagSet is defined
+          - item.bucket_tagging.TagSet is search("defined")
+          - item.bucket_tagging.TagSet is search("verified")
+      loop: "{{ bucket_list.buckets }}"
+      loop_control:
+        label: "{{ item.name }}"
 
   always:
     - name: Delete simple s3_buckets

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -78,7 +78,6 @@
       assert:
         that:
           - item.bucket_acl.Owner is defined
-          - item.bucket_location.LocationConstraint is defined
           - item.bucket_tagging.facts is defined
           - item.bucket_tagging.integration is defined
       loop: "{{ bucket_list.buckets }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -79,9 +79,8 @@
         that:
           - item.bucket_acl.Owner is defined
           - item.bucket_location.LocationConstraint is search(aws_region)
-          - item.bucket_tagging.TagSet is defined
-          - item.bucket_tagging.TagSet is search("defined")
-          - item.bucket_tagging.TagSet is search("verified")
+          - item.bucket_tagging.facts is search("defined")
+          - item.bucket_tagging.integration is search("verified")
       loop: "{{ bucket_list.buckets }}"
       loop_control:
         label: "{{ item.name }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+- name: Test community.aws.aws_s3_bucket_info
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: Create simple s3_buckets
+      s3_bucket:
+        name: "{{ item }}"
+        state: present
+      register: output
+      loop: "{{ testing_buckets }}"
+
+    - name: Get simple S3 bucket list
+      aws_s3_bucket_info:
+      register: bucket_list
+
+    - name: Assert result.changed == False and bucket list was retrieved
+      assert:
+        that:
+          - bucket_list.changed == False
+          - bucket_list.buckets
+
+    - name: Get complex S3 bucket list
+      aws_s3_bucket_info:
+        name_filter: "{{ name_pattern }}"
+        bucket_facts:
+          bucket_accelerate_configuration: true
+          bucket_acl: true
+          bucket_cors: true
+          bucket_encryption: true
+          bucket_lifecycle_configuration: true
+          bucket_location: true
+          bucket_logging: true
+          bucket_notification_configuration: true
+          bucket_ownership_controls: true
+          bucket_policy: true
+          bucket_policy_status: true
+          bucket_replication: true
+          bucket_request_payment: true
+          bucket_tagging: true
+          bucket_website: true
+          public_access_block: true
+        transform_location: true
+      register: bucket_list
+
+    - name: Assert that buckets list contains requested facts
+      assert:
+        that:
+          - item.name is search(name_pattern)
+          - item.bucket_accelerate_configuration is defined
+          - item.bucket_acl is defined
+          - item.bucket_cors is defined
+          - item.bucket_encryption is defined
+          - item.bucket_lifecycle_configuration is defined
+          - item.bucket_location is defined
+          - item.bucket_logging is defined
+          - item.bucket_notification_configuration is defined
+          - item.bucket_ownership_controls is defined
+          - item.bucket_policy is defined
+          - item.bucket_policy_status is defined
+          - item.bucket_replication is defined
+          - item.bucket_request_payment is defined
+          - item.bucket_tagging is defined
+          - item.bucket_website is defined
+          - item.public_access_block is defined
+      loop: "{{ bucket_list.buckets }}"
+
+  always:
+    - name: Delete simple s3_buckets
+      s3_bucket:
+        name: "{{ item }}"
+        state: present
+      loop: "{{ testing_buckets }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -12,8 +12,10 @@
         name: "{{ item }}"
         state: present
         tags:
-          integration: "verified"
-          facts: "defined"
+          "lowercase spaced": "hello cruel world"
+          "Title Case": "Hello Cruel World"
+          CamelCase: "SimpleCamelCase"
+          snake_case: "simple_snake_case"
       register: output
       loop: "{{ testing_buckets }}"
 
@@ -78,8 +80,14 @@
       assert:
         that:
           - item.bucket_acl.Owner is defined
-          - item.bucket_tagging.facts is defined
-          - item.bucket_tagging.integration is defined
+          - item.bucket_tagging.snake_case is defined
+          - item.bucket_tagging.CamelCase is defined
+          - item.bucket_tagging["lowercase spaced"] is defined
+          - item.bucket_tagging["Title Case"] is defined
+          - item.bucket_tagging.snake_case == 'simple_snake_case'
+          - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
+          - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
+          - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
       loop: "{{ bucket_list.buckets }}"
       loop_control:
         label: "{{ item.name }}"


### PR DESCRIPTION
##### SUMMARY
Adding a new functionality to the module.

- ability to filter retrieved bucket list by specifying bucket name or matching string. New options: `name:`, `name_filter:`
- retrieve additional bucket facts/configuration by specifying `bucket_facts:` sub-options (see ansible-doc)
- adding integration test for the module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_s3_bucket_info

##### ADDITIONAL INFORMATION
Example of extended bucket information
```json
{  
  "buckets": [
  {
        "bucket_location": {
            "LocationConstraint": "us-east-1"
        },
        "bucket_request_payment": {
            "Payer": "BucketOwner"
        },
        "bucket_tagging": {},
        "creation_date": "2020-10-12T14:00:42+00:00",
        "name": "testing-bucket",
        "public_access_block": {}
    }
  ]
}
```
