### PR TITLE
Improve elb_target_group stability

### DIFF
--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -380,12 +380,12 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     compare_aws_tags,
-                                                                     ansible_dict_to_boto3_tag_list,
-                                                                     )
 from distutils.version import LooseVersion
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 
 
 def get_tg_attributes(connection, module, tg_arn):

--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -380,7 +380,6 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from distutils.version import LooseVersion
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
@@ -437,7 +436,7 @@ def wait_for_status(connection, module, target_group_arn, targets, status):
 
 
 def fail_if_ip_target_type_not_supported(module):
-    if LooseVersion(botocore.__version__) < LooseVersion('1.7.2'):
+    if not module.botocore_at_least('1.7.2'):
         module.fail_json(msg="target_type ip requires botocore version 1.7.2 or later. Version %s is installed" %
                          botocore.__version__)
 

--- a/tests/integration/targets/elb_target/aliases
+++ b/tests/integration/targets/elb_target/aliases
@@ -1,4 +1,3 @@
 cloud/aws
 elb_target_group
 shippable/aws/group4
-unstable


### PR DESCRIPTION
##### SUMMARY

Adds retries to most boto3 calls and explicitly retries the describe call when we return NotFound on a newly created TG.

##### ISSUE TYPE

- Bugfix Pull Request

Fixes: #236 

##### COMPONENT NAME

elb _target_group

##### ADDITIONAL INFORMATION

CC @markuman 