### PR TITLE
catch ImportError rather than Exception when testing Boto3 imports

### DIFF
--- a/plugins/modules/aws_direct_connect_confirm_connection.py
+++ b/plugins/modules/aws_direct_connect_confirm_connection.py
@@ -67,9 +67,8 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError
-except Exception:
-    pass
-    # handled by imported AnsibleAWSModule
+except ImportError:
+    pass  # handled by imported AnsibleAWSModule
 
 retry_params = {"tries": 10, "delay": 5, "backoff": 1.2, "catch_extra_error_codes": ["DirectConnectClientException"]}
 

--- a/plugins/modules/aws_direct_connect_connection.py
+++ b/plugins/modules/aws_direct_connect_connection.py
@@ -166,9 +166,8 @@ from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import (
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError
-except Exception:
-    pass
-    # handled by imported AnsibleAWSModule
+except ImportError:
+    pass  # handled by imported AnsibleAWSModule
 
 retry_params = {"tries": 10, "delay": 5, "backoff": 1.2, "catch_extra_error_codes": ["DirectConnectClientException"]}
 

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -166,7 +166,7 @@ import time
 
 try:
     import botocore
-except Exception:
+except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/aws_s3_cors.py
+++ b/plugins/modules/aws_s3_cors.py
@@ -97,7 +97,7 @@ rules:
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
-except Exception:
+except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_transit_gateway.py
+++ b/plugins/modules/ec2_transit_gateway.py
@@ -222,9 +222,8 @@ transit_gateway:
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError
-except Exception:
-    pass
-    # handled by imported AnsibleAWSModule
+except ImportError:
+    pass  # handled by imported AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from time import sleep, time

--- a/plugins/modules/ec2_transit_gateway_info.py
+++ b/plugins/modules/ec2_transit_gateway_info.py
@@ -166,9 +166,8 @@ transit_gateways:
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError
-except Exception:
-    pass
-    # handled by imported AnsibleAWSModule
+except ImportError:
+    pass  # handled by imported AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -139,7 +139,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 
 try:
     from botocore.exceptions import ClientError
-except Exception:
+except ImportError:
     pass  # caught by AnsibleAWSModule
 
 

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -298,7 +298,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, bo
 
 try:
     import botocore
-except Exception:
+except ImportError:
     pass  # caught by AnsibleAWSModule
 
 


### PR DESCRIPTION
##### SUMMARY

Cleanup for consistency.

Catching `Exception` is generally considered bad.  Our boto3/botocore import stanzas generally use `ImportError` instead.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_direct_connect_confirm_connection.py
plugins/modules/aws_direct_connect_connection.py
plugins/modules/aws_direct_connect_link_aggregation_group.py
plugins/modules/aws_s3_cors.py
plugins/modules/ec2_transit_gateway.py
plugins/modules/ec2_transit_gateway_info.py
plugins/modules/lambda_policy.py
plugins/modules/rds_snapshot_info.py

##### ADDITIONAL INFORMATION