### PR TITLE
Cleanup - use is_boto3_error_(message|code)

### DIFF
--- a/changelogs/fragments/268-is_boto3_error.yml
+++ b/changelogs/fragments/268-is_boto3_error.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- various community.aws modules - cleanup error handling to use ``is_boto3_error_code`` and ``is_boto3_error_message`` helpers (https://github.com/ansible-collections/community.aws/pull/268).
+- various community.aws modules - improve consistency of handling Boto3 exceptions (https://github.com/ansible-collections/community.aws/pull/268).

--- a/plugins/modules/aws_elasticbeanstalk_app.py
+++ b/plugins/modules/aws_elasticbeanstalk_app.py
@@ -85,7 +85,7 @@ output:
 '''
 
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
@@ -105,7 +105,7 @@ def list_apps(ebs, app_name, module):
             apps = ebs.describe_applications(ApplicationNames=[app_name])
         else:
             apps = ebs.describe_applications()
-    except (BotoCoreError, ClientError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Could not describe application")
 
     return apps.get("Applications", [])
@@ -176,7 +176,7 @@ def main():
             try:
                 create_app = ebs.create_application(**filter_empty(ApplicationName=app_name,
                                                     Description=description))
-            except (BotoCoreError, ClientError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e, msg="Could not create application")
 
             app = describe_app(ebs, app_name, module)
@@ -189,7 +189,7 @@ def main():
                         ebs.update_application(ApplicationName=app_name)
                     else:
                         ebs.update_application(ApplicationName=app_name, Description=description)
-                except (BotoCoreError, ClientError) as e:
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     module.fail_json_aws(e, msg="Could not update application")
 
                 app = describe_app(ebs, app_name, module)
@@ -211,7 +211,7 @@ def main():
                 changed = True
             except is_boto3_error_message('It is currently pending deletion'):
                 changed = False
-            except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
                 module.fail_json_aws(e, msg="Cannot terminate app")
 
             result = dict(changed=changed, app=app)

--- a/plugins/modules/aws_glue_connection.py
+++ b/plugins/modules/aws_glue_connection.py
@@ -131,7 +131,8 @@ physical_connection_requirements:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, get_ec2_security_group_ids_from_names
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
 
 # Non-ansible imports
 import copy

--- a/plugins/modules/aws_glue_connection.py
+++ b/plugins/modules/aws_glue_connection.py
@@ -130,11 +130,6 @@ physical_connection_requirements:
     sample: {'subnet-id':'subnet-aabbccddee'}
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
-
 # Non-ansible imports
 import copy
 import time
@@ -142,6 +137,12 @@ try:
     import botocore
 except ImportError:
     pass
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
 
 
 def _get_glue_connection(connection, module):

--- a/plugins/modules/aws_glue_connection.py
+++ b/plugins/modules/aws_glue_connection.py
@@ -139,7 +139,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_secu
 import copy
 import time
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass
 
@@ -250,13 +250,13 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
                 update_params['Name'] = update_params['ConnectionInput']['Name']
                 connection.update_connection(**update_params)
                 changed = True
-            except (BotoCoreError, ClientError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e)
     else:
         try:
             connection.create_connection(**params)
             changed = True
-        except (BotoCoreError, ClientError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e)
 
     # If changed, get the Glue connection again
@@ -291,7 +291,7 @@ def delete_glue_connection(connection, module, glue_connection):
         try:
             connection.delete_connection(**params)
             changed = True
-        except (BotoCoreError, ClientError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e)
 
     module.exit_json(changed=changed)

--- a/plugins/modules/aws_glue_connection.py
+++ b/plugins/modules/aws_glue_connection.py
@@ -131,6 +131,7 @@ physical_connection_requirements:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
 
@@ -161,11 +162,8 @@ def _get_glue_connection(connection, module):
 
     try:
         return connection.get_connection(**params)['Connection']
-    except (BotoCoreError, ClientError) as e:
-        if e.response['Error']['Code'] == 'EntityNotFoundException':
-            return None
-        else:
-            raise e
+    except is_boto3_error_code('EntityNotFoundException'):
+        return None
 
 
 def _compare_glue_connection_params(user_params, current_params):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -185,15 +185,15 @@ timeout:
     sample: 300
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-
 # Non-ansible imports
 import copy
 try:
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
-    pass
+    pass  # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def _get_glue_job(connection, module, glue_job_name):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -193,6 +193,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -208,11 +209,10 @@ def _get_glue_job(connection, module, glue_job_name):
 
     try:
         return connection.get_job(JobName=glue_job_name)['Job']
-    except (BotoCoreError, ClientError) as e:
-        if e.response['Error']['Code'] == 'EntityNotFoundException':
-            return None
-        else:
-            module.fail_json_aws(e)
+    except is_boto3_error_code('EntityNotFoundException'):
+        return None
+    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e)
 
 
 def _compare_glue_job_params(user_params, current_params):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -192,9 +192,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def _get_glue_job(connection, module, glue_job_name):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -188,7 +188,7 @@ timeout:
 # Non-ansible imports
 import copy
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -211,7 +211,7 @@ def _get_glue_job(connection, module, glue_job_name):
         return connection.get_job(JobName=glue_job_name)['Job']
     except is_boto3_error_code('EntityNotFoundException'):
         return None
-    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
 
 
@@ -292,13 +292,13 @@ def create_or_update_glue_job(connection, module, glue_job):
                 del update_params['JobUpdate']['Name']
                 connection.update_job(**update_params)
                 changed = True
-            except (BotoCoreError, ClientError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e)
     else:
         try:
             connection.create_job(**params)
             changed = True
-        except (BotoCoreError, ClientError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e)
 
     # If changed, get the Glue job again
@@ -324,7 +324,7 @@ def delete_glue_job(connection, module, glue_job):
         try:
             connection.delete_job(JobName=glue_job['Name'])
             changed = True
-        except (BotoCoreError, ClientError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e)
 
     module.exit_json(changed=changed)

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -127,12 +127,12 @@ delete_parameter:
     type: dict
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-
 try:
     from botocore.exceptions import ClientError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
 
 def update_parameter(client, module, args):

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -133,6 +133,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 def update_parameter(client, module, args):
@@ -213,9 +214,9 @@ def delete_parameter(client, module):
         response = client.delete_parameter(
             Name=module.params.get('name')
         )
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'ParameterNotFound':
-            return False, {}
+    except is_boto3_error_code('ParameterNotFound'):
+        return False, {}
+    except ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="deleting parameter")
 
     return True, response

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -128,7 +128,7 @@ delete_parameter:
 '''
 
 try:
-    from botocore.exceptions import ClientError
+    import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -143,7 +143,7 @@ def update_parameter(client, module, args):
     try:
         response = client.put_parameter(**args)
         changed = True
-    except ClientError as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="setting parameter")
 
     return changed, response
@@ -196,7 +196,7 @@ def create_update_parameter(client, module):
                     describe_existing_parameter = describe_existing_parameter_paginator.paginate(
                         Filters=[{"Key": "Name", "Values": [args['Name']]}]).build_full_result()
 
-                except ClientError as e:
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     module.fail_json_aws(e, msg="getting description value")
 
                 if describe_existing_parameter['Parameters'][0]['Description'] != args['Description']:
@@ -216,7 +216,7 @@ def delete_parameter(client, module):
         )
     except is_boto3_error_code('ParameterNotFound'):
         return False, {}
-    except ClientError as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="deleting parameter")
 
     return True, response

--- a/plugins/modules/aws_step_functions_state_machine_execution.py
+++ b/plugins/modules/aws_step_functions_state_machine_execution.py
@@ -94,7 +94,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_er
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 try:
-    from botocore.exceptions import ClientError, BotoCoreError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -127,7 +127,7 @@ def start_execution(module, sfn_client):
     except is_boto3_error_code('ExecutionAlreadyExists'):
         # this will never be executed anymore
         module.exit_json(changed=False)
-    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed to start execution.")
 
     module.exit_json(changed=True, **camel_dict_to_snake_dict(res_execution))
@@ -152,7 +152,7 @@ def stop_execution(module, sfn_client):
             cause=cause,
             error=error
         )
-    except (ClientError, BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to stop execution.")
 
     module.exit_json(changed=True, **camel_dict_to_snake_dict(res))

--- a/plugins/modules/aws_step_functions_state_machine_execution.py
+++ b/plugins/modules/aws_step_functions_state_machine_execution.py
@@ -89,14 +89,15 @@ stop_date:
 '''
 
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-
 try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 def start_execution(module, sfn_client):

--- a/plugins/modules/aws_waf_condition.py
+++ b/plugins/modules/aws_waf_condition.py
@@ -403,9 +403,14 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, compare_policies
-from ansible_collections.amazon.aws.plugins.module_utils.waf import run_func_with_change_token_backoff, MATCH_LOOKUP
-from ansible_collections.amazon.aws.plugins.module_utils.waf import get_rule_with_backoff, list_rules_with_backoff, list_regional_rules_with_backoff
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
+from ansible_collections.amazon.aws.plugins.module_utils.waf import MATCH_LOOKUP
+from ansible_collections.amazon.aws.plugins.module_utils.waf import run_func_with_change_token_backoff
+from ansible_collections.amazon.aws.plugins.module_utils.waf import get_rule_with_backoff
+from ansible_collections.amazon.aws.plugins.module_utils.waf import list_regional_rules_with_backoff
+from ansible_collections.amazon.aws.plugins.module_utils.waf import list_rules_with_backoff
 
 
 class Condition(object):

--- a/plugins/modules/aws_waf_condition.py
+++ b/plugins/modules/aws_waf_condition.py
@@ -402,10 +402,11 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 from ansible_collections.amazon.aws.plugins.module_utils.waf import MATCH_LOOKUP
 from ansible_collections.amazon.aws.plugins.module_utils.waf import run_func_with_change_token_backoff

--- a/plugins/modules/aws_waf_condition.py
+++ b/plugins/modules/aws_waf_condition.py
@@ -403,6 +403,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
@@ -545,9 +546,9 @@ class Condition(object):
             run_func_with_change_token_backoff(self.client, self.module,
                                                {'RegexPatternSetId': regex_pattern_set_id},
                                                self.client.delete_regex_pattern_set, wait=True)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            if e.response['Error']['Code'] == 'WAFNonexistentItemException':
-                return
+        except is_boto3_error_code('WAFNonexistentItemException'):
+            return
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             self.module.fail_json_aws(e, msg='Could not delete regex pattern')
 
     def get_condition_by_name(self, name):

--- a/plugins/modules/cloudfront_invalidation.py
+++ b/plugins/modules/cloudfront_invalidation.py
@@ -139,7 +139,7 @@ location:
 import datetime
 
 try:
-    from botocore.exceptions import ClientError, BotoCoreError
+    import botocore
 except ImportError:
     pass  # caught by imported AnsibleAWSModule
 
@@ -173,7 +173,7 @@ class CloudFrontInvalidationServiceManager(object):
             self.module.warn("InvalidationBatch target paths are not modifiable. "
                              "To make a new invalidation please update caller_reference.")
             return current_invalidation_response, False
-        except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             self.module.fail_json_aws(e, msg="Error creating CloudFront invalidations.")
 
     def get_invalidation(self, distribution_id, caller_reference):
@@ -183,7 +183,7 @@ class CloudFrontInvalidationServiceManager(object):
             paginator = self.client.get_paginator('list_invalidations')
             invalidations = paginator.paginate(DistributionId=distribution_id).build_full_result().get('InvalidationList', {}).get('Items', [])
             invalidation_ids = [inv['Id'] for inv in invalidations]
-        except (BotoCoreError, ClientError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error listing CloudFront invalidations.")
 
         # check if there is an invalidation with the same caller reference
@@ -191,7 +191,7 @@ class CloudFrontInvalidationServiceManager(object):
             try:
                 invalidation = self.client.get_invalidation(DistributionId=distribution_id, Id=inv_id)['Invalidation']
                 caller_ref = invalidation.get('InvalidationBatch', {}).get('CallerReference')
-            except (BotoCoreError, ClientError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 self.module.fail_json_aws(e, msg="Error getting CloudFront invalidation {0}".format(inv_id))
             if caller_ref == caller_reference:
                 current_invalidation = invalidation
@@ -217,7 +217,7 @@ class CloudFrontInvalidationValidationManager(object):
             if distribution_id is None:
                 distribution_id = self.__cloudfront_facts_mgr.get_distribution_id_from_domain_name(alias)
             return distribution_id
-        except (ClientError, BotoCoreError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error validating parameters.")
 
     def create_aws_list(self, invalidation_batch):
@@ -237,7 +237,7 @@ class CloudFrontInvalidationValidationManager(object):
                 'caller_reference': valid_caller_reference
             }
             return valid_invalidation_batch
-        except (ClientError, BotoCoreError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error validating invalidation batch.")
 
 

--- a/plugins/modules/cloudfront_invalidation.py
+++ b/plugins/modules/cloudfront_invalidation.py
@@ -136,16 +136,17 @@ location:
   sample: https://cloudfront.amazonaws.com/2017-03-25/distribution/E1ZID6KZJECZY7/invalidation/I2G9MOWJZFV622
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
 import datetime
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by imported AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
 
 
 class CloudFrontInvalidationServiceManager(object):

--- a/plugins/modules/cloudfront_invalidation.py
+++ b/plugins/modules/cloudfront_invalidation.py
@@ -143,10 +143,11 @@ try:
 except ImportError:
     pass  # caught by imported AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_message
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
 
 

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -155,6 +155,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -174,12 +175,9 @@ class CloudWatchEventRule(object):
         """Returns the existing details of the rule in AWS"""
         try:
             rule_info = self.client.describe_rule(Name=self.name)
-        except botocore.exceptions.ClientError as e:
-            error_code = e.response.get('Error', {}).get('Code')
-            if error_code == 'ResourceNotFoundException':
-                return {}
-            self.module.fail_json_aws(e, msg="Could not describe rule %s" % self.name)
-        except botocore.exceptions.BotoCoreError as e:
+        except is_boto3_error_code('ResourceNotFoundException'):
+            return {}
+        except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
             self.module.fail_json_aws(e, msg="Could not describe rule %s" % self.name)
         return self._snakify(rule_info)
 
@@ -237,12 +235,9 @@ class CloudWatchEventRule(object):
         """Lists the existing targets for the rule in AWS"""
         try:
             targets = self.client.list_targets_by_rule(Rule=self.name)
-        except botocore.exceptions.ClientError as e:
-            error_code = e.response.get('Error', {}).get('Code')
-            if error_code == 'ResourceNotFoundException':
-                return []
-            self.module.fail_json_aws(e, msg="Could not find target for rule %s" % self.name)
-        except botocore.exceptions.BotoCoreError as e:
+        except is_boto3_error_code('ResourceNotFoundException'):
+            return []
+        except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
             self.module.fail_json_aws(e, msg="Could not find target for rule %s" % self.name)
         return self._snakify(targets)['targets']
 

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -154,9 +154,10 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class CloudWatchEventRule(object):

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -255,7 +255,7 @@ def pipeline_description(client, dp_id):
     """
     try:
         return client.describe_pipelines(pipelineIds=[dp_id])
-    except ClientError as e:
+    except ClientError:
         raise DataPipelineNotFound
 
 

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -203,7 +203,6 @@ import time
 
 try:
     import botocore
-    from botocore.exceptions import ClientError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -255,7 +254,7 @@ def pipeline_description(client, dp_id):
     """
     try:
         return client.describe_pipelines(pipelineIds=[dp_id])
-    except ClientError:
+    except is_boto3_error_code('PipelineNotFoundException', 'PipelineDeletedException'):
         raise DataPipelineNotFound
 
 

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -211,6 +211,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 DP_ACTIVE_STATES = ['ACTIVE', 'SCHEDULED']
@@ -361,9 +362,8 @@ def activate_pipeline(client, module):
     else:
         try:
             client.activate_pipeline(pipelineId=dp_id)
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "InvalidRequestException":
-                module.fail_json(msg="You need to populate your pipeline before activation.")
+        except is_boto3_error_code('InvalidRequestException'):
+            module.fail_json(msg="You need to populate your pipeline before activation.")
         try:
             pipeline_status_timeout(client, dp_id, status=DP_ACTIVE_STATES,
                                     timeout=timeout)

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -595,13 +595,13 @@ def describe_launch_templates(connection, launch_template):
         try:
             lt = connection.describe_launch_templates(LaunchTemplateIds=[launch_template['launch_template_id']])
             return lt
-        except (botocore.exceptions.ClientError) as e:
+        except is_boto3_error_code('InvalidLaunchTemplateName.NotFoundException'):
             module.fail_json(msg="No launch template found matching: %s" % launch_template)
     else:
         try:
             lt = connection.describe_launch_templates(LaunchTemplateNames=[launch_template['launch_template_name']])
             return lt
-        except (botocore.exceptions.ClientError) as e:
+        except is_boto3_error_code('InvalidLaunchTemplateName.NotFoundException'):
             module.fail_json(msg="No launch template found matching: %s" % launch_template)
 
 

--- a/plugins/modules/ec2_asg_info.py
+++ b/plugins/modules/ec2_asg_info.py
@@ -223,9 +223,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def match_asg_tags(tags_to_match, asg):

--- a/plugins/modules/ec2_asg_info.py
+++ b/plugins/modules/ec2_asg_info.py
@@ -219,7 +219,7 @@ termination_policies:
 import re
 
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -331,7 +331,7 @@ def find_asgs(conn, module, name=None, tags=None):
     try:
         asgs_paginator = conn.get_paginator('describe_auto_scaling_groups')
         asgs = asgs_paginator.paginate().build_full_result()
-    except (BotoCoreError, ClientError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Failed to describe AutoScalingGroups')
 
     if not asgs:
@@ -339,7 +339,7 @@ def find_asgs(conn, module, name=None, tags=None):
 
     try:
         elbv2 = module.client('elbv2')
-    except ClientError as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         # This is nice to have, not essential
         elbv2 = None
     matched_asgs = []
@@ -376,7 +376,7 @@ def find_asgs(conn, module, name=None, tags=None):
                         asg['target_group_names'] = [tg['TargetGroupName'] for tg in tg_result['TargetGroups']]
                     except is_boto3_error_code('TargetGroupNotFound'):
                         asg['target_group_names'] = []
-                    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+                    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
                         module.fail_json_aws(e, msg="Failed to describe Target Groups")
             else:
                 asg['target_group_names'] = []

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -813,6 +813,7 @@ from ansible.module_utils.common.dict_transformations import snake_dict_to_camel
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.urllib import parse as urlparse
 
+import ansible_collections.amazon.aws.plugins.module_utils.ec2 as ec2_utils
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -815,6 +815,7 @@ from ansible.module_utils.six.moves.urllib import parse as urlparse
 
 import ansible_collections.amazon.aws.plugins.module_utils.ec2 as ec2_utils
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
@@ -1121,15 +1122,13 @@ def discover_security_groups(group, groups, parent_vpc_id=None, subnet_id=None, 
     if subnet_id is not None:
         try:
             sub = ec2.describe_subnets(aws_retry=True, SubnetIds=[subnet_id])
-        except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidGroup.NotFound':
-                module.fail_json(
-                    "Could not find subnet {0} to associate security groups. Please check the vpc_subnet_id and security_groups parameters.".format(
-                        subnet_id
-                    )
+        except is_boto3_error_code('InvalidGroup.NotFound'):
+            module.fail_json(
+                "Could not find subnet {0} to associate security groups. Please check the vpc_subnet_id and security_groups parameters.".format(
+                    subnet_id
                 )
-            module.fail_json_aws(e, msg="Error while searching for subnet {0} parent VPC.".format(subnet_id))
-        except botocore.exceptions.BotoCoreError as e:
+            )
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Error while searching for subnet {0} parent VPC.".format(subnet_id))
         parent_vpc_id = sub['Subnets'][0]['VpcId']
 
@@ -1617,9 +1616,9 @@ def determine_iam_role(name_or_arn):
     try:
         role = iam.get_instance_profile(InstanceProfileName=name_or_arn, aws_retry=True)
         return role['InstanceProfile']['Arn']
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            module.fail_json_aws(e, msg="Could not find instance_role {0}".format(name_or_arn))
+    except is_boto3_error_code('NoSuchEntity'):
+        module.fail_json_aws(e, msg="Could not find instance_role {0}".format(name_or_arn))
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="An error occurred while searching for instance_role {0}. Please try supplying the full ARN.".format(name_or_arn))
 
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -813,7 +813,6 @@ from ansible.module_utils.common.dict_transformations import snake_dict_to_camel
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.urllib import parse as urlparse
 
-import ansible_collections.amazon.aws.plugins.module_utils.ec2 as ec2_utils
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_message

--- a/plugins/modules/ec2_placement_group.py
+++ b/plugins/modules/ec2_placement_group.py
@@ -87,12 +87,13 @@ placement_group:
 
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 try:
     from botocore.exceptions import (BotoCoreError, ClientError)
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/ec2_placement_group.py
+++ b/plugins/modules/ec2_placement_group.py
@@ -88,7 +88,7 @@ placement_group:
 '''
 
 try:
-    from botocore.exceptions import (BotoCoreError, ClientError)
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -106,7 +106,7 @@ def get_placement_group_details(connection, module):
                 "Name": "group-name",
                 "Values": [name]
             }])
-    except (BotoCoreError, ClientError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(
             e,
             msg="Couldn't find placement group named [%s]" % name)
@@ -136,7 +136,7 @@ def create_placement_group(connection, module):
             "state": 'DryRun',
             "strategy": strategy,
         })
-    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(
             e,
             msg="Couldn't create placement group [%s]" % name)
@@ -154,7 +154,7 @@ def delete_placement_group(connection, module):
     try:
         connection.delete_placement_group(
             GroupName=name, DryRun=module.check_mode)
-    except (BotoCoreError, ClientError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(
             e,
             msg="Couldn't delete placement group [%s]" % name)

--- a/plugins/modules/ec2_transit_gateway_info.py
+++ b/plugins/modules/ec2_transit_gateway_info.py
@@ -170,6 +170,7 @@ except ImportError:
     pass  # handled by imported AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
@@ -206,11 +207,9 @@ class AnsibleEc2TgwInfo(object):
         try:
             response = self._connection.describe_transit_gateways(
                 TransitGatewayIds=transit_gateway_ids, Filters=filters)
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidTransitGatewayID.NotFound':
-                self._results['transit_gateways'] = []
-                return
-            raise
+        except is_boto3_error_code('InvalidTransitGatewayID.NotFound'):
+            self._results['transit_gateways'] = []
+            return
 
         for transit_gateway in response['TransitGateways']:
             transit_gateway_info.append(camel_dict_to_snake_dict(transit_gateway, ignore_list=['Tags']))

--- a/plugins/modules/ec2_transit_gateway_info.py
+++ b/plugins/modules/ec2_transit_gateway_info.py
@@ -169,12 +169,13 @@ try:
 except ImportError:
     pass  # handled by imported AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class AnsibleEc2TgwInfo(object):

--- a/plugins/modules/ec2_transit_gateway_info.py
+++ b/plugins/modules/ec2_transit_gateway_info.py
@@ -165,7 +165,7 @@ transit_gateways:
 '''
 
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass  # handled by imported AnsibleAWSModule
 
@@ -250,7 +250,7 @@ def main():
     tgwf_manager = AnsibleEc2TgwInfo(module=module, results=results)
     try:
         tgwf_manager.describe_transit_gateways()
-    except (BotoCoreError, ClientError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e)
 
     module.exit_json(**results)

--- a/plugins/modules/ec2_transit_gateway_info.py
+++ b/plugins/modules/ec2_transit_gateway_info.py
@@ -170,12 +170,10 @@ except ImportError:
     pass  # handled by imported AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    AWSRetry,
-    boto3_tag_list_to_ansible_dict,
-    camel_dict_to_snake_dict,
-    ansible_dict_to_boto3_filter_list
-)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class AnsibleEc2TgwInfo(object):

--- a/plugins/modules/ec2_vpc_egress_igw.py
+++ b/plugins/modules/ec2_vpc_egress_igw.py
@@ -57,14 +57,13 @@ vpc_id:
     sample: vpc-012345678
 '''
 
-
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-
 try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def delete_eigw(module, conn, eigw_id):

--- a/plugins/modules/ec2_vpc_egress_igw.py
+++ b/plugins/modules/ec2_vpc_egress_igw.py
@@ -62,9 +62,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def delete_eigw(module, conn, eigw_id):

--- a/plugins/modules/ec2_vpc_egress_igw.py
+++ b/plugins/modules/ec2_vpc_egress_igw.py
@@ -63,6 +63,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -78,14 +79,9 @@ def delete_eigw(module, conn, eigw_id):
 
     try:
         response = conn.delete_egress_only_internet_gateway(DryRun=module.check_mode, EgressOnlyInternetGatewayId=eigw_id)
-    except botocore.exceptions.ClientError as e:
-        # When boto3 method is run with DryRun=True it returns an error on success
-        # We need to catch the error and return something valid
-        if e.response.get('Error', {}).get('Code') == "DryRunOperation":
-            changed = True
-        else:
-            module.fail_json_aws(e, msg="Could not delete Egress-Only Internet Gateway {0} from VPC {1}".format(eigw_id, module.vpc_id))
-    except botocore.exceptions.BotoCoreError as e:
+    except is_boto3_error_code('DryRunOperation'):
+        changed = True
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Could not delete Egress-Only Internet Gateway {0} from VPC {1}".format(eigw_id, module.vpc_id))
 
     if not module.check_mode:
@@ -107,16 +103,13 @@ def create_eigw(module, conn, vpc_id):
 
     try:
         response = conn.create_egress_only_internet_gateway(DryRun=module.check_mode, VpcId=vpc_id)
-    except botocore.exceptions.ClientError as e:
+    except is_boto3_error_code('DryRunOperation'):
         # When boto3 method is run with DryRun=True it returns an error on success
         # We need to catch the error and return something valid
-        if e.response.get('Error', {}).get('Code') == "DryRunOperation":
-            changed = True
-        elif e.response.get('Error', {}).get('Code') == "InvalidVpcID.NotFound":
-            module.fail_json_aws(e, msg="invalid vpc ID '{0}' provided".format(vpc_id))
-        else:
-            module.fail_json_aws(e, msg="Could not create Egress-Only Internet Gateway for vpc ID {0}".format(vpc_id))
-    except botocore.exceptions.BotoCoreError as e:
+        changed = True
+    except is_boto3_error_code('InvalidVpcID.NotFound') as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="invalid vpc ID '{0}' provided".format(vpc_id))
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Could not create Egress-Only Internet Gateway for vpc ID {0}".format(vpc_id))
 
     if not module.check_mode:

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -109,11 +109,12 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -110,11 +110,10 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AWSRetry,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     camel_dict_to_snake_dict,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 
 # VPC-supported IANA protocol numbers

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -110,6 +110,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -131,11 +132,9 @@ def list_ec2_vpc_nacls(connection, module):
 
     try:
         nacls = connection.describe_network_acls(aws_retry=True, NetworkAclIds=nacl_ids, Filters=filters)
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidNetworkAclID.NotFound':
-            module.fail_json(msg='Unable to describe ACL.  NetworkAcl does not exist')
-        module.fail_json_aws(e, msg="Unable to describe network ACLs {0}".format(nacl_ids))
-    except BotoCoreError as e:
+    except is_boto3_error_code('InvalidNetworkAclID.NotFound'):
+        module.fail_json(msg='Unable to describe ACL.  NetworkAcl does not exist')
+    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to describe network ACLs {0}".format(nacl_ids))
 
     # Turn the boto3 result in to ansible_friendly_snaked_names

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -105,7 +105,7 @@ nacls:
 '''
 
 try:
-    from botocore.exceptions import ClientError, BotoCoreError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -134,7 +134,7 @@ def list_ec2_vpc_nacls(connection, module):
         nacls = connection.describe_network_acls(aws_retry=True, NetworkAclIds=nacl_ids, Filters=filters)
     except is_boto3_error_code('InvalidNetworkAclID.NotFound'):
         module.fail_json(msg='Unable to describe ACL.  NetworkAcl does not exist')
-    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to describe network ACLs {0}".format(nacl_ids))
 
     # Turn the boto3 result in to ansible_friendly_snaked_names

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -226,18 +226,21 @@ route_table:
 
 import re
 from time import sleep
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, snake_dict_to_camel_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags, AWSRetry
-
 
 try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 
 
 CIDR_RE = re.compile(r'^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$')

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -233,6 +233,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
@@ -373,11 +374,8 @@ def ensure_tags(connection=None, module=None, resource_id=None, tags=None, purge
 def describe_route_tables_with_backoff(connection, **params):
     try:
         return connection.describe_route_tables(**params)['RouteTables']
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidRouteTableID.NotFound':
-            return None
-        else:
-            raise
+    except is_boto3_error_code('InvalidRouteTableID.NotFound'):
+        return None
 
 
 def get_route_table_by_id(connection, module, route_table_id):

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -232,15 +232,16 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
 from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 
 

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -195,6 +195,7 @@ except ImportError:
 from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import sort_json_policy_dict
@@ -227,11 +228,8 @@ class EcsEcr:
                 repositoryNames=[name], **build_kwargs(registry_id))
             repos = res.get('repositories')
             return repos and repos[0]
-        except ClientError as err:
-            code = err.response['Error'].get('Code', 'Unknown')
-            if code == 'RepositoryNotFoundException':
-                return None
-            raise
+        except is_boto3_error_code('RepositoryNotFoundException'):
+            return None
 
     def get_repository_policy(self, registry_id, name):
         try:
@@ -239,11 +237,8 @@ class EcsEcr:
                 repositoryName=name, **build_kwargs(registry_id))
             text = res.get('policyText')
             return text and json.loads(text)
-        except ClientError as err:
-            code = err.response['Error'].get('Code', 'Unknown')
-            if code == 'RepositoryPolicyNotFoundException':
-                return None
-            raise
+        except is_boto3_error_code('RepositoryPolicyNotFoundException'):
+            return None
 
     def create_repository(self, registry_id, name, image_tag_mutability):
         if registry_id:
@@ -330,11 +325,8 @@ class EcsEcr:
                 repositoryName=name, **build_kwargs(registry_id))
             text = res.get('lifecyclePolicyText')
             return text and json.loads(text)
-        except ClientError as err:
-            code = err.response['Error'].get('Code', 'Unknown')
-            if code == 'LifecyclePolicyNotFoundException':
-                return None
-            raise
+        except is_boto3_error_code('LifecyclePolicyNotFoundException'):
+            return None
 
     def put_lifecycle_policy(self, registry_id, name, policy_text):
         if not self.check_mode:

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -188,7 +188,7 @@ import json
 import traceback
 
 try:
-    from botocore.exceptions import ClientError
+    import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -513,7 +513,7 @@ def run(ecr, params):
 
     except Exception as err:
         msg = str(err)
-        if isinstance(err, ClientError):
+        if isinstance(err, botocore.exceptions.ClientError):
             msg = boto_exception(err)
         result['msg'] = msg
         result['exception'] = traceback.format_exc()

--- a/plugins/modules/efs.py
+++ b/plugins/modules/efs.py
@@ -235,6 +235,7 @@ except ImportError as e:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -623,8 +624,8 @@ def iterate_all(attr, map_method, **kwargs):
                 args['Marker'] = data['Nextmarker']
                 continue
             break
-        except ClientError as e:
-            if e.response['Error']['Code'] == "ThrottlingException" and wait < 600:
+        except is_boto3_error_code('ThrottlingException'):
+            if wait < 600:
                 sleep(wait)
                 wait = wait * 2
                 continue

--- a/plugins/modules/efs.py
+++ b/plugins/modules/efs.py
@@ -230,7 +230,7 @@ from time import sleep
 from time import time as timestamp
 
 try:
-    from botocore.exceptions import ClientError, BotoCoreError
+    import botocore
 except ImportError as e:
     pass  # Handled by AnsibleAWSModule
 
@@ -431,7 +431,7 @@ class EFSConnection(object):
             try:
                 self.connection.create_file_system(**params)
                 changed = True
-            except (ClientError, BotoCoreError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 self.module.fail_json_aws(e, msg="Unable to create file system.")
 
         # we always wait for the state to be available when creating.
@@ -469,7 +469,7 @@ class EFSConnection(object):
                 try:
                     self.connection.update_file_system(FileSystemId=fs_id, **params)
                     changed = True
-                except (ClientError, BotoCoreError) as e:
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Unable to update file system.")
         return changed
 
@@ -489,7 +489,7 @@ class EFSConnection(object):
                         FileSystemId=fs_id,
                         TagKeys=tags_to_delete
                     )
-                except (ClientError, BotoCoreError) as e:
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Unable to delete tags.")
 
                 result = True
@@ -500,7 +500,7 @@ class EFSConnection(object):
                         FileSystemId=fs_id,
                         Tags=ansible_dict_to_boto3_tag_list(tags_need_modify)
                     )
-                except (ClientError, BotoCoreError) as e:
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Unable to create tags.")
 
                 result = True

--- a/plugins/modules/efs.py
+++ b/plugins/modules/efs.py
@@ -234,11 +234,12 @@ try:
 except ImportError as e:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 
 

--- a/plugins/modules/efs.py
+++ b/plugins/modules/efs.py
@@ -235,11 +235,10 @@ except ImportError as e:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (compare_aws_tags,
-                                                                     camel_dict_to_snake_dict,
-                                                                     ansible_dict_to_boto3_tag_list,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 
 
 def _index_by_key(key, items):

--- a/plugins/modules/elasticache_info.py
+++ b/plugins/modules/elasticache_info.py
@@ -225,6 +225,7 @@ elasticache_clusters:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
@@ -243,12 +244,8 @@ def describe_cache_clusters_with_backoff(client, cluster_id=None):
         params['CacheClusterId'] = cluster_id
     try:
         response = paginator.paginate(**params).build_full_result()
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'CacheClusterNotFound':
-            return []
-        raise
-    except botocore.exceptions.BotoCoreError:
-        raise
+    except is_boto3_error_code('CacheClusterNotFound'):
+        return []
     return response['CacheClusters']
 
 

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -119,6 +119,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 def create(module, connection, replication_id, cluster_id, name):
@@ -128,12 +129,11 @@ def create(module, connection, replication_id, cluster_id, name):
                                               CacheClusterId=cluster_id,
                                               SnapshotName=name)
         changed = True
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == "SnapshotAlreadyExistsFault":
-            response = {}
-            changed = False
-        else:
-            module.fail_json_aws(e, msg="Unable to create the snapshot.")
+    except is_boto3_error_code('SnapshotAlreadyExistsFault'):
+        response = {}
+        changed = False
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Unable to create the snapshot.")
     return response, changed
 
 
@@ -154,15 +154,14 @@ def delete(module, connection, name):
     try:
         response = connection.delete_snapshot(SnapshotName=name)
         changed = True
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == "SnapshotNotFoundFault":
-            response = {}
-            changed = False
-        elif e.response['Error']['Code'] == "InvalidSnapshotState":
-            module.fail_json(msg="Error: InvalidSnapshotState. The snapshot is not in an available state or failed state to allow deletion."
-                             "You may need to wait a few minutes.")
-        else:
-            module.fail_json_aws(e, msg="Unable to delete the snapshot.")
+    except is_boto3_error_code('SnapshotNotFoundFault'):
+        response = {}
+        changed = False
+    except is_boto3_error_code('InvalidSnapshotState'):  # pylint: disable=duplicate-except
+        module.fail_json(msg="Error: InvalidSnapshotState. The snapshot is not in an available state or failed state to allow deletion."
+                         "You may need to wait a few minutes.")
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Unable to delete the snapshot.")
     return response, changed
 
 

--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -379,12 +379,13 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 
 

--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -381,11 +381,11 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 
 
 def get_tg_attributes(connection, module, tg_arn):

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -177,14 +177,14 @@ iam_group:
                     sample: /
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-
 try:
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
 def compare_attached_group_policies(current_attached_policies, new_attached_policies):

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -183,6 +183,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
@@ -386,11 +387,8 @@ def get_group(connection, module, name):
     try:
         paginator = connection.get_paginator('get_group')
         return paginator.paginate(GroupName=name).build_full_result()
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            return None
-        else:
-            raise
+    except is_boto3_error_code('NoSuchEntity'):
+        return None
 
 
 @AWSRetry.exponential_backoff()
@@ -399,11 +397,8 @@ def get_attached_policy_list(connection, module, name):
     try:
         paginator = connection.get_paginator('list_attached_group_policies')
         return paginator.paginate(GroupName=name).build_full_result()['AttachedPolicies']
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            return None
-        else:
-            raise
+    except is_boto3_error_code('NoSuchEntity'):
+        return None
 
 
 def main():

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -182,9 +182,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 

--- a/plugins/modules/iam_password_policy.py
+++ b/plugins/modules/iam_password_policy.py
@@ -104,6 +104,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -169,11 +170,10 @@ class IAMConnection(object):
     def delete_password_policy(self, policy):
         try:
             results = policy.delete()
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            if e.response['Error']['Code'] == 'NoSuchEntity':
-                self.module.exit_json(changed=False, task_status={'IAM': "Couldn't find IAM Password Policy"})
-            else:
-                self.module.fail_json_aws(e, msg="Couldn't delete IAM Password Policy")
+        except is_boto3_error_code('NoSuchEntity'):
+            self.module.exit_json(changed=False, task_status={'IAM': "Couldn't find IAM Password Policy"})
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
+            self.module.fail_json_aws(e, msg="Couldn't delete IAM Password Policy")
         return camel_dict_to_snake_dict(results)
 
 

--- a/plugins/modules/iam_password_policy.py
+++ b/plugins/modules/iam_password_policy.py
@@ -103,9 +103,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class IAMConnection(object):

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -87,10 +87,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_er
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
-class PolicyError(Exception):
-    pass
-
-
 class Policy:
 
     def __init__(self, client, name, policy_name):
@@ -207,8 +203,6 @@ def main():
         module.exit_json(changed=False, msg=e.response['Error']['Message'])
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
-    except PolicyError as e:
-        module.fail_json(msg=str(e))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -82,6 +82,8 @@ try:
 except ImportError:
     pass
 
+from ansible.module_utils.six import string_types
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -85,6 +85,7 @@ except ImportError:
 from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
@@ -204,9 +205,9 @@ def main():
             policy = GroupPolicy(**args)
 
         module.exit_json(**(policy.run()))
-    except (BotoCoreError, ClientError) as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            module.exit_json(changed=False, msg=e.response['Error']['Message'])
+    except is_boto3_error_code('NoSuchEntity') as e:
+        module.exit_json(changed=False, msg=e.response['Error']['Message'])
+    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
     except PolicyError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -78,7 +78,7 @@ all_policy_names:
 '''
 
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass
 
@@ -205,7 +205,7 @@ def main():
         module.exit_json(**(policy.run()))
     except is_boto3_error_code('NoSuchEntity') as e:
         module.exit_json(changed=False, msg=e.response['Error']['Message'])
-    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
     except PolicyError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -82,8 +82,6 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils.six import string_types
-
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry

--- a/plugins/modules/iam_role.py
+++ b/plugins/modules/iam_role.py
@@ -194,18 +194,18 @@ iam_role:
 
 import json
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, compare_policies
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AWSRetry,
-                                                                     ansible_dict_to_boto3_tag_list,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     compare_aws_tags,
-                                                                     )
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 
 
 def compare_assume_role_policy_doc(current_policy_doc, new_policy_doc):

--- a/plugins/modules/iam_role.py
+++ b/plugins/modules/iam_role.py
@@ -199,12 +199,13 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -152,11 +152,12 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -153,7 +153,9 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -153,6 +153,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -210,12 +211,9 @@ def describe_iam_roles(module, client):
     if name:
         try:
             roles = [client.get_role(RoleName=name)['Role']]
-        except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'NoSuchEntity':
-                return []
-            else:
-                module.fail_json_aws(e, msg="Couldn't get IAM role %s" % name)
-        except botocore.exceptions.BotoCoreError as e:
+        except is_boto3_error_code('NoSuchEntity'):
+            return []
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Couldn't get IAM role %s" % name)
     else:
         params = dict()

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -115,6 +115,7 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 def compare_attached_policies(current_attached_policies, new_attached_policies):
@@ -297,34 +298,30 @@ def get_user(connection, module, name):
 
     try:
         return connection.get_user(**params)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            return None
-        else:
-            module.fail_json(msg="Unable to get user {0}: {1}".format(name, to_native(e)),
-                             **camel_dict_to_snake_dict(e.response))
+    except is_boto3_error_code('NoSuchEntity'):
+        return None
+    except ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Unable to get user {0}".format(name))
 
 
 def get_attached_policy_list(connection, module, name):
 
     try:
         return connection.list_attached_user_policies(UserName=name)['AttachedPolicies']
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            return None
-        else:
-            module.fail_json_aws(e, msg="Unable to get policies for user {0}".format(name))
+    except is_boto3_error_code('NoSuchEntity'):
+        return None
+    except ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Unable to get policies for user {0}".format(name))
 
 
 def delete_user_login_profile(connection, module, user_name):
 
     try:
         return connection.delete_login_profile(UserName=user_name)
-    except botocore.exceptions.ClientError as e:
-        if e.response["Error"]["Code"] == "NoSuchEntity":
-            return None
-        else:
-            module.fail_json_aws(e, msg="Unable to delete login profile for user {0}".format(user_name))
+    except is_boto3_error_code('NoSuchEntity'):
+        return None
+    except ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Unable to delete login profile for user {0}".format(user_name))
 
 
 def main():

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -300,7 +300,7 @@ def get_user(connection, module, name):
         return connection.get_user(**params)
     except is_boto3_error_code('NoSuchEntity'):
         return None
-    except ClientError as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to get user {0}".format(name))
 
 
@@ -310,7 +310,7 @@ def get_attached_policy_list(connection, module, name):
         return connection.list_attached_user_policies(UserName=name)['AttachedPolicies']
     except is_boto3_error_code('NoSuchEntity'):
         return None
-    except ClientError as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to get policies for user {0}".format(name))
 
 
@@ -320,7 +320,7 @@ def delete_user_login_profile(connection, module, user_name):
         return connection.delete_login_profile(UserName=user_name)
     except is_boto3_error_code('NoSuchEntity'):
         return None
-    except ClientError as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to delete login profile for user {0}".format(user_name))
 
 

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -111,7 +111,6 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -144,7 +144,7 @@ name:
 import re
 
 try:
-    from botocore.exceptions import ClientError, BotoCoreError
+    import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -183,12 +183,12 @@ class AWSConnection:
             if not self.region:
                 self.region = self.resource_client['lambda'].meta.region_name
 
-        except (ClientError, BotoCoreError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             ansible_obj.fail_json(msg="Unable to connect, authorize or access resource: {0}".format(e))
 
         try:
             self.account_id = self.resource_client['iam'].get_user()['User']['Arn'].split(':')[4]
-        except (ClientError, ValueError, KeyError, IndexError):
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError, ValueError, KeyError, IndexError):
             self.account_id = ''
 
     def client(self, resource='lambda'):
@@ -272,7 +272,7 @@ def get_lambda_alias(module, aws):
         results = client.get_alias(**api_params)
     except is_boto3_error_code('ResourceNotFoundException'):
         results = None
-    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg='Error retrieving function alias')
 
     return results
@@ -313,7 +313,7 @@ def lambda_alias(module, aws):
                 if not module.check_mode:
                     try:
                         results = client.update_alias(**api_params)
-                    except (ClientError, BotoCoreError) as e:
+                    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         module.fail_json(msg='Error updating function alias: {0}'.format(e))
 
         else:
@@ -324,7 +324,7 @@ def lambda_alias(module, aws):
                 if not module.check_mode:
                     results = client.create_alias(**api_params)
                 changed = True
-            except (ClientError, BotoCoreError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json(msg='Error creating function alias: {0}'.format(e))
 
     else:  # state = 'absent'
@@ -336,7 +336,7 @@ def lambda_alias(module, aws):
                 if not module.check_mode:
                     results = client.delete_alias(**api_params)
                 changed = True
-            except (ClientError, BotoCoreError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json(msg='Error deleting function alias: {0}'.format(e))
 
     return dict(changed=changed, **dict(results or facts))

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -148,10 +148,11 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -144,11 +144,12 @@ name:
 import re
 
 try:
-    from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
+    from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -182,7 +183,7 @@ class AWSConnection:
             if not self.region:
                 self.region = self.resource_client['lambda'].meta.region_name
 
-        except (ClientError, ParamValidationError, MissingParametersError) as e:
+        except (ClientError, BotoCoreError) as e:
             ansible_obj.fail_json(msg="Unable to connect, authorize or access resource: {0}".format(e))
 
         try:
@@ -269,12 +270,10 @@ def get_lambda_alias(module, aws):
     # check if alias exists and get facts
     try:
         results = client.get_alias(**api_params)
-
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        if e.response['Error']['Code'] == 'ResourceNotFoundException':
-            results = None
-        else:
-            module.fail_json(msg='Error retrieving function alias: {0}'.format(e))
+    except is_boto3_error_code('ResourceNotFoundException'):
+        results = None
+    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg='Error retrieving function alias')
 
     return results
 
@@ -314,7 +313,7 @@ def lambda_alias(module, aws):
                 if not module.check_mode:
                     try:
                         results = client.update_alias(**api_params)
-                    except (ClientError, ParamValidationError, MissingParametersError) as e:
+                    except (ClientError, BotoCoreError) as e:
                         module.fail_json(msg='Error updating function alias: {0}'.format(e))
 
         else:
@@ -325,7 +324,7 @@ def lambda_alias(module, aws):
                 if not module.check_mode:
                     results = client.create_alias(**api_params)
                 changed = True
-            except (ClientError, ParamValidationError, MissingParametersError) as e:
+            except (ClientError, BotoCoreError) as e:
                 module.fail_json(msg='Error creating function alias: {0}'.format(e))
 
     else:  # state = 'absent'
@@ -337,7 +336,7 @@ def lambda_alias(module, aws):
                 if not module.check_mode:
                     results = client.delete_alias(**api_params)
                 changed = True
-            except (ClientError, ParamValidationError, MissingParametersError) as e:
+            except (ClientError, BotoCoreError) as e:
                 module.fail_json(msg='Error deleting function alias: {0}'.format(e))
 
     return dict(changed=changed, **dict(results or facts))

--- a/plugins/modules/lambda_facts.py
+++ b/plugins/modules/lambda_facts.py
@@ -88,19 +88,18 @@ lambda_facts.function.TheName:
     returned: success
     type: dict
 '''
-
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 import json
 import datetime
 import sys
 import re
 
-
 try:
     from botocore.exceptions import ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def fix_return(node):

--- a/plugins/modules/lambda_facts.py
+++ b/plugins/modules/lambda_facts.py
@@ -98,9 +98,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def fix_return(node):

--- a/plugins/modules/lambda_facts.py
+++ b/plugins/modules/lambda_facts.py
@@ -94,7 +94,7 @@ import sys
 import re
 
 try:
-    from botocore.exceptions import ClientError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -149,7 +149,7 @@ def alias_details(client, module):
             lambda_facts.update(aliases=client.list_aliases(FunctionName=function_name, **params)['Aliases'])
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_facts.update(aliases=[])
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get aliases")
     else:
         module.fail_json(msg='Parameter function_name required for query=aliases.')
@@ -202,7 +202,7 @@ def config_details(client, module):
             lambda_facts.update(client.get_function_configuration(FunctionName=function_name))
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_facts.update(function={})
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
     else:
         params = dict()
@@ -216,7 +216,7 @@ def config_details(client, module):
             lambda_facts.update(function_list=client.list_functions(**params)['Functions'])
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_facts.update(function_list=[])
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get function list")
 
         functions = dict()
@@ -256,7 +256,7 @@ def mapping_details(client, module):
         lambda_facts.update(mappings=client.list_event_source_mappings(**params)['EventSourceMappings'])
     except is_boto3_error_code('ResourceNotFoundException'):
         lambda_facts.update(mappings=[])
-    except ClientError as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Trying to get source event mappings")
 
     if function_name:
@@ -286,7 +286,7 @@ def policy_details(client, module):
             lambda_facts.update(policy=json.loads(client.get_policy(FunctionName=function_name)['Policy']))
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_facts.update(policy={})
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get {0} policy".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=policy.')
@@ -318,7 +318,7 @@ def version_details(client, module):
             lambda_facts.update(versions=client.list_versions_by_function(FunctionName=function_name, **params)['Versions'])
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_facts.update(versions=[])
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=versions.')

--- a/plugins/modules/lambda_facts.py
+++ b/plugins/modules/lambda_facts.py
@@ -99,6 +99,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -146,11 +147,10 @@ def alias_details(client, module):
             params['Marker'] = module.params.get('next_marker')
         try:
             lambda_facts.update(aliases=client.list_aliases(FunctionName=function_name, **params)['Aliases'])
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                lambda_facts.update(aliases=[])
-            else:
-                module.fail_json_aws(e, msg="Trying to get aliases")
+        except is_boto3_error_code('ResourceNotFoundException'):
+            lambda_facts.update(aliases=[])
+        except ClientError as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(e, msg="Trying to get aliases")
     else:
         module.fail_json(msg='Parameter function_name required for query=aliases.')
 
@@ -200,11 +200,10 @@ def config_details(client, module):
     if function_name:
         try:
             lambda_facts.update(client.get_function_configuration(FunctionName=function_name))
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                lambda_facts.update(function={})
-            else:
-                module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
+        except is_boto3_error_code('ResourceNotFoundException'):
+            lambda_facts.update(function={})
+        except ClientError as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
     else:
         params = dict()
         if module.params.get('max_items'):
@@ -215,11 +214,10 @@ def config_details(client, module):
 
         try:
             lambda_facts.update(function_list=client.list_functions(**params)['Functions'])
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                lambda_facts.update(function_list=[])
-            else:
-                module.fail_json_aws(e, msg="Trying to get function list")
+        except is_boto3_error_code('ResourceNotFoundException'):
+            lambda_facts.update(function_list=[])
+        except ClientError as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(e, msg="Trying to get function list")
 
         functions = dict()
         for func in lambda_facts.pop('function_list', []):
@@ -256,11 +254,10 @@ def mapping_details(client, module):
 
     try:
         lambda_facts.update(mappings=client.list_event_source_mappings(**params)['EventSourceMappings'])
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'ResourceNotFoundException':
-            lambda_facts.update(mappings=[])
-        else:
-            module.fail_json_aws(e, msg="Trying to get source event mappings")
+    except is_boto3_error_code('ResourceNotFoundException'):
+        lambda_facts.update(mappings=[])
+    except ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Trying to get source event mappings")
 
     if function_name:
         return {function_name: camel_dict_to_snake_dict(lambda_facts)}
@@ -287,11 +284,10 @@ def policy_details(client, module):
         try:
             # get_policy returns a JSON string so must convert to dict before reassigning to its key
             lambda_facts.update(policy=json.loads(client.get_policy(FunctionName=function_name)['Policy']))
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                lambda_facts.update(policy={})
-            else:
-                module.fail_json_aws(e, msg="Trying to get {0} policy".format(function_name))
+        except is_boto3_error_code('ResourceNotFoundException'):
+            lambda_facts.update(policy={})
+        except ClientError as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(e, msg="Trying to get {0} policy".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=policy.')
 
@@ -320,11 +316,10 @@ def version_details(client, module):
 
         try:
             lambda_facts.update(versions=client.list_versions_by_function(FunctionName=function_name, **params)['Versions'])
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                lambda_facts.update(versions=[])
-            else:
-                module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
+        except is_boto3_error_code('ResourceNotFoundException'):
+            lambda_facts.update(versions=[])
+        except ClientError as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=versions.')
 

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -78,18 +78,17 @@ function.TheName:
     returned: success
     type: dict
 '''
-
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 import json
 import datetime
 import re
-
 
 try:
     from botocore.exceptions import ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def fix_return(node):

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -83,7 +83,7 @@ import datetime
 import re
 
 try:
-    from botocore.exceptions import ClientError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -138,7 +138,7 @@ def alias_details(client, module):
             lambda_info.update(aliases=client.list_aliases(FunctionName=function_name, **params)['Aliases'])
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_info.update(aliases=[])
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get aliases")
     else:
         module.fail_json(msg='Parameter function_name required for query=aliases.')
@@ -191,7 +191,7 @@ def config_details(client, module):
             lambda_info.update(client.get_function_configuration(FunctionName=function_name))
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_info.update(function={})
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
     else:
         params = dict()
@@ -205,7 +205,7 @@ def config_details(client, module):
             lambda_info.update(function_list=client.list_functions(**params)['Functions'])
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_info.update(function_list=[])
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get function list")
 
         functions = dict()
@@ -245,7 +245,7 @@ def mapping_details(client, module):
         lambda_info.update(mappings=client.list_event_source_mappings(**params)['EventSourceMappings'])
     except is_boto3_error_code('ResourceNotFoundException'):
         lambda_info.update(mappings=[])
-    except ClientError as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Trying to get source event mappings")
 
     if function_name:
@@ -275,7 +275,7 @@ def policy_details(client, module):
             lambda_info.update(policy=json.loads(client.get_policy(FunctionName=function_name)['Policy']))
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_info.update(policy={})
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get {0} policy".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=policy.')
@@ -307,7 +307,7 @@ def version_details(client, module):
             lambda_info.update(versions=client.list_versions_by_function(FunctionName=function_name, **params)['Versions'])
         except is_boto3_error_code('ResourceNotFoundException'):
             lambda_info.update(versions=[])
-        except ClientError as e:  # pylint: disable=duplicate-except
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=versions.')

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -87,9 +87,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def fix_return(node):

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -136,7 +136,7 @@ import json
 import re
 
 try:
-    from botocore.exceptions import ClientError, BotoCoreError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -289,7 +289,7 @@ def get_policy_statement(module, client):
         policy_results = client.get_policy(**api_params)
     except is_boto3_error_code('ResourceNotFoundException'):
         return {}
-    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="retrieving function policy")
 
     # get_policy returns a JSON string so must convert to dict before reassigning to its key
@@ -325,7 +325,7 @@ def add_policy_permission(module, client):
     if not module.check_mode:
         try:
             client.add_permission(**api_params)
-        except (ClientError, BotoCoreError) as e:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="adding permission to policy")
         changed = True
 
@@ -353,7 +353,7 @@ def remove_policy_permission(module, client):
         if not module.check_mode:
             client.remove_permission(**api_params)
             changed = True
-    except (ClientError, BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="removing permission from policy")
 
     return changed

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -134,13 +134,15 @@ lambda_policy_action:
 
 import json
 import re
-from ansible.module_utils._text import to_native
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
 try:
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils._text import to_native
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
 def pc(key):
@@ -285,14 +287,9 @@ def get_policy_statement(module, client):
     # check if function policy exists
     try:
         policy_results = client.get_policy(**api_params)
-    except ClientError as e:
-        try:
-            if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                return {}
-        except AttributeError:  # catches ClientErrors without response, e.g. fail before connect
-            pass
-        module.fail_json_aws(e, msg="retrieving function policy")
-    except Exception as e:
+    except is_boto3_error_code('ResourceNotFoundException'):
+        return {}
+    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="retrieving function policy")
 
     # get_policy returns a JSON string so must convert to dict before reassigning to its key
@@ -328,7 +325,7 @@ def add_policy_permission(module, client):
     if not module.check_mode:
         try:
             client.add_permission(**api_params)
-        except Exception as e:
+        except (ClientError, BotoCoreError) as e:
             module.fail_json_aws(e, msg="adding permission to policy")
         changed = True
 
@@ -356,7 +353,7 @@ def remove_policy_permission(module, client):
         if not module.check_mode:
             client.remove_permission(**api_params)
             changed = True
-    except Exception as e:
+    except (ClientError, BotoCoreError) as e:
         module.fail_json_aws(e, msg="removing permission from policy")
 
     return changed

--- a/plugins/modules/lightsail.py
+++ b/plugins/modules/lightsail.py
@@ -160,9 +160,10 @@ except ImportError:
     # will be caught by AnsibleAWSModule
     pass
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def find_instance_info(module, client, instance_name, fail_if_not_found=False):

--- a/plugins/modules/lightsail.py
+++ b/plugins/modules/lightsail.py
@@ -161,6 +161,7 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
@@ -168,9 +169,11 @@ def find_instance_info(module, client, instance_name, fail_if_not_found=False):
 
     try:
         res = client.get_instance(instanceName=instance_name)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'NotFoundException' and not fail_if_not_found:
-            return None
+    except is_boto3_error_code('NotFoundException') as e:
+        if fail_if_not_found:
+            module.fail_json_aws(e)
+        return None
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
     return res['instance']
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -758,6 +758,7 @@ from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.core import get_boto3_client_method_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
@@ -1036,11 +1037,8 @@ def promote_replication_instance(client, module, instance, read_replica):
         try:
             call_method(client, module, method_name='promote_read_replica', parameters={'DBInstanceIdentifier': instance['DBInstanceIdentifier']})
             changed = True
-        except is_boto3_error_code('InvalidDBInstanceState') as e:
-            if 'DB Instance is not a read replica' in e.response['Error']['Message']:
-                pass
-            else:
-                raise e
+        except is_boto3_error_message('DB Instance is not a read replica'):
+            pass
     return changed
 
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -745,26 +745,28 @@ vpc_security_groups:
       sample: sg-12345678
 '''
 
-from ansible.module_utils._text import to_text
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.rds import (
-    arg_spec_to_rds_params,
-    call_method,
-    ensure_tags,
-    get_final_identifier,
-    get_rds_method_attribute,
-    get_tags,
-)
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list, AWSRetry
-from ansible.module_utils.six import string_types
-
 from time import sleep
 
 try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.six import string_types
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.core import get_boto3_client_method_parameters
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.rds import arg_spec_to_rds_params
+from ansible_collections.amazon.aws.plugins.module_utils.rds import call_method
+from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
+from ansible_collections.amazon.aws.plugins.module_utils.rds import get_final_identifier
+from ansible_collections.amazon.aws.plugins.module_utils.rds import get_rds_method_attribute
+from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
 
 
 def get_rds_method_attribute_name(instance, state, creation_source, read_replica):

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -17,8 +17,6 @@ author: "Rob White (@wimnat)"
 notes:
   - If specifying expiration time as days then transition time must also be specified in days
   - If specifying expiration time as a date then transition time must also be specified as a date
-requirements:
-  - python-dateutil
 options:
   name:
     description:

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -194,7 +194,7 @@ from copy import deepcopy
 import datetime
 
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    import botocore
 except ImportError:
     pass  # handled by AnsibleAwsModule
 
@@ -227,7 +227,7 @@ def create_lifecycle_rule(client, module):
         current_lifecycle_rules = current_lifecycle['Rules']
     except is_boto3_error_code('NoSuchLifecycleConfiguration'):
         current_lifecycle_rules = []
-    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
 
     rule = dict(Filter=dict(Prefix=prefix), Status=status.title())
@@ -303,7 +303,7 @@ def create_lifecycle_rule(client, module):
     # Write lifecycle to bucket
     try:
         client.put_bucket_lifecycle_configuration(Bucket=name, LifecycleConfiguration=lifecycle_configuration)
-    except (BotoCoreError, ClientError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e)
 
     module.exit_json(changed=changed)
@@ -388,7 +388,7 @@ def destroy_lifecycle_rule(client, module):
         current_lifecycle_rules = client.get_bucket_lifecycle_configuration(Bucket=name)['Rules']
     except is_boto3_error_code('NoSuchLifecycleConfiguration'):
         current_lifecycle_rules = []
-    except (ClientError, BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
 
     # Create lifecycle
@@ -418,7 +418,7 @@ def destroy_lifecycle_rule(client, module):
         elif current_lifecycle_rules:
             changed = True
             client.delete_bucket_lifecycle(Bucket=name)
-    except (ClientError, BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e)
     module.exit_json(changed=changed)
 

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -478,13 +478,13 @@ def main():
     if expiration_date is not None:
         try:
             datetime.datetime.strptime(expiration_date, "%Y-%m-%dT%H:%M:%S.000Z")
-        except ValueError as e:
+        except ValueError:
             module.fail_json(msg="expiration_date is not a valid ISO-8601 format. The time must be midnight and a timezone of GMT must be included")
 
     if transition_date is not None:
         try:
             datetime.datetime.strptime(transition_date, "%Y-%m-%dT%H:%M:%S.000Z")
-        except ValueError as e:
+        except ValueError:
             module.fail_json(msg="expiration_date is not a valid ISO-8601 format. The time must be midnight and a timezone of GMT must be included")
 
     if state == 'present':

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -222,7 +222,7 @@ EXAMPLES = '''
 import json
 
 try:
-    from botocore.exceptions import BotoCoreError, ClientError, ParamValidationError
+    import botocore
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
@@ -417,7 +417,7 @@ def update_tags(client, queue_url, module):
 
     try:
         existing_tags = client.list_queue_tags(QueueUrl=queue_url, aws_retry=True)['Tags']
-    except (ClientError, KeyError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError, KeyError) as e:
         existing_tags = {}
 
     tags_to_add, tags_to_remove = compare_aws_tags(existing_tags, new_tags, purge_tags=purge_tags)
@@ -464,7 +464,7 @@ def main():
             result = create_or_update_sqs_queue(client, module)
         elif state == 'absent':
             result = delete_sqs_queue(client, module)
-    except (BotoCoreError, ClientError, ParamValidationError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Failed to control sqs queue')
     else:
         module.exit_json(**result)

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -227,6 +227,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
@@ -246,10 +247,8 @@ def get_queue_name(module, is_fifo=False):
 def get_queue_url(client, name):
     try:
         return client.get_queue_url(QueueName=name)['QueueUrl']
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
-            return None
-        raise
+    except is_boto3_error_code('AWS.SimpleQueueService.NonExistentQueue'):
+        return None
 
 
 def describe_queue(client, queue_url):

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -226,13 +226,14 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
 
 
 def get_queue_name(module, is_fifo=False):

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -220,18 +220,18 @@ EXAMPLES = '''
 '''
 
 import json
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AWSRetry,
-                                                                     camel_dict_to_snake_dict,
-                                                                     compare_aws_tags,
-                                                                     snake_dict_to_camel_dict,
-                                                                     compare_policies,
-                                                                     )
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError, ParamValidationError
 except ImportError:
     pass  # handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
 
 
 def get_queue_name(module, is_fifo=False):


### PR DESCRIPTION
##### SUMMARY

Make heavier use of is_boto3_error_code and is_boto3_error_message.  This reduces the chances of accidentally dropping exceptions on the floor and makes some of the code paths simpler to follow.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_elasticbeanstalk_app.py
plugins/modules/aws_glue_connection.py
plugins/modules/aws_glue_job.py
plugins/modules/aws_kms_info.py
plugins/modules/aws_ssm_parameter_store.py
plugins/modules/aws_step_functions_state_machine_execution.py
plugins/modules/aws_waf_condition.py
plugins/modules/cloudfront_invalidation.py
plugins/modules/cloudwatchevent_rule.py
plugins/modules/data_pipeline.py
plugins/modules/ec2_asg.py
plugins/modules/ec2_asg_info.py
plugins/modules/ec2_instance.py
plugins/modules/ec2_placement_group.py
plugins/modules/ec2_transit_gateway_info.py
plugins/modules/ec2_vpc_egress_igw.py
plugins/modules/ec2_vpc_nacl_info.py
plugins/modules/ec2_vpc_route_table.py
plugins/modules/ecs_ecr.py
plugins/modules/ecs_service_info.py
plugins/modules/efs.py
plugins/modules/elasticache.py
plugins/modules/elasticache_info.py
plugins/modules/elasticache_snapshot.py
plugins/modules/elb_target_group.py
plugins/modules/execute_lambda.py
plugins/modules/iam_group.py
plugins/modules/iam_managed_policy.py
plugins/modules/iam_password_policy.py
plugins/modules/iam_policy_info.py
plugins/modules/iam_role.py
plugins/modules/iam_role_info.py
plugins/modules/iam_user.py
plugins/modules/lambda_alias.py
plugins/modules/lambda_facts.py
plugins/modules/lambda_info.py
plugins/modules/lambda_policy.py
plugins/modules/lightsail.py
plugins/modules/rds_instance.py
plugins/modules/rds_param_group.py
plugins/modules/s3_lifecycle.py
plugins/modules/sqs_queue.py

##### ADDITIONAL INFORMATION

I recommend reviewing the commits separately it's easier to follow what's changing.