### PR TITLE
Put an upper limit on boto3 in CI

### DIFF
--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,2 +1,3 @@
-boto3 >= 1.9.250  # minimum version that supports botocore 1.13.3
-botocore >= 1.13.3  # adds support for ECR image scanning
+boto3 >= 1.9.250, <= 1.15.18  # minimum version that supports botocore 1.13.3, max that will work with ansible 2.9's other constraints
+botocore<1.19.0,>=1.13.3  # adds support for ECR image scanning
+


### PR DESCRIPTION
##### SUMMARY
Ansible 2.9 has a test constraint for openshift >= 0.6.2, < 0.9.0.  We're only specifying a minimum boto3 today and 1.16.x has released, which pulls in a newer urllib3 than that openshift supports.

Example: https://app.shippable.com/github/ansible-collections/community.aws/runs/907/19/console

For now it can be fixed by capping what boto3 we use in CI, though if 2.9 will have extended support we'll need to deal with it eventually.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/constraints.txt