### PR TITLE
aws_ssm: add profile support in connections

### DIFF
--- a/changelogs/fragments/278-aws_ssm-profile-support.yml
+++ b/changelogs/fragments/278-aws_ssm-profile-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_ssm connection plugin - add support for specifying a profile to be used when connecting (https://github.com/ansible-collections/community.aws/pull/278).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -54,6 +54,7 @@ options:
     - name: ansible_aws_ssm_plugin
     default: '/usr/local/bin/session-manager-plugin'
   profile:
+    description: Sets AWS profile to use.
     vars:
     - name: ansible_aws_ssm_profile
     version_added: 1.5.0

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -54,10 +54,9 @@ options:
     - name: ansible_aws_ssm_plugin
     default: '/usr/local/bin/session-manager-plugin'
   profile:
-    description: Sets AWS profile to use.
     vars:
     - name: ansible_aws_ssm_profile
-    default: ''
+    version_added: 1.5.0
   retries:
     description: Number of attempts to connect.
     default: 3

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -309,7 +309,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("failed to find the executable specified %s."
                                " Please verify if the executable exists and re-try." % executable)
 
-        profile_name = self.get_option('profile')
+        profile_name = self.get_option('profile') or ''
         region_name = self.get_option('region')
         ssm_parameters = dict()
         client = self._get_boto_client('ssm', region_name=region_name, profile_name=profile_name)

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -522,14 +522,19 @@ class Connection(ConnectionBase):
             aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
         if aws_session_token is None:
             aws_session_token = os.environ.get("AWS_SESSION_TOKEN", None)
+        if not profile_name:
+            profile_name = os.environ.get("AWS_PROFILE", None)
 
-        session = boto3.session.Session(
+        session_args = dict(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
             region_name=region_name,
-            profile_name=profile_name
         )
+        if profile_name:
+            session_args['profile_name'] = profile_name
+        session = boto3.session.Session(**session_args)
+
         client = session.client(
             service,
             config=Config(signature_version="s3v4")


### PR DESCRIPTION
##### SUMMARY
The `aws_ssm` connection type had no way of setting a profile except via environment variable. We have a specific need to set the profile name for this connection type, and this achieves that.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/connection/aws_ssm.py
