### PR TITLE
Sanitize parameters when comparing with existing ecs_taskdefinition

### DIFF
--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -459,6 +459,20 @@ def main():
 
             # No revision explicitly specified. Attempt to find an active, matching revision that has all the properties requested
             for td in existing_definitions_in_family:
+                # sanitize parameters based on type and default value
+                for container in module.params['containers']:
+                    for param in ('memory', 'cpu', 'memoryReservation'):
+                        if param in container:
+                            container[param] = int(container[param])
+                    if 'portMappings' in container:
+                        for port_mapping in container['portMappings']:
+                            for port in ('hostPort', 'containerPort'):
+                                if port in port_mapping:
+                                    port_mapping[port] = int(port_mapping[port])
+                            if 'protocol' not in port_mapping:
+                                port_mapping['protocol'] = 'tcp'
+                    if 'essential' not in container:
+                        container['essential'] = True
                 requested_volumes = module.params['volumes'] or []
                 requested_containers = module.params['containers'] or []
                 requested_task_role_arn = module.params['task_role_arn']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addresses issues with idempotence for `ecs_taskdefinition` module
* If certain parameters are templatized, they will have different data types in the existing task definition as compared to the  requested values.
e.g. `cpu: "{{ nginx.cpu }}"` will appear as `cpu: "1111" (string)` in the module invocation. And when you invoke this the second time, the module fails to detect that the CPU value is actually the same. And registers a new task definition.
* Certain (non essential) parameters can be omitted from the module invocation. But on the second invocation when we compare the module parameters with existing task_definition(s), these parameters appear in the comparison and fail a potential match.
e.g. Key `essential` in `containers`. Key `protocol` in `containers[].portMapping`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_taskdefinition

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Unfortunately the module output does not indicate why it's registering a new task definition. Hence command output might not be very useful.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
