### PR TITLE
Make cloudfront_info work on empty AWS account, add tests

### DIFF
--- a/changelogs/fragments/293-cloudfront-info-python-fix.yaml
+++ b/changelogs/fragments/293-cloudfront-info-python-fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - cloudfront_info - Fix error with joining lists as sometimes dicts were returned (https://github.com/ansible-collections/community.aws/pull/293).

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -346,7 +346,7 @@ class CloudFrontServiceManager:
             func = partial(self.client.list_distributions)
             distribution_list = self.paginated_response(func, 'DistributionList')
             if distribution_list['Quantity'] == 0:
-                return {}
+                return []
             else:
                 distribution_list = distribution_list['Items']
             if not keyed:
@@ -360,7 +360,7 @@ class CloudFrontServiceManager:
             func = partial(self.client.list_distributions_by_web_acl_id, WebAclId=web_acl_id)
             distribution_list = self.paginated_response(func, 'DistributionList')
             if distribution_list['Quantity'] == 0:
-                return {}
+                return []
             else:
                 distribution_list = distribution_list['Items']
             return self.keyed_list_helper(distribution_list)

--- a/tests/integration/targets/cloudfront_distribution/aliases
+++ b/tests/integration/targets/cloudfront_distribution/aliases
@@ -2,3 +2,5 @@
 disabled
 
 cloud/aws
+unsupported
+cloudfront_info

--- a/tests/integration/targets/cloudfront_distribution/aliases
+++ b/tests/integration/targets/cloudfront_distribution/aliases
@@ -1,6 +1,2 @@
-# reason: broken
-disabled
-
 cloud/aws
-unsupported
 cloudfront_info

--- a/tests/integration/targets/cloudfront_distribution/tasks/cloudfront_info.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/cloudfront_info.yml
@@ -1,0 +1,35 @@
+---
+
+block:
+  - name: Create a Cloudfront distribution for testing cloudfront_info module against
+    cloudfront_distribution:
+      origins:
+      - domain_name: "{{ cloudfront_hostname }}-origin.info.example.com"
+        id: "{{ cloudfront_hostname }}-origin.info.example.com"
+      default_cache_behavior:
+        target_origin_id: "{{ cloudfront_hostname }}-origin.info.example.com"
+      state: present
+      wait: yes
+      purge_origins: yes
+    register: cloudfront_test_distribution
+
+  - name: Use cloudfront_info module to retrieve CF distribution details
+    cloudfront_info:
+      distribution: true
+      distribution_id: "{{ cloudfront_test_distribution.id }}"
+    register: cloudfront_info_results
+
+  - name: Ensure cloudfront_info returned results
+    assert:
+      that:
+        - cloudfront_info_results.result is defined
+        - cloudfront_info_results.distribution is defined
+        - cloudfront_info_results.result.id == cloudfront_test_distribution.id
+
+always:
+
+  - name: clean up cloudfront distribution
+    cloudfront_distribution:
+      distribution_id: "{{ cloudfront_test_distribution.id }}"
+      enabled: no
+      state: absent

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -501,3 +501,5 @@
       enabled: no
       wait: yes
       state: absent
+
+- include: ./cloudfront_info.yml


### PR DESCRIPTION
##### SUMMARY
Make sure module methods always return lists

Otherwise one will get the following error (if no distributions are found, as in this case a dict will be returned):

```
cloudfront_info.py, line 505, in get_distribution_id_from_domain_name
TypeError: unsupported operand type(s) for +=: 'dict' and 'dict'
```
Also I am adding some tests, so this module won't fall through the cracks another time.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_info module