### PR TITLE
Added state_machine_arn when unchanged.

### DIFF
--- a/changelogs/302-aws_step_functions_state_machine-ARN-not-change.yml
+++ b/changelogs/302-aws_step_functions_state_machine-ARN-not-change.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- state_machine_arn - return ``state_machine_arn`` when state is unchanged (https://github.com/ansible-collections/community.aws/pull/302).

--- a/plugins/modules/aws_step_functions_state_machine.py
+++ b/plugins/modules/aws_step_functions_state_machine.py
@@ -123,7 +123,7 @@ def manage_state_machine(state, sfn_client, module):
             remove(state_machine_arn, sfn_client, module)
 
     check_mode(module, msg='State is up-to-date.')
-    module.exit_json(changed=False)
+    module.exit_json(changed=False, state_machine_arn=state_machine_arn)
 
 
 def create(sfn_client, module):

--- a/tests/integration/targets/aws_step_functions_state_machine/defaults/main.yml
+++ b/tests/integration/targets/aws_step_functions_state_machine/defaults/main.yml
@@ -1,4 +1,4 @@
 # the random_num is generated in a set_fact task at the start of the testsuite
-state_machine_name: "{{ resource_prefix }}_step_functions_state_machine_ansible_test_{{ random_num }}"
-step_functions_role_name: "ansible-test-sts-{{ resource_prefix }}-step_functions-role"
+state_machine_name: "{{ resource_prefix }}_step_function_{{ random_num }}"
+step_functions_role_name: "ansible-test-{{ resource_prefix }}-step-function"
 execution_name: "{{ resource_prefix }}_sfn_execution"

--- a/tests/integration/targets/aws_step_functions_state_machine/tasks/main.yml
+++ b/tests/integration/targets/aws_step_functions_state_machine/tasks/main.yml
@@ -61,6 +61,7 @@
     - assert:
         that:
           - creation_output.changed == True
+          - '"state_machine_arn" in creation_output'
 
     - name: Pause a few seconds to ensure state machine role is available
       pause:
@@ -95,6 +96,7 @@
     - assert:
         that:
           - result.changed == False
+          - result.state_machine_arn == creation_output.state_machine_arn
 
     - name: Update an existing state machine -- check_mode
       aws_step_functions_state_machine:

--- a/tests/integration/targets/aws_step_functions_state_machine/tasks/main.yml
+++ b/tests/integration/targets/aws_step_functions_state_machine/tasks/main.yml
@@ -26,11 +26,11 @@
       pause:
         seconds: 10
 
-    # ==== Tests ===================================================
-
     - name: Create a random component for state machine name
       set_fact:
         random_num: "{{ 999999999 | random }}"
+
+    # ==== Tests ===================================================
 
     - name: Create a new state machine -- check_mode
       aws_step_functions_state_machine:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've added the state machine ARN to the output when the state machine is unchanged. Per documentation, it should always be returned but wasn't included when no changes were made.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.aws.aws_step_functions_state_machine

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When you have a community.aws.aws_step_functions_state_machine task, if the state machine is unchanged you will not get the expected "state_machine_arn" key. This is not the expected behavior.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [Debug statemachine] ************************************************************************************************************************************************
ok: [localhost] => {
    "statemachine": {
        "changed": false,
        "failed": false
    }
}

TASK [Debug statemachine] ************************************************************************************************************************************************
ok: [localhost] => {
    "statemachine": {
        "changed": false,
        "failed": false
        "state_machine_arn": "arn:aws:states:us-east-1:123456789:stateMachine:NAME"
    }
}
```
