### PR TITLE
Added Tier as option to aws_ssm_parameter_store module

### DIFF
--- a/changelogs/fragments/305-aws-ssm-parameter-tier-option.yml
+++ b/changelogs/fragments/305-aws-ssm-parameter-tier-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_ssm_parameter_store - added tier parameter option ( https://github.com/ansible/ansible/issues/59738 )

--- a/changelogs/fragments/305-aws-ssm-parameter-tier-option.yml
+++ b/changelogs/fragments/305-aws-ssm-parameter-tier-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- aws_ssm_parameter_store - added tier parameter option ( https://github.com/ansible/ansible/issues/59738 )
+- aws_ssm_parameter_store - added tier parameter option (https://github.com/ansible/ansible/issues/59738).

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -72,7 +72,13 @@ options:
     choices: ['Standard', 'Advanced', 'Intelligent-Tiering']
     default: Standard
     type: str
-author: "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"
+
+author:
+  - "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"
+  - "Nathan Webster (@nathanwebsterdotme)"
+  - "Bill Wang (@ozbillwang) <ozbillwang@gmail.com>"
+  - "Michael De La Rue (@mikedlr)"
+
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -72,6 +72,7 @@ options:
     choices: ['Standard', 'Advanced', 'Intelligent-Tiering']
     default: Standard
     type: str
+    version_added: 1.5.0
 
 author:
   - "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -67,16 +67,12 @@ options:
     type: str
   tier:
     description:
-      - Allows to create parameter with different tiers
+      - Paramter Store Tier Type
     required: false
     choices: ['Standard', 'Advanced', 'Intelligent-Tiering']
     default: Standard
     type: str
-author:
-  - Davinder Pal ( @116davinder )
-  - Nathan Webster (@nathanwebsterdotme)
-  - Bill Wang (@ozbillwang) <ozbillwang@gmail.com>
-  - Michael De La Rue (@mikedlr)
+author: "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -65,7 +65,15 @@ options:
     choices: ['never', 'changed', 'always']
     default: changed
     type: str
+  tier:
+    description:
+      - Allows to create parameter with different tiers
+    required: false
+    choices: ['Standard', 'Advanced', 'Intelligent-Tiering']
+    default: Standard
+    type: str
 author:
+  - Davinder Pal ( @116davinder )
   - Nathan Webster (@nathanwebsterdotme)
   - Bill Wang (@ozbillwang) <ozbillwang@gmail.com>
   - Michael De La Rue (@mikedlr)
@@ -110,6 +118,13 @@ EXAMPLES = '''
     string_type: "String"
     value: "Test1234"
     overwrite_value: "always"
+
+- name: Create or update key/value pair in aws parameter store with tier
+  community.aws.aws_ssm_parameter_store:
+    name: "Hello"
+    description: "This is your first key"
+    value: "World"
+    tier: "Advanced"
 
 - name: recommend to use with aws_ssm lookup plugin
   ansible.builtin.debug:
@@ -156,7 +171,8 @@ def create_update_parameter(client, module):
     args = dict(
         Name=module.params.get('name'),
         Value=module.params.get('value'),
-        Type=module.params.get('string_type')
+        Type=module.params.get('string_type'),
+        Tier=module.params.get('tier')
     )
 
     if (module.params.get('overwrite_value') in ("always", "changed")):
@@ -236,6 +252,7 @@ def setup_module_object():
         decryption=dict(default=True, type='bool'),
         key_id=dict(default="alias/aws/ssm"),
         overwrite_value=dict(default='changed', choices=['never', 'changed', 'always']),
+        tier=dict(default='Standard', choices=['Standard', 'Advanced', 'Intelligent-Tiering']),
     )
 
     return AnsibleAWSModule(

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -67,7 +67,7 @@ options:
     type: str
   tier:
     description:
-      - Paramter Store Tier Type
+      - Parameter store tier type.
     required: false
     choices: ['Standard', 'Advanced', 'Intelligent-Tiering']
     default: Standard


### PR DESCRIPTION
##### SUMMARY
Added Tier as parameter for parameter store.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.aws.aws_ssm_parameter_store

##### ADDITIONAL INFORMATION
Original Pull Request: ansible/ansible#61933
Original Issue: ansible/ansible#59738

if this doesn't get merged then I have published same module in personal repository: https://github.com/116davinder/ansible.missing_collection