### PR TITLE
Use lower case days in rds_instance's "preferred_maintenance_window" parameter docs

### DIFF
--- a/docs/community.aws.rds_instance_module.rst
+++ b/docs/community.aws.rds_instance_module.rst
@@ -864,7 +864,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The weekly time range (in UTC) of at least 30 minutes, during which system maintenance can occur. The option must be in the format &quot;ddd:hh24:mi-ddd:hh24:mi&quot; where ddd is one of Mon, Tue, Wed, Thu, Fri, Sat, Sun.</div>
+                        <div>The weekly time range (in UTC) of at least 30 minutes, during which system maintenance can occur. The option must be in the format &quot;ddd:hh24:mi-ddd:hh24:mi&quot; where ddd is one of mon, tue, wed, thu, fri, sat, sun.</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: maintenance_window</div>
                 </td>
             </tr>

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -294,7 +294,7 @@ options:
     preferred_maintenance_window:
         description:
           - The weekly time range (in UTC) of at least 30 minutes, during which system maintenance can occur. The option must
-            be in the format "ddd:hh24:mi-ddd:hh24:mi" where ddd is one of Mon, Tue, Wed, Thu, Fri, Sat, Sun.
+            be in the format "ddd:hh24:mi-ddd:hh24:mi" where ddd is one of mon, tue, wed, thu, fri, sat, sun.
         aliases:
           - maintenance_window
         type: str


### PR DESCRIPTION
##### SUMMARY
The current docs explicitly list the days with capitals (`Mon, Tue`) etc. This works, but AWS then stores this as lowercase, causing idempotency issues the next time the task is run as the string value is different.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`rds_instance`

##### ADDITIONAL INFORMATION
The integration test actually _do_ use the all lowercase format: 
https://github.com/ansible-collections/community.aws/blob/main/tests/integration/targets/rds_instance/tasks/test_modification.yml#L152

NOTE: it looks as if other modules have a similar documentation issue, but I didn't confirm this:

https://github.com/ansible-collections/community.aws/blob/main/plugins/modules/rds.py#L137
https://github.com/ansible-collections/community.aws/blob/main/plugins/modules/redshift.py#L103


