### PR TITLE
Fix for aws_kms_info with external/custom key store keys

### DIFF
--- a/changelogs/fragments/311-fix-aws_kms_info-external-keys.yaml
+++ b/changelogs/fragments/311-fix-aws_kms_info-external-keys.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_kms_info - fixed incompatibility with external and custom key-store keys. The module was attempting to call `GetKeyRotationStatus`, which raises `UnsupportedOperationException` for these key types (https://github.com/ansible-collections/community.aws/pull/311)

--- a/changelogs/fragments/311-fix-aws_kms_info-external-keys.yaml
+++ b/changelogs/fragments/311-fix-aws_kms_info-external-keys.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - aws_kms_info - fixed incompatibility with external and custom key-store keys. The module was attempting to call `GetKeyRotationStatus`, which raises `UnsupportedOperationException` for these key types (https://github.com/ansible-collections/community.aws/pull/311)
+  - aws_kms_info - fixed incompatibility with external and custom key-store keys. The module was attempting to call `GetKeyRotationStatus`, which raises `UnsupportedOperationException` for these key types (https://github.com/ansible-collections/community.aws/pull/311).

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -373,7 +373,11 @@ def get_key_details(connection, module, key_id, tokens=None):
                          exception=traceback.format_exc(),
                          **camel_dict_to_snake_dict(e.response))
     result['aliases'] = aliases.get(result['KeyId'], [])
-    result['enable_key_rotation'] = get_enable_key_rotation_with_backoff(connection, key_id)
+
+    if result['Origin'] == 'AWS_KMS':
+        result['enable_key_rotation'] = get_enable_key_rotation_with_backoff(connection, key_id)
+    else:
+        result['enable_key_rotation'] = None
 
     if module.params.get('pending_deletion'):
         return camel_dict_to_snake_dict(result)


### PR DESCRIPTION
##### SUMMARY
aws_kms_info raises an exception when used with a KMS key where the source of key material is external.

> botocore.errorfactory.UnsupportedOperationException: An error occurred (UnsupportedOperationException) when calling the GetKeyRotationStatus operation: arn:aws:kms:<key_id> origin is EXTERNAL which is not valid for this operation.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_kms_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The documentation states that these key types are not supported, https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works

> Unsupported CMK types. Automatic key rotation is not supported on the following types of CMKs, but you can rotate these CMKs manually.
> - Asymmetric CMKs
> - CMKs in custom key stores
> - CMKs that have imported key material

We don't have to handle the case for asymmetric keys because the KMS end-point just returns false. But we do have to handle the external/custom key store key cases:
```bash
$ aws kms get-key-rotation-status --key-id <asymmetric_key_id>
{
    "KeyRotationEnabled": false
}

$ aws kms get-key-rotation-status --key-id <external_key_id>
An error occurred (UnsupportedOperationException) when calling the GetKeyRotationStatus operation: arn:aws:kms:<key_id> origin is EXTERNAL which is not valid for this operation.
```

Note I haven't added a regression test because aws_kms cannot create KMS keys with external key material.


