### PR TITLE
Added note to ec2_eip.py about using ec2_tag

### DIFF
--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -94,6 +94,8 @@ notes:
    - This module returns multiple changed statuses on disassociation or release.
      It returns an overall status based on any changes occurring. It also returns
      individual changed statuses for disassociation and release.
+   - Please note that this module doesn't currently support tagging. You must use the
+     amazon.aws.ec2_tag module to add any tags you require to this object.
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
As discussed in the IRC channel (#ansible-aws), this module does not currently support tagging at the time of creation. This creates a pointer to the correct module to support tagging.
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_eip
