### PR TITLE
adding uptime parameter to community.aws.ec2_instance_info

### DIFF
--- a/changelogs/fragments/318-cleanup-vpc_igw.yml
+++ b/changelogs/fragments/318-cleanup-vpc_igw.yml
@@ -1,0 +1,7 @@
+minor_changes:
+- ec2_vpc_igw - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
+- ec2_vpc_igw_info - Add AWSRetry decorators to improve reliability (https://github.com/ansible-collections/community.aws/pull/318).
+- ec2_vpc_igw - Add ``purge_tags`` parameter so that tags can be added without purging existing tags to match the collection standard tagging behaviour (https://github.com/ansible-collections/community.aws/pull/318).
+- ec2_vpc_igw_info - Add ``convert_tags`` parameter so that tags can be returned in standard dict format rather than the both list of dict format (https://github.com/ansible-collections/community.aws/pull/318).
+deprecated_features:
+- ec2_vpc_igw_info - After 2022-06-22 the ``convert_tags`` parameter default value will change from ``False`` to ``True`` to match the collection standard behavior (https://github.com/ansible-collections/community.aws/pull/318).

--- a/changelogs/fragments/324-add-jittered-backoff-to-iam_policy-modules.yaml
+++ b/changelogs/fragments/324-add-jittered-backoff-to-iam_policy-modules.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - iam_policy - Added jittered_backoff to handle AWS rate limiting (https://github.com/ansible-collections/community.aws/pull/324).
+  - iam_policy_info - Added jittered_backoff to handle AWS rate limiting (https://github.com/ansible-collections/community.aws/pull/324).

--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -14,7 +14,7 @@ module: aws_api_gateway
 version_added: 1.0.0
 short_description: Manage AWS API Gateway APIs
 description:
-     - Allows for the management of API Gateway APIs
+     - Allows for the management of API Gateway APIs.
      - Normally you should give the api_id since there is no other
        stable guaranteed unique identifier for the API.  If you do
        not give api_id then a new API will be created each time
@@ -40,7 +40,7 @@ options:
   swagger_file:
     description:
       - JSON or YAML file containing swagger definitions for API.
-        Exactly one of swagger_file, swagger_text or swagger_dict must
+        Exactly one of I(swagger_file), I(swagger_text) or I(swagger_dict) must
         be present.
     type: path
     aliases: ['src', 'api_file']
@@ -60,13 +60,13 @@ options:
     type: str
   deploy_desc:
     description:
-      - Description of the deployment - recorded and visible in the
-        AWS console.
+      - Description of the deployment.
+      - Recorded and visible in the AWS console.
     default: Automatic deployment by Ansible.
     type: str
   cache_enabled:
     description:
-      - Enable API GW caching of backend responses. Defaults to false.
+      - Enable API GW caching of backend responses.
     type: bool
     default: false
   cache_size:
@@ -83,20 +83,22 @@ options:
     description:
       - Canary settings for the deployment of the stage.
       - 'Dict with following settings:'
-      - 'percentTraffic: The percent (0-100) of traffic diverted to a canary deployment.'
-      - 'deploymentId: The ID of the canary deployment.'
-      - 'stageVariableOverrides: Stage variables overridden for a canary release deployment.'
-      - 'useStageCache: A Boolean flag to indicate whether the canary deployment uses the stage cache or not.'
+      - 'C(percentTraffic): The percent (0-100) of traffic diverted to a canary deployment.'
+      - 'C(deploymentId): The ID of the canary deployment.'
+      - 'C(stageVariableOverrides): Stage variables overridden for a canary release deployment.'
+      - 'C(useStageCache): A Boolean flag to indicate whether the canary deployment uses the stage cache or not.'
       - See docs U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html#APIGateway.Client.create_stage)
     type: dict
   tracing_enabled:
     description:
       - Specifies whether active tracing with X-ray is enabled for the API GW stage.
     type: bool
+    default: false
   endpoint_type:
     description:
-      - Type of endpoint configuration, use C(EDGE) for an edge optimized API endpoint,
-      - C(REGIONAL) for just a regional deploy or PRIVATE for a private API.
+      - Type of endpoint configuration.
+      - Use C(EDGE) for an edge optimized API endpoint,
+        C(REGIONAL) for just a regional deploy or C(PRIVATE) for a private API.
       - This flag will only be used when creating a new API Gateway setup, not for updates.
     choices: ['EDGE', 'REGIONAL', 'PRIVATE']
     type: str

--- a/plugins/modules/aws_application_scaling_policy.py
+++ b/plugins/modules/aws_application_scaling_policy.py
@@ -15,14 +15,14 @@ notes:
     - for details of the parameters and returns see
       U(http://boto3.readthedocs.io/en/latest/reference/services/application-autoscaling.html#ApplicationAutoScaling.Client.put_scaling_policy)
 description:
-    - Creates, updates or removes a Scaling Policy
+    - Creates, updates or removes a Scaling Policy.
 author:
     - Gustavo Maia (@gurumaia)
     - Chen Leibovich (@chenl87)
 requirements: [ json, botocore, boto3 ]
 options:
     state:
-        description: Whether a policy should be present or absent
+        description: Whether a policy should be C(present) or C(absent).
         required: yes
         choices: ['absent', 'present']
         type: str
@@ -57,12 +57,12 @@ options:
         choices: ['StepScaling', 'TargetTrackingScaling']
         type: str
     step_scaling_policy_configuration:
-        description: A step scaling policy. This parameter is required if you are creating a policy and the policy type is StepScaling.
+        description: A step scaling policy. This parameter is required if you are creating a policy and I(policy_type=StepScaling).
         required: no
         type: dict
     target_tracking_scaling_policy_configuration:
         description:
-            - A target tracking policy. This parameter is required if you are creating a new policy and the policy type is TargetTrackingScaling.
+            - A target tracking policy. This parameter is required if you are creating a new policy and I(policy_type=TargetTrackingScaling).
             - 'Full documentation of the suboptions can be found in the API documentation:'
             - 'U(https://docs.aws.amazon.com/autoscaling/application/APIReference/API_TargetTrackingScalingPolicyConfiguration.html)'
         required: no
@@ -84,7 +84,7 @@ options:
                 description: The time (in seconds) to wait after scaling-out before another scaling action can occur.
                 type: int
             TargetValue:
-                description: The target value for the metric
+                description: The target value for the metric.
                 type: float
     minimum_tasks:
         description: The minimum value to scale to in response to a scale in event.
@@ -97,9 +97,10 @@ options:
         required: no
         type: int
     override_task_capacity:
-        description: Whether or not to override values of minimum and/or maximum tasks if it's already set.
+        description:
+        - Whether or not to override values of minimum and/or maximum tasks if it's already set.
+        - Defaults to C(false).
         required: no
-        default: no
         type: bool
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/aws_direct_connect_connection.py
+++ b/plugins/modules/aws_direct_connect_connection.py
@@ -64,9 +64,10 @@ options:
     type: str
   forced_update:
     description:
-      - To modify bandwidth or location the connection will need to be deleted and recreated.
-        By default this will not happen - this option must be set to True.
+      - To modify I(bandwidth) or I(location) the connection needs to be deleted and recreated.
+      - By default this will not happen.  This option must be explicitly set to C(true) to change I(bandwith) or I(location).
     type: bool
+    default: false
 '''
 
 EXAMPLES = """
@@ -93,7 +94,7 @@ EXAMPLES = """
     name: ansible-test-connection
     location: EqDC2
     bandwidth: 10Gbps
-    forced_update: True
+    forced_update: true
 
 # delete the connection
 - community.aws.aws_direct_connect_connection:

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -59,6 +59,7 @@ options:
       - This allows the minimum number of links to be set to 0, any hosted connections disassociated,
         and any virtual interfaces associated to the LAG deleted.
     type: bool
+    default: false
   connection_id:
     description:
       - A connection ID to link with the link aggregation group upon creation.
@@ -67,12 +68,14 @@ options:
     description:
       - To be used with I(state=absent) to delete connections after disassociating them with the LAG.
     type: bool
+    default: false
   wait:
     description:
       - Whether or not to wait for the operation to complete.
       - May be useful when waiting for virtual interfaces to be deleted.
       - The time to wait can be controlled by setting I(wait_timeout).
     type: bool
+    default: false
   wait_timeout:
     description:
       - The duration in seconds to wait if I(wait=true).

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -66,7 +66,7 @@ options:
     tags:
       description:
         - Should be input as a dict of key-value pairs.
-        - Note that numeric keys or values must be wrapped in quotes. e.g. "Priority:" '1'
+        - "Note that numeric keys or values must be wrapped in quotes. e.g. C(Priority: '1')"
       type: dict
 
     purge_tags:
@@ -87,7 +87,7 @@ options:
 
     aliases:
       description:
-        - A list) of domain name aliases (CNAMEs) as strings to be used for the distribution.
+        - A list of domain name aliases (CNAMEs) as strings to be used for the distribution.
         - Each alias must be unique across all distribution for the AWS account.
       type: list
       elements: str
@@ -141,7 +141,7 @@ options:
           description:
             - Custom headers you wish to add to the request before passing it to the origin.
             - For more information see the CloudFront documentation
-              at U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html)
+              at U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html).
           type: list
           elements: dict
           suboptions:
@@ -191,7 +191,7 @@ options:
       description:
         - A dict specifying the default cache behavior of the distribution.
         - If not specified, the I(target_origin_id) is defined as the I(target_origin_id) of the first valid
-          I(cache_behavior) in I(cache_behaviors) with defaults.
+          cache_behavior in I(cache_behaviors) with defaults.
       suboptions:
         target_origin_id:
           description:
@@ -492,7 +492,7 @@ options:
     enabled:
       description:
         - A boolean value that specifies whether the distribution is enabled or disabled.
-      default: false
+        - Defaults to C(false).
       type: bool
 
     viewer_certificate:
@@ -504,18 +504,18 @@ options:
           type: bool
           description:
             - If you're using the CloudFront domain name for your distribution, such as C(123456789abcde.cloudfront.net)
-              you should set I(cloudfront_default_certificate=true)
+              you should set I(cloudfront_default_certificate=true).
             - If I(cloudfront_default_certificate=true) do not set I(ssl_support_method).
         iam_certificate_id:
           type: str
           description:
             - The ID of a certificate stored in IAM to use for HTTPS connections.
-            - If I(iam_certificate_id) is set then you must also specify I(ssl_support_method)
+            - If I(iam_certificate_id) is set then you must also specify I(ssl_support_method).
         acm_certificate_arn:
           type: str
           description:
             - The ID of a certificate stored in ACM to use for HTTPS connections.
-            - If I(acm_certificate_id) is set then you must also specify I(ssl_support_method)
+            - If I(acm_certificate_id) is set then you must also specify I(ssl_support_method).
         ssl_support_method:
           type: str
           description:
@@ -541,12 +541,12 @@ options:
               type: str
               description:
               - The method that you want to use to restrict distribution of your content by country.
-              - Valid values are C(none), C(whitelist), C(blacklist)
+              - Valid values are C(none), C(whitelist), C(blacklist).
             items:
               description:
               - A list of ISO 3166-1 two letter (Alpha 2) country codes that the
                 restriction should apply to.
-              - 'See the ISO website for a full list of codes U(https://www.iso.org/obp/ui/#search/code/)'
+              - 'See the ISO website for a full list of codes U(https://www.iso.org/obp/ui/#search/code/).'
               type: list
 
     web_acl_id:
@@ -558,14 +558,14 @@ options:
       description:
         - The version of the http protocol to use for the distribution.
         - AWS defaults this to C(http2).
-        - Valid values are C(http1.1) and C(http2)
+        - Valid values are C(http1.1) and C(http2).
       type: str
 
     ipv6_enabled:
       description:
         - Determines whether IPv6 support is enabled or not.
+        - Defaults to C(false).
       type: bool
-      default: false
 
     wait:
       description:

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -27,7 +27,7 @@ options:
     type: str
   name:
     description:
-      - The name of the new AMI to copy. (As of 2.3 the default is 'default', in prior versions it was 'null'.)
+      - The name of the new AMI to copy. (As of 2.3 the default is C(default), in prior versions it was C(null).)
     default: "default"
     type: str
   description:
@@ -38,20 +38,22 @@ options:
     description:
       - Whether or not the destination snapshots of the copied AMI should be encrypted.
     type: bool
+    default: false
   kms_key_id:
     description:
       - KMS key id used to encrypt the image. If not specified, uses default EBS Customer Master Key (CMK) for your account.
     type: str
   wait:
     description:
-      - Wait for the copied AMI to be in state 'available' before returning.
+      - Wait for the copied AMI to be in state C(available) before returning.
     type: bool
     default: 'no'
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds. Prior to 2.3 the default was 1200.
+      - How long before wait gives up, in seconds.
+      - Prior to 2.3 the default was C(1200).
       - From 2.3-2.5 this option was deprecated in favor of boto3 waiter defaults.
-        This was reenabled in 2.6 to allow timeouts greater than 10 minutes.
+      - This was reenabled in 2.6 to allow timeouts greater than 10 minutes.
     default: 600
     type: int
   tags:

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -532,12 +532,19 @@ def list_ec2_instances(connection, module):
     except ClientError as e:
         module.fail_json_aws(e, msg="Failed to list ec2 instances")
 
-    timedelta = int(uptime) if uptime else 0
-    oldest_launch_time = datetime.datetime.utcnow() - datetime.timedelta(hours=timedelta)
-    # Get instances from reservations
     instances = []
-    for reservation in reservations['Reservations']:
-        instances += [instance for instance in reservation['Instances'] if instance['LaunchTime'].replace(tzinfo=None) < oldest_launch_time]
+
+
+
+    if uptime:
+        timedelta = int(uptime) if uptime else 0
+        oldest_launch_time = datetime.datetime.utcnow() - datetime.timedelta(hours=timedelta)
+        # Get instances from reservations
+        for reservation in reservations['Reservations']:
+            instances += [instance for instance in reservation['Instances'] if instance['LaunchTime'].replace(tzinfo=None) < oldest_launch_time]
+    else:
+        for reservation in reservations['Reservations']:
+            instances = instances + reservation['Instances']
 
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_instances = [camel_dict_to_snake_dict(instance) for instance in instances]

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -35,7 +35,7 @@ options:
     type: dict
   uptime:
     description:
-      - minimum running uptime in hours of instances.  For example if uptime is 60, it would return all instances that have run more than 60 hours.
+      - minimum running uptime in minutes of instances.  For example if uptime is 60, it would return all instances that have run more than 60 minutes.
     required: false
     type: int
 
@@ -71,12 +71,13 @@ EXAMPLES = r'''
     filters:
       instance-state-name: [ "shutting-down", "stopping", "stopped" ]
 
-- name: Gather information about any instance with Name beginning with RHEL and been running at least 60 hours
+- name: Gather information about any instance with Name beginning with RHEL and been running at least 60 minutes
   community.aws.ec2_instance_info:
     region: "{{ ec2_region }}"
     uptime: 60
     filters:
       "tag:Name": "RHEL-*"
+      instance-state-name: [ "running" ]
   register: ec2_node_info
 
 '''
@@ -538,7 +539,7 @@ def list_ec2_instances(connection, module):
 
     if uptime:
         timedelta = int(uptime) if uptime else 0
-        oldest_launch_time = datetime.datetime.utcnow() - datetime.timedelta(hours=timedelta)
+        oldest_launch_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=timedelta)
         # Get instances from reservations
         for reservation in reservations['Reservations']:
             instances += [instance for instance in reservation['Instances'] if instance['LaunchTime'].replace(tzinfo=None) < oldest_launch_time]

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -35,7 +35,7 @@ options:
     type: dict
   uptime:
     description:
-      - minimum running uptime in minutes of instances.  For example if uptime is 60, it would return all instances that have run more than 60 minutes.
+      - minimum running uptime in hours of instances.  For example if uptime is 60, it would return all instances that have run more than 60 hours.
     required: false
     type: int
 
@@ -71,7 +71,7 @@ EXAMPLES = r'''
     filters:
       instance-state-name: [ "shutting-down", "stopping", "stopped" ]
 
-- name: Gather information about any instance with Name beginning with RHEL and been running at least 60 minutes
+- name: Gather information about any instance with Name beginning with RHEL and been running at least 60 hours
   community.aws.ec2_instance_info:
     region: "{{ ec2_region }}"
     uptime: 60

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -71,7 +71,7 @@ EXAMPLES = r'''
     filters:
       instance-state-name: [ "shutting-down", "stopping", "stopped" ]
 
-- name: grab info
+- name: Gather information about any instance with Name beginning with RHEL and been running at least 60 minutes
   community.aws.ec2_instance_info:
     region: "{{ ec2_region }}"
     uptime: 60

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -33,6 +33,11 @@ options:
     required: false
     default: {}
     type: dict
+  uptime:
+    description:
+      - minimum running uptime in minutes of instances.  For example if uptime is 60, it would return all instances that have run more than 60 minutes.
+    required: false
+    type: int
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -65,6 +70,14 @@ EXAMPLES = r'''
   community.aws.ec2_instance_info:
     filters:
       instance-state-name: [ "shutting-down", "stopping", "stopped" ]
+
+- name: grab info
+  community.aws.ec2_instance_info:
+    region: "{{ ec2_region }}"
+    uptime: 60
+    filters:
+      "tag:Name": "RHEL-*"
+  register: ec2_node_info
 
 '''
 
@@ -494,7 +507,6 @@ instances:
 import traceback
 import datetime
 
-
 try:
     import boto3
     import botocore
@@ -514,26 +526,18 @@ def list_ec2_instances(connection, module):
     uptime = module.params.get('uptime')
     filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
 
-    # Determine oldest launch_time
-    if uptime is None:
-        oldest_launch_time = datetime.datetime.utcnow() + datetime.timedelta(days=30 * 365)
-    else:
-        oldest_launch_time = datetime.datetime.utcnow() - datetime.timedelta(hours=int(uptime))
-
     try:
         reservations_paginator = connection.get_paginator('describe_instances')
         reservations = reservations_paginator.paginate(InstanceIds=instance_ids, Filters=filters).build_full_result()
     except ClientError as e:
         module.fail_json_aws(e, msg="Failed to list ec2 instances")
 
+    timedelta = int(uptime) if uptime else 0
+    oldest_launch_time = datetime.datetime.utcnow() - datetime.timedelta(hours=timedelta)
     # Get instances from reservations
     instances = []
     for reservation in reservations['Reservations']:
-      for ec2_instance in reservation:
-          print(ec2_instance)
-          ec2_instance['launch_time'] = ec2_instance['launch_time'].replace(tzinfo=oldest_launch_time.tzinfo)
-          # if reservation['launch_time'] < oldest_launch_time:
-          instances = instances + reservation['Instances']
+        instances += [instance for instance in reservation['Instances'] if instance['LaunchTime'].replace(tzinfo=None) < oldest_launch_time]
 
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_instances = [camel_dict_to_snake_dict(instance) for instance in instances]

--- a/plugins/modules/ec2_vpc_igw.py
+++ b/plugins/modules/ec2_vpc_igw.py
@@ -22,9 +22,16 @@ options:
     type: str
   tags:
     description:
-      - "A dict of tags to apply to the internet gateway. Any tags currently applied to the internet gateway and not present here will be removed."
+      - A dict of tags to apply to the internet gateway.
+      - To remove all tags set I(tags={}) and I(purge_tags=true).
     aliases: [ 'resource_tags' ]
     type: dict
+  purge_tags:
+    description:
+      - Remove tags not listed in I(tags).
+    type: bool
+    default: true
+    version_added: 1.3.0
   state:
     description:
       - Create or terminate the IGW
@@ -85,17 +92,16 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.six import string_types
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    AWSRetry,
-    camel_dict_to_snake_dict,
-    boto3_tag_list_to_ansible_dict,
-    ansible_dict_to_boto3_filter_list,
-    ansible_dict_to_boto3_tag_list,
-    compare_aws_tags
-)
-from ansible.module_utils.six import string_types
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 
 
 class AnsibleEc2Igw(object):
@@ -103,16 +109,17 @@ class AnsibleEc2Igw(object):
     def __init__(self, module, results):
         self._module = module
         self._results = results
-        self._connection = self._module.client('ec2')
+        self._connection = self._module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
         self._check_mode = self._module.check_mode
 
     def process(self):
         vpc_id = self._module.params.get('vpc_id')
         state = self._module.params.get('state', 'present')
         tags = self._module.params.get('tags')
+        purge_tags = self._module.params.get('purge_tags')
 
         if state == 'present':
-            self.ensure_igw_present(vpc_id, tags)
+            self.ensure_igw_present(vpc_id, tags, purge_tags)
         elif state == 'absent':
             self.ensure_igw_absent(vpc_id)
 
@@ -120,7 +127,7 @@ class AnsibleEc2Igw(object):
         filters = ansible_dict_to_boto3_filter_list({'attachment.vpc-id': vpc_id})
         igws = []
         try:
-            response = self._connection.describe_internet_gateways(Filters=filters)
+            response = self._connection.describe_internet_gateways(aws_retry=True, Filters=filters)
             igws = response.get('InternetGateways', [])
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self._module.fail_json_aws(e)
@@ -135,21 +142,25 @@ class AnsibleEc2Igw(object):
         return igw
 
     def check_input_tags(self, tags):
+        if tags is None:
+            return
         nonstring_tags = [k for k, v in tags.items() if not isinstance(v, string_types)]
         if nonstring_tags:
             self._module.fail_json(msg='One or more tags contain non-string values: {0}'.format(nonstring_tags))
 
-    def ensure_tags(self, igw_id, tags, add_only):
+    def ensure_tags(self, igw_id, tags, purge_tags):
         final_tags = []
 
         filters = ansible_dict_to_boto3_filter_list({'resource-id': igw_id, 'resource-type': 'internet-gateway'})
         cur_tags = None
         try:
-            cur_tags = self._connection.describe_tags(Filters=filters)
+            cur_tags = self._connection.describe_tags(aws_retry=True, Filters=filters)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self._module.fail_json_aws(e, msg="Couldn't describe tags")
 
-        purge_tags = bool(not add_only)
+        if tags is None:
+            return boto3_tag_list_to_ansible_dict(cur_tags.get('Tags'))
+
         to_update, to_delete = compare_aws_tags(boto3_tag_list_to_ansible_dict(cur_tags.get('Tags')), tags, purge_tags)
         final_tags = boto3_tag_list_to_ansible_dict(cur_tags.get('Tags'))
 
@@ -159,7 +170,8 @@ class AnsibleEc2Igw(object):
                     # update tags
                     final_tags.update(to_update)
                 else:
-                    AWSRetry.exponential_backoff()(self._connection.create_tags)(
+                    self._connection.create_tags(
+                        aws_retry=True,
                         Resources=[igw_id],
                         Tags=ansible_dict_to_boto3_tag_list(to_update)
                     )
@@ -179,7 +191,7 @@ class AnsibleEc2Igw(object):
                     for key in to_delete:
                         tags_list.append({'Key': key})
 
-                    AWSRetry.exponential_backoff()(self._connection.delete_tags)(Resources=[igw_id], Tags=tags_list)
+                    self._connection.delete_tags(aws_retry=True, Resources=[igw_id], Tags=tags_list)
 
                 self._results['changed'] = True
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
@@ -187,7 +199,7 @@ class AnsibleEc2Igw(object):
 
         if not self._check_mode and (to_update or to_delete):
             try:
-                response = self._connection.describe_tags(Filters=filters)
+                response = self._connection.describe_tags(aws_retry=True, Filters=filters)
                 final_tags = boto3_tag_list_to_ansible_dict(response.get('Tags'))
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 self._module.fail_json_aws(e, msg="Couldn't describe tags")
@@ -213,14 +225,14 @@ class AnsibleEc2Igw(object):
 
         try:
             self._results['changed'] = True
-            self._connection.detach_internet_gateway(InternetGatewayId=igw['internet_gateway_id'], VpcId=vpc_id)
-            self._connection.delete_internet_gateway(InternetGatewayId=igw['internet_gateway_id'])
+            self._connection.detach_internet_gateway(aws_retry=True, InternetGatewayId=igw['internet_gateway_id'], VpcId=vpc_id)
+            self._connection.delete_internet_gateway(aws_retry=True, InternetGatewayId=igw['internet_gateway_id'])
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self._module.fail_json_aws(e, msg="Unable to delete Internet Gateway")
 
         return self._results
 
-    def ensure_igw_present(self, vpc_id, tags):
+    def ensure_igw_present(self, vpc_id, tags, purge_tags):
         self.check_input_tags(tags)
 
         igw = self.get_matching_igw(vpc_id)
@@ -232,21 +244,21 @@ class AnsibleEc2Igw(object):
                 return self._results
 
             try:
-                response = self._connection.create_internet_gateway()
+                response = self._connection.create_internet_gateway(aws_retry=True)
 
                 # Ensure the gateway exists before trying to attach it or add tags
                 waiter = get_waiter(self._connection, 'internet_gateway_exists')
                 waiter.wait(InternetGatewayIds=[response['InternetGateway']['InternetGatewayId']])
 
                 igw = camel_dict_to_snake_dict(response['InternetGateway'])
-                self._connection.attach_internet_gateway(InternetGatewayId=igw['internet_gateway_id'], VpcId=vpc_id)
+                self._connection.attach_internet_gateway(aws_retry=True, InternetGatewayId=igw['internet_gateway_id'], VpcId=vpc_id)
                 self._results['changed'] = True
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 self._module.fail_json_aws(e, msg='Unable to create Internet Gateway')
 
         igw['vpc_id'] = vpc_id
 
-        igw['tags'] = self.ensure_tags(igw_id=igw['internet_gateway_id'], tags=tags, add_only=False)
+        igw['tags'] = self.ensure_tags(igw_id=igw['internet_gateway_id'], tags=tags, purge_tags=purge_tags)
 
         igw_info = self.get_igw_info(igw)
         self._results.update(igw_info)
@@ -258,7 +270,8 @@ def main():
     argument_spec = dict(
         vpc_id=dict(required=True),
         state=dict(default='present', choices=['present', 'absent']),
-        tags=dict(default=dict(), required=False, type='dict', aliases=['resource_tags'])
+        tags=dict(required=False, type='dict', aliases=['resource_tags']),
+        purge_tags=dict(default=True, type='bool'),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -35,7 +35,7 @@ options:
   connection_type:
     description:
       - The type of VPN connection.
-      - At this time only 'ipsec.1' is supported.
+      - At this time only C(ipsec.1) is supported.
     default: ipsec.1
     type: str
   vpn_gateway_id:
@@ -63,8 +63,8 @@ options:
     required: no
   tunnel_options:
     description:
-      - An optional list object containing no more than two dict members, each of which may contain 'TunnelInsideCidr'
-        and/or 'PreSharedKey' keys with appropriate string values.  AWS defaults will apply in absence of either of
+      - An optional list object containing no more than two dict members, each of which may contain I(TunnelInsideCidr)
+        and/or I(PreSharedKey) keys with appropriate string values.  AWS defaults will apply in absence of either of
         the aforementioned keys.
     required: no
     type: list
@@ -78,11 +78,11 @@ options:
             description: The pre-shared key (PSK) to establish initial authentication between the virtual private gateway and customer gateway.
   filters:
     description:
-      - An alternative to using vpn_connection_id. If multiple matches are found, vpn_connection_id is required.
+      - An alternative to using I(vpn_connection_id). If multiple matches are found, vpn_connection_id is required.
         If one of the following suboptions is a list of items to filter by, only one item needs to match to find the VPN
-        that correlates. e.g. if the filter 'cidr' is ['194.168.2.0/24', '192.168.2.0/24'] and the VPN route only has the
-        destination cidr block of '192.168.2.0/24' it will be found with this filter (assuming there are not multiple
-        VPNs that are matched). Another example, if the filter 'vpn' is equal to ['vpn-ccf7e7ad', 'vpn-cb0ae2a2'] and one
+        that correlates. e.g. if the filter I(cidr) is C(['194.168.2.0/24', '192.168.2.0/24']) and the VPN route only has the
+        destination cidr block of C(192.168.2.0/24) it will be found with this filter (assuming there are not multiple
+        VPNs that are matched). Another example, if the filter I(vpn) is equal to C(['vpn-ccf7e7ad', 'vpn-cb0ae2a2']) and one
         of of the VPNs has the state deleted (exists but is unmodifiable) and the other exists and is not deleted,
         it will be found via this filter. See examples.
     suboptions:
@@ -91,7 +91,7 @@ options:
           - The customer gateway configuration of the VPN as a string (in the format of the return value) or a list of those strings.
       static-routes-only:
         description:
-          - The type of routing; true or false.
+          - The type of routing; C(true) or C(false).
       cidr:
         description:
           - The destination cidr of the VPN's route as a string or a list of those strings.
@@ -127,15 +127,16 @@ options:
     description:
       - Whether or not to delete VPN connections routes that are not specified in the task.
     type: bool
+    default: false
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds.
+      - How long, in seconds, before wait gives up.
     default: 600
     type: int
     required: false
   delay:
     description:
-      - The time to wait before checking operation again. in seconds.
+      - The time, in seconds, to wait before checking operation again.
     required: false
     type: int
     default: 15

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -45,8 +45,8 @@ options:
         description:
             - If yes, remove the policy from the repository.
             - Alias C(delete_policy) has been deprecated and will be removed after 2022-06-01.
+            - Defaults to C(false).
         required: false
-        default: false
         type: bool
         aliases: [ delete_policy ]
     image_tag_mutability:
@@ -63,9 +63,9 @@ options:
         type: json
     purge_lifecycle_policy:
         description:
-            - if yes, remove the lifecycle policy from the repository.
+            - if C(true), remove the lifecycle policy from the repository.
+            - Defaults to C(false).
         required: false
-        default: false
         type: bool
     state:
         description:
@@ -76,7 +76,7 @@ options:
         type: str
     scan_on_push:
         description:
-            - if yes, images are scanned for known vulnerabilities after being pushed to the repository.
+            - if C(true), images are scanned for known vulnerabilities after being pushed to the repository.
             - I(scan_on_push) requires botocore >= 1.13.3
         required: false
         default: false

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -88,6 +88,7 @@ options:
           - Force deployment of service even if there are no changes.
         required: false
         type: bool
+        default: false
     deployment_configuration:
         description:
           - Optional parameters that control the deployment_configuration.
@@ -136,12 +137,12 @@ options:
         suboptions:
           subnets:
             description:
-              - A list of subnet IDs to associate with the task
+              - A list of subnet IDs to associate with the task.
             type: list
             elements: str
           security_groups:
             description:
-              - A list of security group names or group IDs to associate with the task
+              - A list of security group names or group IDs to associate with the task.
             type: list
             elements: str
           assign_public_ip:
@@ -170,19 +171,20 @@ options:
         suboptions:
             container_name:
                 description:
-                  - container name for service discovery registration
+                  - Container name for service discovery registration.
                 type: str
             container_port:
                 description:
-                  - container port for service discovery registration
+                  - Container port for service discovery registration.
                 type: int
             arn:
                 description:
-                  - Service discovery registry ARN
+                  - Service discovery registry ARN.
                 type: str
     scheduling_strategy:
         description:
-          - The scheduling strategy, defaults to "REPLICA" if not given to preserve previous behavior
+          - The scheduling strategy.
+          - Defaults to C(REPLICA) if not given to preserve previous behavior.
         required: false
         choices: ["DAEMON", "REPLICA"]
         type: str

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -42,6 +42,7 @@ options:
             - Always create new task definition.
         required: False
         type: bool
+        default: false
     containers:
         description:
             - A list of containers definitions.
@@ -95,7 +96,7 @@ options:
     memory:
         description:
             - The amount (in MiB) of memory used by the task. If using the EC2 launch type, this field is optional and any value can be used.
-            - If using the Fargate launch type, this field is required and is limited by the cpu.
+            - If using the Fargate launch type, this field is required and is limited by the CPU.
         required: false
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -64,17 +64,17 @@ options:
     type: str
   cache_subnet_group:
     description:
-      - The subnet group name to associate with. Only use if inside a vpc.
-      - Required if inside a vpc
+      - The subnet group name to associate with. Only use if inside a VPC.
+      - Required if inside a VPC.
     type: str
   security_group_ids:
     description:
-      - A list of vpc security group IDs to associate with this cache cluster. Only use if inside a vpc.
+      - A list of VPC security group IDs to associate with this cache cluster. Only use if inside a VPC.
     type: list
     elements: str
   cache_security_groups:
     description:
-      - A list of cache security group names to associate with this cache cluster. Must be an empty list if inside a vpc.
+      - A list of cache security group names to associate with this cache cluster. Must be an empty list if inside a VPC.
     type: list
     elements: str
   zone:
@@ -89,8 +89,8 @@ options:
   hard_modify:
     description:
       - Whether to destroy and recreate an existing cache cluster if necessary in order to modify its state.
+      - Defaults to C(false).
     type: bool
-    default: false
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -22,7 +22,7 @@ DOCUMENTATION = r'''
 ---
 module: elb_application_lb
 version_added: 1.0.0
-short_description: Manage an Application load balancer
+short_description: Manage an Application Load Balancer
 description:
     - Manage an AWS Application Elastic Load Balancer. See U(https://aws.amazon.com/blogs/aws/new-aws-application-load-balancer/) for details.
 requirements: [ boto3 ]
@@ -50,12 +50,12 @@ options:
   deletion_protection:
     description:
       - Indicates whether deletion protection for the ELB is enabled.
-    default: no
+      - Defaults to C(false).
     type: bool
   http2:
     description:
       - Indicates whether to enable HTTP2 routing.
-    default: no
+      - Defaults to C(false).
     type: bool
   idle_timeout:
     description:
@@ -124,14 +124,14 @@ options:
     type: str
   purge_listeners:
     description:
-      - If yes, existing listeners will be purged from the ELB to match exactly what is defined by I(listeners) parameter. If the I(listeners) parameter is
-        not set then listeners will not be modified
+      - If C(yes), existing listeners will be purged from the ELB to match exactly what is defined by I(listeners) parameter.
+      - If the I(listeners) parameter is not set then listeners will not be modified.
     default: yes
     type: bool
   purge_tags:
     description:
-      - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter. If the I(tags) parameter is not set then
-        tags will not be modified.
+      - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter.
+      - If the I(tags) parameter is not set then tags will not be modified.
     default: yes
     type: bool
   subnets:
@@ -176,7 +176,7 @@ options:
     type: int
   purge_rules:
     description:
-      - When set to no, keep the existing load balancer rules in place. Will modify and add, but will not delete.
+      - When set to C(no), keep the existing load balancer rules in place. Will modify and add, but will not delete.
     default: yes
     type: bool
 extends_documentation_fragment:

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -19,62 +19,62 @@ author:
 options:
   state:
     description:
-      - Create or destroy the ELB
+      - Create or destroy the ELB.
     choices: ["present", "absent"]
     required: true
     type: str
   name:
     description:
-      - The name of the ELB
+      - The name of the ELB.
     required: true
     type: str
   listeners:
     description:
-      - List of ports/protocols for this ELB to listen on (see example)
+      - List of ports/protocols for this ELB to listen on (see example).
     type: list
     elements: dict
   purge_listeners:
     description:
-      - Purge existing listeners on ELB that are not found in listeners
+      - Purge existing listeners on ELB that are not found in listeners.
     type: bool
-    default: 'yes'
+    default: true
   instance_ids:
     description:
-      - List of instance ids to attach to this ELB
+      - List of instance ids to attach to this ELB.
     type: list
     elements: str
   purge_instance_ids:
     description:
-      - Purge existing instance ids on ELB that are not found in instance_ids
+      - Purge existing instance ids on ELB that are not found in I(instance_ids).
     type: bool
-    default: 'no'
+    default: false
   zones:
     description:
-      - List of availability zones to enable on this ELB
+      - List of availability zones to enable on this ELB.
     type: list
     elements: str
   purge_zones:
     description:
-      - Purge existing availability zones on ELB that are not found in zones
+      - Purge existing availability zones on ELB that are not found in zones.
     type: bool
-    default: 'no'
+    default: false
   security_group_ids:
     description:
-      - A list of security groups to apply to the elb
+      - A list of security groups to apply to the ELB.
     type: list
     elements: str
   security_group_names:
     description:
-      - A list of security group names to apply to the elb
+      - A list of security group names to apply to the ELB.
     type: list
     elements: str
   health_check:
     description:
-      - An associative array of health check configuration settings (see example)
+      - An associative array of health check configuration settings (see example).
     type: dict
   access_logs:
     description:
-      - An associative array of access logs configuration settings (see example)
+      - An associative array of access logs configuration settings (see example).
     type: dict
   subnets:
     description:
@@ -83,49 +83,50 @@ options:
     elements: str
   purge_subnets:
     description:
-      - Purge existing subnet on ELB that are not found in subnets
+      - Purge existing subnets on ELB that are not found in subnets.
     type: bool
-    default: 'no'
+    default: false
   scheme:
     description:
-      - The scheme to use when creating the ELB. For a private VPC-visible ELB use 'internal'.
-        If you choose to update your scheme with a different value the ELB will be destroyed and
-        recreated. To update scheme you must use the option wait.
+      - The scheme to use when creating the ELB.
+      - For a private VPC-visible ELB use C(internal).
+      - If you choose to update your scheme with a different value the ELB will be destroyed and
+        recreated. To update scheme you must set I(wait=true).
     choices: ["internal", "internet-facing"]
     default: 'internet-facing'
     type: str
   validate_certs:
     description:
-      - When set to C(no), SSL certificates will not be validated for boto versions >= 2.6.0.
+      - When set to C(false), SSL certificates will not be validated for boto versions >= 2.6.0.
     type: bool
-    default: 'yes'
+    default: true
   connection_draining_timeout:
     description:
-      - Wait a specified timeout allowing connections to drain before terminating an instance
+      - Wait a specified timeout allowing connections to drain before terminating an instance.
     type: int
   idle_timeout:
     description:
-      - ELB connections from clients and to servers are timed out after this amount of time
+      - ELB connections from clients and to servers are timed out after this amount of time.
     type: int
   cross_az_load_balancing:
     description:
-      - Distribute load across all configured Availability Zones
+      - Distribute load across all configured Availability Zones.
+      - Defaults to C(false).
     type: bool
-    default: 'no'
   stickiness:
     description:
-      - An associative array of stickiness policy settings. Policy will be applied to all listeners ( see example )
+      - An associative array of stickiness policy settings. Policy will be applied to all listeners (see example).
     type: dict
   wait:
     description:
       - When specified, Ansible will check the status of the load balancer to ensure it has been successfully
         removed from AWS.
     type: bool
-    default: 'no'
+    default: false
   wait_timeout:
     description:
-      - Used in conjunction with wait. Number of seconds to wait for the elb to be terminated.
-        A maximum of 600 seconds (10 minutes) is allowed.
+      - Used in conjunction with wait. Number of seconds to wait for the ELB to be terminated.
+        A maximum of C(600) seconds (10 minutes) is allowed.
     default: 60
     type: int
   tags:

--- a/plugins/modules/elb_network_lb.py
+++ b/plugins/modules/elb_network_lb.py
@@ -21,12 +21,12 @@ options:
   cross_zone_load_balancing:
     description:
       - Indicates whether cross-zone load balancing is enabled.
-    default: false
+      - Defaults to C(false).
     type: bool
   deletion_protection:
     description:
       - Indicates whether deletion protection for the ELB is enabled.
-    default: false
+      - Defaults to C(false).
     type: bool
   listeners:
     description:

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -12,27 +12,30 @@ module: elb_target
 version_added: 1.0.0
 short_description: Manage a target in a target group
 description:
-    - Used to register or deregister a target in a target group
+    - Used to register or deregister a target in a target group.
 author: "Rob White (@wimnat)"
 options:
   deregister_unused:
     description:
-      - The default behaviour for targets that are unused is to leave them registered. If instead you would like to remove them
-        set I(deregister_unused) to yes.
+      - The default behaviour for targets that are unused is to leave them registered.
+      - If instead you would like to remove them set I(deregister_unused=true).
+    default: false
     type: bool
   target_az:
     description:
-      - An Availability Zone or all. This determines whether the target receives traffic from the load balancer nodes in the specified
+      - An Availability Zone or C(all). This determines whether the target receives traffic from the load balancer nodes in the specified
         Availability Zone or from all enabled Availability Zones for the load balancer. This parameter is not supported if the target
         type of the target group is instance.
     type: str
   target_group_arn:
     description:
-      - The Amazon Resource Name (ARN) of the target group. Mutually exclusive of I(target_group_name).
+      - The Amazon Resource Name (ARN) of the target group.
+      - Mutually exclusive of I(target_group_name).
     type: str
   target_group_name:
     description:
-      - The name of the target group. Mutually exclusive of I(target_group_arn).
+      - The name of the target group.
+      - Mutually exclusive of I(target_group_arn).
     type: str
   target_id:
     description:
@@ -55,7 +58,7 @@ options:
     type: str
   target_status_timeout:
     description:
-      - Maximum time in seconds to wait for target_status change
+      - Maximum time in seconds to wait for I(target_status) change.
     required: false
     default: 60
     type: int

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -33,17 +33,17 @@ options:
     type: str
   new_name:
     description:
-      - When state is present, this will update the name of the cert.
-      - The cert, key and cert_chain parameters will be ignored if this is defined.
+      - When I(state=present), this will update the name of the cert.
+      - The I(cert), I(key) and I(cert_chain) parameters will be ignored if this is defined.
     type: str
   new_path:
     description:
-      - When state is present, this will update the path of the cert.
+      - When I(state=present), this will update the path of the cert.
       - The I(cert), I(key) and I(cert_chain) parameters will be ignored if this is defined.
     type: str
   state:
     description:
-      - Whether to create(or update) or delete the certificate.
+      - Whether to create (or update) or delete the certificate.
       - If I(new_path) or I(new_name) is defined, specifying present will attempt to make an update these.
     required: true
     choices: [ "present", "absent" ]
@@ -72,7 +72,7 @@ options:
     description:
       - By default the module will not upload a certificate that is already uploaded into AWS.
       - If I(dup_ok=True), it will upload the certificate as long as the name is unique.
-    default: False
+      - Defaults to C(false).
     type: bool
 
 requirements: [ "boto" ]

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -120,7 +120,7 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies, AWSRetry
 from ansible.module_utils.six import string_types
 
 
@@ -236,16 +236,16 @@ class UserPolicy(Policy):
         return 'user'
 
     def _list(self, name):
-        return self.client.list_user_policies(UserName=name)
+        return self.client.list_user_policies(aws_retry=True, UserName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_user_policy(UserName=name, PolicyName=policy_name)
+        return self.client.get_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name)
 
     def _put(self, name, policy_name, policy_doc):
-        return self.client.put_user_policy(UserName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
+        return self.client.put_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
     def _delete(self, name, policy_name):
-        return self.client.delete_user_policy(UserName=name, PolicyName=policy_name)
+        return self.client.delete_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name)
 
 
 class RolePolicy(Policy):
@@ -255,16 +255,16 @@ class RolePolicy(Policy):
         return 'role'
 
     def _list(self, name):
-        return self.client.list_role_policies(RoleName=name)
+        return self.client.list_role_policies(aws_retry=True, RoleName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_role_policy(RoleName=name, PolicyName=policy_name)
+        return self.client.get_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name)
 
     def _put(self, name, policy_name, policy_doc):
-        return self.client.put_role_policy(RoleName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
+        return self.client.put_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
     def _delete(self, name, policy_name):
-        return self.client.delete_role_policy(RoleName=name, PolicyName=policy_name)
+        return self.client.delete_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name)
 
 
 class GroupPolicy(Policy):
@@ -274,16 +274,16 @@ class GroupPolicy(Policy):
         return 'group'
 
     def _list(self, name):
-        return self.client.list_group_policies(GroupName=name)
+        return self.client.list_group_policies(aws_retry=True, GroupName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_group_policy(GroupName=name, PolicyName=policy_name)
+        return self.client.get_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name)
 
     def _put(self, name, policy_name, policy_doc):
-        return self.client.put_group_policy(GroupName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
+        return self.client.put_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
     def _delete(self, name, policy_name):
-        return self.client.delete_group_policy(GroupName=name, PolicyName=policy_name)
+        return self.client.delete_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name)
 
 
 def main():
@@ -314,7 +314,7 @@ def main():
                          date='2022-06-01', collection_name='community.aws')
 
     args = dict(
-        client=module.client('iam'),
+        client=module.client('iam', retry_decorator=AWSRetry.jittered_backoff()),
         name=module.params.get('iam_name'),
         policy_name=module.params.get('policy_name'),
         policy_document=module.params.get('policy_document'),

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -85,6 +85,7 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible.module_utils.six import string_types
 
 
@@ -147,10 +148,10 @@ class UserPolicy(Policy):
         return 'user'
 
     def _list(self, name):
-        return self.client.list_user_policies(UserName=name)
+        return self.client.list_user_policies(aws_retry=True, UserName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_user_policy(UserName=name, PolicyName=policy_name)
+        return self.client.get_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name)
 
 
 class RolePolicy(Policy):
@@ -160,10 +161,10 @@ class RolePolicy(Policy):
         return 'role'
 
     def _list(self, name):
-        return self.client.list_role_policies(RoleName=name)
+        return self.client.list_role_policies(aws_retry=True, RoleName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_role_policy(RoleName=name, PolicyName=policy_name)
+        return self.client.get_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name)
 
 
 class GroupPolicy(Policy):
@@ -173,10 +174,10 @@ class GroupPolicy(Policy):
         return 'group'
 
     def _list(self, name):
-        return self.client.list_group_policies(GroupName=name)
+        return self.client.list_group_policies(aws_retry=True, GroupName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_group_policy(GroupName=name, PolicyName=policy_name)
+        return self.client.get_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name)
 
 
 def main():
@@ -189,7 +190,7 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     args = dict(
-        client=module.client('iam'),
+        client=module.client('iam', retry_decorator=AWSRetry.jittered_backoff()),
         name=module.params.get('iam_name'),
         policy_name=module.params.get('policy_name'),
     )

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -12,14 +12,14 @@ DOCUMENTATION = r'''
 ---
 module: route53
 version_added: 1.0.0
-short_description: add or delete entries in Amazons Route53 DNS service
+short_description: add or delete entries in Amazons Route 53 DNS service
 description:
-     - Creates and deletes DNS records in Amazons Route53 service
+     - Creates and deletes DNS records in Amazons Route 53 service.
 options:
   state:
     description:
       - Specifies the state of the resource record. As of Ansible 2.4, the I(command) option has been changed
-        to I(state) as default and the choices 'present' and 'absent' have been added, but I(command) still works as well.
+        to I(state) as default and the choices C(present) and C(absent) have been added, but I(command) still works as well.
     required: true
     aliases: [ 'command' ]
     choices: [ 'present', 'absent', 'get', 'create', 'delete' ]
@@ -53,8 +53,8 @@ options:
   alias:
     description:
       - Indicates if this is an alias record.
+      - Defaults to C(false).
     type: bool
-    default: false
   alias_hosted_zone_id:
     description:
       - The hosted zone identifier.
@@ -67,7 +67,7 @@ options:
   value:
     description:
       - The new value when creating a DNS record.  YAML lists or multiple comma-spaced values are allowed for non-alias records.
-      - When deleting a record all values for the record must be specified or Route53 will not delete it.
+      - When deleting a record all values for the record must be specified or Route 53 will not delete it.
     type: list
     elements: str
   overwrite:
@@ -76,14 +76,14 @@ options:
     type: bool
   retry_interval:
     description:
-      - In the case that route53 is still servicing a prior request, this module will wait and try again after this many seconds.
-        If you have many domain names, the default of 500 seconds may be too long.
+      - In the case that Route 53 is still servicing a prior request, this module will wait and try again after this many seconds.
+        If you have many domain names, the default of C(500) seconds may be too long.
     default: 500
     type: int
   private_zone:
     description:
-      - If set to C(yes), the private zone matching the requested name within the domain will be used if there are both public and private zones.
-        The default is to use the public zone.
+      - If set to C(true), the private zone matching the requested name within the domain will be used if there are both public and private zones.
+      - The default is to use the public zone.
     type: bool
     default: false
   identifier:

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: sqs_queue
 version_added: 1.0.0
-short_description: Creates or deletes AWS SQS queues.
+short_description: Creates or deletes AWS SQS queues
 description:
   - Create or delete AWS SQS queues.
   - Update attributes on existing queues.
@@ -83,8 +83,9 @@ options:
     type: int
   content_based_deduplication:
     type: bool
-    description: Enables content-based deduplication. Used for FIFOs only.
-    default: false
+    description:
+      - Enables content-based deduplication. Used for FIFOs only.
+      - Defaults to C(false).
   tags:
     description:
       - Tag dict to apply to the queue (requires botocore 1.5.40 or above).

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -63,8 +63,10 @@
       name: '{{ resource_prefix }}-instance'
       image_id: '{{ ec2_amis.images[0].image_id }}'
       security_group: '{{ security_group.group_id }}'
+      vpc_subnet_id: '{{ vpc_subnet_create.subnet.id }}'
       wait: no  ## Don't delay the tests, we'll check again before we need it
-    register: ec2_instance_result
+    register: create_ec2_instance_result
+
   # =====================================================
   - name: Look for signs of concurrent EIP tests.  Pause if they are running or their prefix comes before ours.
     vars:
@@ -570,19 +572,23 @@
         - eip_info.addresses[0].allocation_id is defined
         - eip_info.addresses[0].instance_id == '{{ instance_info.instances[0].instance_id }}'
   # =====================================================
-  - name: Cleanup IGW
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw
   - name: Cleanup instance
     ec2_instance:
-      name: '{{ resource_prefix }}-instance'
+      instance_ids: '{{ create_ec2_instance_result.instance_ids }}'
       state: absent
   - name: Cleanup instance eip
     ec2_eip:
       state: absent
       public_ip: '{{ instance_eip.public_ip }}'
+    register: eip_cleanup
+    retries: 5
+    delay: 5
+    until: eip_cleanup is successful
+  - name: Cleanup IGW
+    ec2_vpc_igw:
+      state: absent
+      vpc_id: '{{ vpc_result.vpc.id }}'
+    register: vpc_igw
   - name: Cleanup security group
     ec2_group:
       state: absent
@@ -642,6 +648,18 @@
       cidr_block: '{{ vpc_cidr }}'
   # =====================================================
   always:
+  - name: Cleanup instance (by id)
+    ec2_instance:
+      instance_ids: '{{ create_ec2_instance_result.instance_ids }}'
+      state: absent
+      wait: true
+    ignore_errors: true
+  - name: Cleanup instance (by name)
+    ec2_instance:
+      name: '{{ resource_prefix }}-instance'
+      state: absent
+      wait: true
+    ignore_errors: true
   - name: Cleanup ENI A
     ec2_eni:
       state: absent
@@ -652,20 +670,19 @@
       state: absent
       eni_id: '{{ eni_create_b.interface.id }}'
     ignore_errors: true
+  - name: Cleanup instance eip
+    ec2_eip:
+      state: absent
+      public_ip: '{{ instance_eip.public_ip }}'
+    retries: 5
+    delay: 5
+    until: eip_cleanup is successful
+    ignore_errors: true
   - name: Cleanup IGW
     ec2_vpc_igw:
       state: absent
       vpc_id: '{{ vpc_result.vpc.id }}'
     register: vpc_igw
-  - name: Cleanup instance
-    ec2_instance:
-      name: '{{ resource_prefix }}-instance'
-      state: absent
-    ignore_errors: true
-  - name: Cleanup instance eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ instance_eip.public_ip }}'
     ignore_errors: true
   - name: Cleanup security group
     ec2_group:

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
@@ -1,0 +1,60 @@
+- block:
+  - name: "create t3.nano instance"
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-t3nano-1"
+      region: "{{ ec2_region }}"
+      image_id: "{{ ec2_ami_image }}"
+      tags:
+        TestId: "{{ ec2_instance_tag_TestId }}"
+      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+      instance_type: t3.nano
+      wait: yes
+
+  - name: "check ec2 instance"
+    ec2_instance_info:
+      filters:
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+        instance-state-name: [ "running"]
+    register: instance_facts
+
+  - name: "Confirm existence of instance id."
+    assert:
+      that:
+        - "{{ instance_facts.instances | length }} == 1"
+
+  - name: "check using uptime 100 hours - should fail"
+    ec2_instance_info:
+      region: "{{ ec2_region }}"
+      uptime: 6000
+      filters:
+        instance-state-name: [ "running"]
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+    register: instance_facts
+
+  - name: "Confirm there is no running instance"
+    assert:
+      that:
+        - "{{ instance_facts.instances | length }} == 0"
+
+  - name: "check using uptime 1 minute"
+    ec2_instance_info:
+      region: "{{ ec2_region }}"
+      uptime: 1
+      filters:
+        instance-state-name: [ "running"]
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+    register: instance_facts
+
+  - name: "Confirm there is one running instance"
+    assert:
+      that:
+        - "{{ instance_facts.instances | length }} == 1"
+
+  always:
+  - name: "Terminate instances"
+    ec2_instance:
+      state: absent
+      filters:
+        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
+      wait: yes
+    ignore_errors: yes

--- a/tests/integration/targets/ec2_vpc_igw/aliases
+++ b/tests/integration/targets/ec2_vpc_igw/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group2
+ec2_vpc_igw_info

--- a/tests/integration/targets/ec2_vpc_igw/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+vpc_name: '{{ resource_prefix }}-vpc'
+vpc_seed: '{{ resource_prefix }}'
+vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'

--- a/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -3,72 +3,415 @@
   collections:
     - amazon.aws
 
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: set up aws connection info
-    set_fact:
-      aws_connection_info: &aws_connection_info
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region }}"
-    no_log: yes
+  # ============================================================
+  - name: Fetch IGWs in check_mode
+    ec2_vpc_igw_info:
+    register: igw_info
+    check_mode: True
+
+  - name: Assert success
+    assert:
+      that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
 
   # ============================================================
   - name: create a VPC
     ec2_vpc_net:
-      name: "{{ resource_prefix }}-vpc"
+      name: "{{ vpc_name }}"
       state: present
-      cidr_block: "10.232.232.128/26"
-      <<: *aws_connection_info
+      cidr_block: "{{ vpc_cidr }}"
       tags:
         Name: "{{ resource_prefix }}-vpc"
         Description: "Created by ansible-test"
     register: vpc_result
 
+  - name: Assert success
+    assert:
+      that:
+          - vpc_result is successful
+
   # ============================================================
+  - name: Search for internet gateway by VPC - no matches
+    ec2_vpc_igw_info:
+      filters:
+        attachment.vpc-id: '{{ vpc_result.vpc.id }}'
+    register:  igw_info
+
+  - name: Assert success
+    assert:
+      that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
+
+  # ============================================================
+  - name: create internet gateway (expected changed=true) - CHECK_MODE
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        tag_one: '{{ resource_prefix }} One'
+        "Tag Two": 'two {{ resource_prefix }}'
+    register: vpc_igw_create
+    check_mode: yes
+
+  - name: assert creation would happen (expected changed=true) - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_create is changed
+
   - name: create internet gateway (expected changed=true)
     ec2_vpc_igw:
       state: present
       vpc_id: "{{ vpc_result.vpc.id }}"
-      <<: *aws_connection_info
+      tags:
+        tag_one: '{{ resource_prefix }} One'
+        "Tag Two": 'two {{ resource_prefix }}'
     register: vpc_igw_create
 
   - name: assert creation happened (expected changed=true)
     assert:
       that:
-          - 'vpc_igw_create'
+          - vpc_igw_create is changed
           - 'vpc_igw_create.gateway_id.startswith("igw-")'
           - 'vpc_igw_create.vpc_id == vpc_result.vpc.id'
           - '"tags" in vpc_igw_create'
+          - vpc_igw_create.tags | length == 2
+          - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
           - '"gateway_id" in vpc_igw_create'
 
   # ============================================================
+  - name: Save IDs for later
+    set_fact:
+      igw_id: '{{ vpc_igw_create.gateway_id }}'
+      vpc_id: '{{ vpc_result.vpc.id }}'
+
+  # ============================================================
+  - name: Search for internet gateway by VPC
+    ec2_vpc_igw_info:
+      filters:
+        attachment.vpc-id: '{{ vpc_id }}'
+    register:  igw_info
+
+  - name: 'Check standard IGW details'
+    assert:
+      that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
+          - '"attachments" in current_igw'
+          - current_igw.attachments | length == 1
+          - '"state" in current_igw.attachments[0]'
+          - current_igw.attachments[0].state == "available"
+          - '"vpc_id" in current_igw.attachments[0]'
+          - current_igw.attachments[0].vpc_id == vpc_id
+          - '"internet_gateway_id" in current_igw'
+          - current_igw.internet_gateway_id == igw_id
+          - '"tags" in current_igw'
+          - current_igw.tags | length == 2
+          - '"key" in current_igw.tags[0]'
+          - '"value" in current_igw.tags[0]'
+          - '"key" in current_igw.tags[1]'
+          - '"value" in current_igw.tags[1]'
+          # Order isn't guaranteed in boto3 style, so just check the keys and
+          # values we expect are in there.
+          - current_igw.tags[0].key in ["tag_one", "Tag Two"]
+          - current_igw.tags[1].key in ["tag_one", "Tag Two"]
+          - current_igw.tags[0].value in [resource_prefix + " One", "two " + resource_prefix]
+          - current_igw.tags[1].value in [resource_prefix + " One", "two " + resource_prefix]
+    vars:
+      current_igw: '{{ igw_info.internet_gateways[0] }}'
+
+  # ============================================================
+  - name: Fetch IGW by ID
+    ec2_vpc_igw_info:
+      internet_gateway_ids: '{{ igw_id }}'
+      convert_tags: yes
+    register:  igw_info
+
+  - name: 'Check standard IGW details'
+    assert:
+      that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
+          - '"attachments" in current_igw'
+          - current_igw.attachments | length == 1
+          - '"state" in current_igw.attachments[0]'
+          - current_igw.attachments[0].state == "available"
+          - '"vpc_id" in current_igw.attachments[0]'
+          - current_igw.attachments[0].vpc_id == vpc_id
+          - '"internet_gateway_id" in current_igw'
+          - current_igw.internet_gateway_id == igw_id
+          - '"tags" in current_igw'
+          - current_igw.tags | length == 2
+          - '"tag_one" in current_igw.tags'
+          - '"Tag Two" in current_igw.tags'
+          - current_igw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - current_igw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    vars:
+      current_igw: '{{ igw_info.internet_gateways[0] }}'
+
+  # ============================================================
+  - name: Fetch IGW by ID (list)
+    ec2_vpc_igw_info:
+      internet_gateway_ids:
+      - '{{ igw_id }}'
+    register:  igw_info
+
+  - name: 'Check standard IGW details'
+    assert:
+      that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
+          - '"attachments" in current_igw'
+          - current_igw.attachments | length == 1
+          - '"state" in current_igw.attachments[0]'
+          - current_igw.attachments[0].state == "available"
+          - '"vpc_id" in current_igw.attachments[0]'
+          - current_igw.attachments[0].vpc_id == vpc_id
+          - '"internet_gateway_id" in current_igw'
+          - current_igw.internet_gateway_id == igw_id
+          - '"tags" in current_igw'
+    vars:
+      current_igw: '{{ igw_info.internet_gateways[0] }}'
+
+  # ============================================================
+  - name: attempt to recreate internet gateway on VPC (expected changed=false) - CHECK_MODE
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_igw_recreate
+    check_mode: yes
+
+  - name: assert recreation would do nothing (expected changed=false) - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_recreate is not changed
+
   - name: attempt to recreate internet gateway on VPC (expected changed=false)
     ec2_vpc_igw:
       state: present
       vpc_id: "{{ vpc_result.vpc.id }}"
-      <<: *aws_connection_info
     register: vpc_igw_recreate
 
   - name: assert recreation did nothing (expected changed=false)
     assert:
       that:
-          - 'vpc_igw_recreate.changed == False'
-          - 'vpc_igw_recreate.gateway_id == vpc_igw_create.gateway_id'
-          - 'vpc_igw_recreate.vpc_id == vpc_igw_create.vpc_id'
+          - vpc_igw_recreate is not changed
+          - vpc_igw_recreate.gateway_id == igw_id
+          - vpc_igw_recreate.vpc_id == vpc_id
+          - '"tags" in vpc_igw_create'
+          - vpc_igw_create.tags | length == 2
+          - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
   # ============================================================
+  - name: Update the tags (no change) - CHECK_MODE
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        tag_one: '{{ resource_prefix }} One'
+        "Tag Two": 'two {{ resource_prefix }}'
+    register: vpc_igw_recreate
+    check_mode: yes
+
+  - name: assert tag update would do nothing (expected changed=false) - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_recreate is not changed
+
+  - name: Update the tags (no change)
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        tag_one: '{{ resource_prefix }} One'
+        "Tag Two": 'two {{ resource_prefix }}'
+    register: vpc_igw_recreate
+
+  - name: assert tag update did nothing (expected changed=false)
+    assert:
+      that:
+          - vpc_igw_recreate is not changed
+          - vpc_igw_recreate.gateway_id == igw_id
+          - vpc_igw_recreate.vpc_id == vpc_id
+          - '"tags" in vpc_igw_recreate'
+          - vpc_igw_recreate.tags | length == 2
+          - vpc_igw_recreate.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_recreate.tags["Tag Two"] == 'two {{ resource_prefix }}'
+
+  # ============================================================
+  - name: Update the tags - remove and add - CHECK_MODE
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        tag_three: '{{ resource_prefix }} Three'
+        "Tag Two": 'two {{ resource_prefix }}'
+    register: vpc_igw_update
+    check_mode: yes
+
+  - name: assert tag update would happen (expected changed=true) - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_update is changed
+
+  - name: Update the tags - remove and add
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        tag_three: '{{ resource_prefix }} Three'
+        "Tag Two": 'two {{ resource_prefix }}'
+    register: vpc_igw_update
+
+  - name: assert tags are updated (expected changed=true)
+    assert:
+      that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 2
+          - vpc_igw_update.tags["tag_three"] == '{{ resource_prefix }} Three'
+          - vpc_igw_update.tags["Tag Two"] == 'two {{ resource_prefix }}'
+
+  # ============================================================
+  - name: Update the tags add without purge - CHECK_MODE
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      purge_tags: no
+      tags:
+        tag_one: '{{ resource_prefix }} One'
+    register: vpc_igw_update
+    check_mode: yes
+
+  - name: assert tags would be added - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_update is changed
+
+  - name: Update the tags add without purge
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      purge_tags: no
+      tags:
+        tag_one: '{{ resource_prefix }} One'
+    register: vpc_igw_update
+
+  - name: assert tags added
+    assert:
+      that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 3
+          - vpc_igw_update.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_update.tags["tag_three"] == '{{ resource_prefix }} Three'
+          - vpc_igw_update.tags["Tag Two"] == 'two {{ resource_prefix }}'
+
+  # ============================================================
+  - name: Remove all tags - CHECK_MODE
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags: {}
+    register: vpc_igw_update
+    check_mode: yes
+
+  - name: assert tags would be removed - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_update is changed
+
+  - name: Remove all tags
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags: {}
+    register: vpc_igw_update
+
+  - name: assert tags removed
+    assert:
+      that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 0
+
+  # ============================================================
+  - name: test state=absent (expected changed=true) - CHECK_MODE
+    ec2_vpc_igw:
+      state: absent
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_igw_delete
+    check_mode: yes
+
+  - name: assert state=absent (expected changed=true) - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_delete is changed
+
   - name: test state=absent (expected changed=true)
     ec2_vpc_igw:
       state: absent
       vpc_id: "{{ vpc_result.vpc.id }}"
-      <<: *aws_connection_info
     register: vpc_igw_delete
 
   - name: assert state=absent (expected changed=true)
     assert:
       that:
-          - 'vpc_igw_delete.changed'
+          - vpc_igw_delete is changed
+
+  # ============================================================
+  - name: Fetch IGW by ID (list)
+    ec2_vpc_igw_info:
+      internet_gateway_ids:
+      - '{{ igw_id }}'
+    register:  igw_info
+    ignore_errors: True
+
+  - name: 'Check IGW does not exist'
+    assert:
+      that:
+        # Deliberate choice not to change bevahiour when searching by ID
+        - igw_info is failed
+
+  # ============================================================
+  - name: test state=absent when already deleted (expected changed=false) - CHECK_MODE
+    ec2_vpc_igw:
+      state: absent
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_igw_delete
+    check_mode: yes
+
+  - name: assert state=absent (expected changed=false) - CHECK_MODE
+    assert:
+      that:
+          - vpc_igw_delete is not changed
+
+  - name: test state=absent when already deleted (expected changed=false)
+    ec2_vpc_igw:
+      state: absent
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_igw_delete
+
+  - name: assert state=absent (expected changed=false)
+    assert:
+      that:
+          - vpc_igw_delete is not changed
 
   always:
     # ============================================================
@@ -76,13 +419,11 @@
       ec2_vpc_igw:
         state: absent
         vpc_id: "{{ vpc_result.vpc.id }}"
-        <<: *aws_connection_info
       ignore_errors: true
 
     - name: tidy up VPC
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc"
+        name: "{{ vpc_name }}"
         state: absent
-        cidr_block: "10.232.232.128/26"
-        <<: *aws_connection_info
+        cidr_block: "{{ vpc_cidr }}"
       ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
This parameter used to exist in the ec2_instance_find.py module that somehow got lost time written by James Laska.  It is currently (before this PR) very difficult and not very Ansible freindly to determine how long an instance has been running, as the only filter provided is launch_time.  It is a common cloud automation use-case to determine which instances have been online longer than a certain time period (e.g. which instances have been running for more than 2 hours?)

From experimentation and much Googling, the best I could come up with was something like this->
```
    - name: math task
      debug:
        msg: "{{ (ansible_date_time.iso8601[:19] | to_datetime('%Y-%m-%dT%H:%M:%S') - aws_time[:19] | to_datetime('%Y-%m-%dT%H:%M:%S')).total_seconds() / 3600 }}"
```

which is not easy to read, requires some Python knowledge and may be outside the skill set of an operations engineer who is writing Ansible Playbooks.  Working with the infamous @spredzy we have come up with a very simple `uptime` parameter based on the previous module, and merged this into the existing functionality of ec2_instance_info so we don't need to add "yet another AWS module" to the infinite queue. We also made sure this works for both python 2 and python 3 environments. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_instance_info
##### ADDITIONAL INFORMATION

Here is an example
```paste below
- name: Gather information about any instance with Name beginning with RHEL and been running at least 60 minutes
  community.aws.ec2_instance_info:
    region: "{{ ec2_region }}"
    uptime: 60
    filters:
      "tag:Name": "RHEL-*"
  register: ec2_node_info
```
