### PR TITLE
Sanity test / doc-default-does-not-match-spec fixups

### DIFF
--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -14,7 +14,7 @@ module: aws_api_gateway
 version_added: 1.0.0
 short_description: Manage AWS API Gateway APIs
 description:
-     - Allows for the management of API Gateway APIs
+     - Allows for the management of API Gateway APIs.
      - Normally you should give the api_id since there is no other
        stable guaranteed unique identifier for the API.  If you do
        not give api_id then a new API will be created each time
@@ -40,7 +40,7 @@ options:
   swagger_file:
     description:
       - JSON or YAML file containing swagger definitions for API.
-        Exactly one of swagger_file, swagger_text or swagger_dict must
+        Exactly one of I(swagger_file), I(swagger_text) or I(swagger_dict) must
         be present.
     type: path
     aliases: ['src', 'api_file']
@@ -60,13 +60,13 @@ options:
     type: str
   deploy_desc:
     description:
-      - Description of the deployment - recorded and visible in the
-        AWS console.
+      - Description of the deployment.
+      - Recorded and visible in the AWS console.
     default: Automatic deployment by Ansible.
     type: str
   cache_enabled:
     description:
-      - Enable API GW caching of backend responses. Defaults to false.
+      - Enable API GW caching of backend responses.
     type: bool
     default: false
   cache_size:
@@ -83,10 +83,10 @@ options:
     description:
       - Canary settings for the deployment of the stage.
       - 'Dict with following settings:'
-      - 'percentTraffic: The percent (0-100) of traffic diverted to a canary deployment.'
-      - 'deploymentId: The ID of the canary deployment.'
-      - 'stageVariableOverrides: Stage variables overridden for a canary release deployment.'
-      - 'useStageCache: A Boolean flag to indicate whether the canary deployment uses the stage cache or not.'
+      - 'C(percentTraffic): The percent (0-100) of traffic diverted to a canary deployment.'
+      - 'C(deploymentId): The ID of the canary deployment.'
+      - 'C(stageVariableOverrides): Stage variables overridden for a canary release deployment.'
+      - 'C(useStageCache): A Boolean flag to indicate whether the canary deployment uses the stage cache or not.'
       - See docs U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html#APIGateway.Client.create_stage)
     type: dict
   tracing_enabled:
@@ -96,8 +96,9 @@ options:
     default: false
   endpoint_type:
     description:
-      - Type of endpoint configuration, use C(EDGE) for an edge optimized API endpoint,
-      - C(REGIONAL) for just a regional deploy or PRIVATE for a private API.
+      - Type of endpoint configuration.
+      - Use C(EDGE) for an edge optimized API endpoint,
+        C(REGIONAL) for just a regional deploy or C(PRIVATE) for a private API.
       - This flag will only be used when creating a new API Gateway setup, not for updates.
     choices: ['EDGE', 'REGIONAL', 'PRIVATE']
     type: str

--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -93,6 +93,7 @@ options:
     description:
       - Specifies whether active tracing with X-ray is enabled for the API GW stage.
     type: bool
+    default: false
   endpoint_type:
     description:
       - Type of endpoint configuration, use C(EDGE) for an edge optimized API endpoint,

--- a/plugins/modules/aws_application_scaling_policy.py
+++ b/plugins/modules/aws_application_scaling_policy.py
@@ -97,9 +97,10 @@ options:
         required: no
         type: int
     override_task_capacity:
-        description: Whether or not to override values of minimum and/or maximum tasks if it's already set.
+        description:
+        - Whether or not to override values of minimum and/or maximum tasks if it's already set.
+        - Defaults to C(false).
         required: no
-        default: no
         type: bool
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/aws_application_scaling_policy.py
+++ b/plugins/modules/aws_application_scaling_policy.py
@@ -15,14 +15,14 @@ notes:
     - for details of the parameters and returns see
       U(http://boto3.readthedocs.io/en/latest/reference/services/application-autoscaling.html#ApplicationAutoScaling.Client.put_scaling_policy)
 description:
-    - Creates, updates or removes a Scaling Policy
+    - Creates, updates or removes a Scaling Policy.
 author:
     - Gustavo Maia (@gurumaia)
     - Chen Leibovich (@chenl87)
 requirements: [ json, botocore, boto3 ]
 options:
     state:
-        description: Whether a policy should be present or absent
+        description: Whether a policy should be C(present) or C(absent).
         required: yes
         choices: ['absent', 'present']
         type: str
@@ -57,12 +57,12 @@ options:
         choices: ['StepScaling', 'TargetTrackingScaling']
         type: str
     step_scaling_policy_configuration:
-        description: A step scaling policy. This parameter is required if you are creating a policy and the policy type is StepScaling.
+        description: A step scaling policy. This parameter is required if you are creating a policy and I(policy_type=StepScaling).
         required: no
         type: dict
     target_tracking_scaling_policy_configuration:
         description:
-            - A target tracking policy. This parameter is required if you are creating a new policy and the policy type is TargetTrackingScaling.
+            - A target tracking policy. This parameter is required if you are creating a new policy and I(policy_type=TargetTrackingScaling).
             - 'Full documentation of the suboptions can be found in the API documentation:'
             - 'U(https://docs.aws.amazon.com/autoscaling/application/APIReference/API_TargetTrackingScalingPolicyConfiguration.html)'
         required: no
@@ -84,7 +84,7 @@ options:
                 description: The time (in seconds) to wait after scaling-out before another scaling action can occur.
                 type: int
             TargetValue:
-                description: The target value for the metric
+                description: The target value for the metric.
                 type: float
     minimum_tasks:
         description: The minimum value to scale to in response to a scale in event.

--- a/plugins/modules/aws_direct_connect_connection.py
+++ b/plugins/modules/aws_direct_connect_connection.py
@@ -64,8 +64,8 @@ options:
     type: str
   forced_update:
     description:
-      - To modify bandwidth or location the connection will need to be deleted and recreated.
-        By default this will not happen - this option must be set to True.
+      - To modify I(bandwidth) or I(location) the connection needs to be deleted and recreated.
+      - By default this will not happen.  This option must be explicitly set to C(true) to change I(bandwith) or I(location).
     type: bool
     default: false
 '''
@@ -94,7 +94,7 @@ EXAMPLES = """
     name: ansible-test-connection
     location: EqDC2
     bandwidth: 10Gbps
-    forced_update: True
+    forced_update: true
 
 # delete the connection
 - community.aws.aws_direct_connect_connection:

--- a/plugins/modules/aws_direct_connect_connection.py
+++ b/plugins/modules/aws_direct_connect_connection.py
@@ -67,6 +67,7 @@ options:
       - To modify bandwidth or location the connection will need to be deleted and recreated.
         By default this will not happen - this option must be set to True.
     type: bool
+    default: false
 '''
 
 EXAMPLES = """

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -59,6 +59,7 @@ options:
       - This allows the minimum number of links to be set to 0, any hosted connections disassociated,
         and any virtual interfaces associated to the LAG deleted.
     type: bool
+    default: false
   connection_id:
     description:
       - A connection ID to link with the link aggregation group upon creation.
@@ -67,12 +68,14 @@ options:
     description:
       - To be used with I(state=absent) to delete connections after disassociating them with the LAG.
     type: bool
+    default: false
   wait:
     description:
       - Whether or not to wait for the operation to complete.
       - May be useful when waiting for virtual interfaces to be deleted.
       - The time to wait can be controlled by setting I(wait_timeout).
     type: bool
+    default: false
   wait_timeout:
     description:
       - The duration in seconds to wait if I(wait=true).

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -66,7 +66,7 @@ options:
     tags:
       description:
         - Should be input as a dict of key-value pairs.
-        - Note that numeric keys or values must be wrapped in quotes. e.g. "Priority:" '1'
+        - "Note that numeric keys or values must be wrapped in quotes. e.g. C(Priority: '1')"
       type: dict
 
     purge_tags:
@@ -87,7 +87,7 @@ options:
 
     aliases:
       description:
-        - A list) of domain name aliases (CNAMEs) as strings to be used for the distribution.
+        - A list of domain name aliases (CNAMEs) as strings to be used for the distribution.
         - Each alias must be unique across all distribution for the AWS account.
       type: list
       elements: str
@@ -141,7 +141,7 @@ options:
           description:
             - Custom headers you wish to add to the request before passing it to the origin.
             - For more information see the CloudFront documentation
-              at U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html)
+              at U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html).
           type: list
           elements: dict
           suboptions:
@@ -191,7 +191,7 @@ options:
       description:
         - A dict specifying the default cache behavior of the distribution.
         - If not specified, the I(target_origin_id) is defined as the I(target_origin_id) of the first valid
-          I(cache_behavior) in I(cache_behaviors) with defaults.
+          cache_behavior in I(cache_behaviors) with defaults.
       suboptions:
         target_origin_id:
           description:
@@ -504,18 +504,18 @@ options:
           type: bool
           description:
             - If you're using the CloudFront domain name for your distribution, such as C(123456789abcde.cloudfront.net)
-              you should set I(cloudfront_default_certificate=true)
+              you should set I(cloudfront_default_certificate=true).
             - If I(cloudfront_default_certificate=true) do not set I(ssl_support_method).
         iam_certificate_id:
           type: str
           description:
             - The ID of a certificate stored in IAM to use for HTTPS connections.
-            - If I(iam_certificate_id) is set then you must also specify I(ssl_support_method)
+            - If I(iam_certificate_id) is set then you must also specify I(ssl_support_method).
         acm_certificate_arn:
           type: str
           description:
             - The ID of a certificate stored in ACM to use for HTTPS connections.
-            - If I(acm_certificate_id) is set then you must also specify I(ssl_support_method)
+            - If I(acm_certificate_id) is set then you must also specify I(ssl_support_method).
         ssl_support_method:
           type: str
           description:
@@ -541,12 +541,12 @@ options:
               type: str
               description:
               - The method that you want to use to restrict distribution of your content by country.
-              - Valid values are C(none), C(whitelist), C(blacklist)
+              - Valid values are C(none), C(whitelist), C(blacklist).
             items:
               description:
               - A list of ISO 3166-1 two letter (Alpha 2) country codes that the
                 restriction should apply to.
-              - 'See the ISO website for a full list of codes U(https://www.iso.org/obp/ui/#search/code/)'
+              - 'See the ISO website for a full list of codes U(https://www.iso.org/obp/ui/#search/code/).'
               type: list
 
     web_acl_id:
@@ -558,7 +558,7 @@ options:
       description:
         - The version of the http protocol to use for the distribution.
         - AWS defaults this to C(http2).
-        - Valid values are C(http1.1) and C(http2)
+        - Valid values are C(http1.1) and C(http2).
       type: str
 
     ipv6_enabled:

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -492,7 +492,7 @@ options:
     enabled:
       description:
         - A boolean value that specifies whether the distribution is enabled or disabled.
-      default: false
+        - Defaults to C(false).
       type: bool
 
     viewer_certificate:
@@ -564,8 +564,8 @@ options:
     ipv6_enabled:
       description:
         - Determines whether IPv6 support is enabled or not.
+        - Defaults to C(false).
       type: bool
-      default: false
 
     wait:
       description:

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -27,7 +27,7 @@ options:
     type: str
   name:
     description:
-      - The name of the new AMI to copy. (As of 2.3 the default is 'default', in prior versions it was 'null'.)
+      - The name of the new AMI to copy. (As of 2.3 the default is C(default), in prior versions it was C(null).)
     default: "default"
     type: str
   description:
@@ -45,14 +45,15 @@ options:
     type: str
   wait:
     description:
-      - Wait for the copied AMI to be in state 'available' before returning.
+      - Wait for the copied AMI to be in state C(available) before returning.
     type: bool
     default: 'no'
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds. Prior to 2.3 the default was 1200.
+      - How long before wait gives up, in seconds.
+      - Prior to 2.3 the default was C(1200).
       - From 2.3-2.5 this option was deprecated in favor of boto3 waiter defaults.
-        This was reenabled in 2.6 to allow timeouts greater than 10 minutes.
+      - This was reenabled in 2.6 to allow timeouts greater than 10 minutes.
     default: 600
     type: int
   tags:

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -38,6 +38,7 @@ options:
     description:
       - Whether or not the destination snapshots of the copied AMI should be encrypted.
     type: bool
+    default: false
   kms_key_id:
     description:
       - KMS key id used to encrypt the image. If not specified, uses default EBS Customer Master Key (CMK) for your account.

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -127,6 +127,7 @@ options:
     description:
       - Whether or not to delete VPN connections routes that are not specified in the task.
     type: bool
+    default: false
   wait_timeout:
     description:
       - How long before wait gives up, in seconds.

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -35,7 +35,7 @@ options:
   connection_type:
     description:
       - The type of VPN connection.
-      - At this time only 'ipsec.1' is supported.
+      - At this time only C(ipsec.1) is supported.
     default: ipsec.1
     type: str
   vpn_gateway_id:
@@ -63,8 +63,8 @@ options:
     required: no
   tunnel_options:
     description:
-      - An optional list object containing no more than two dict members, each of which may contain 'TunnelInsideCidr'
-        and/or 'PreSharedKey' keys with appropriate string values.  AWS defaults will apply in absence of either of
+      - An optional list object containing no more than two dict members, each of which may contain I(TunnelInsideCidr)
+        and/or I(PreSharedKey) keys with appropriate string values.  AWS defaults will apply in absence of either of
         the aforementioned keys.
     required: no
     type: list
@@ -78,11 +78,11 @@ options:
             description: The pre-shared key (PSK) to establish initial authentication between the virtual private gateway and customer gateway.
   filters:
     description:
-      - An alternative to using vpn_connection_id. If multiple matches are found, vpn_connection_id is required.
+      - An alternative to using I(vpn_connection_id). If multiple matches are found, vpn_connection_id is required.
         If one of the following suboptions is a list of items to filter by, only one item needs to match to find the VPN
-        that correlates. e.g. if the filter 'cidr' is ['194.168.2.0/24', '192.168.2.0/24'] and the VPN route only has the
-        destination cidr block of '192.168.2.0/24' it will be found with this filter (assuming there are not multiple
-        VPNs that are matched). Another example, if the filter 'vpn' is equal to ['vpn-ccf7e7ad', 'vpn-cb0ae2a2'] and one
+        that correlates. e.g. if the filter I(cidr) is C(['194.168.2.0/24', '192.168.2.0/24']) and the VPN route only has the
+        destination cidr block of C(192.168.2.0/24) it will be found with this filter (assuming there are not multiple
+        VPNs that are matched). Another example, if the filter I(vpn) is equal to C(['vpn-ccf7e7ad', 'vpn-cb0ae2a2']) and one
         of of the VPNs has the state deleted (exists but is unmodifiable) and the other exists and is not deleted,
         it will be found via this filter. See examples.
     suboptions:
@@ -91,7 +91,7 @@ options:
           - The customer gateway configuration of the VPN as a string (in the format of the return value) or a list of those strings.
       static-routes-only:
         description:
-          - The type of routing; true or false.
+          - The type of routing; C(true) or C(false).
       cidr:
         description:
           - The destination cidr of the VPN's route as a string or a list of those strings.
@@ -130,13 +130,13 @@ options:
     default: false
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds.
+      - How long, in seconds, before wait gives up.
     default: 600
     type: int
     required: false
   delay:
     description:
-      - The time to wait before checking operation again. in seconds.
+      - The time, in seconds, to wait before checking operation again.
     required: false
     type: int
     default: 15

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -63,7 +63,7 @@ options:
         type: json
     purge_lifecycle_policy:
         description:
-            - if yes, remove the lifecycle policy from the repository.
+            - if C(true), remove the lifecycle policy from the repository.
             - Defaults to C(false).
         required: false
         type: bool
@@ -76,7 +76,7 @@ options:
         type: str
     scan_on_push:
         description:
-            - if yes, images are scanned for known vulnerabilities after being pushed to the repository.
+            - if C(true), images are scanned for known vulnerabilities after being pushed to the repository.
             - I(scan_on_push) requires botocore >= 1.13.3
         required: false
         default: false

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -45,8 +45,8 @@ options:
         description:
             - If yes, remove the policy from the repository.
             - Alias C(delete_policy) has been deprecated and will be removed after 2022-06-01.
+            - Defaults to C(false).
         required: false
-        default: false
         type: bool
         aliases: [ delete_policy ]
     image_tag_mutability:
@@ -64,8 +64,8 @@ options:
     purge_lifecycle_policy:
         description:
             - if yes, remove the lifecycle policy from the repository.
+            - Defaults to C(false).
         required: false
-        default: false
         type: bool
     state:
         description:

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -137,12 +137,12 @@ options:
         suboptions:
           subnets:
             description:
-              - A list of subnet IDs to associate with the task
+              - A list of subnet IDs to associate with the task.
             type: list
             elements: str
           security_groups:
             description:
-              - A list of security group names or group IDs to associate with the task
+              - A list of security group names or group IDs to associate with the task.
             type: list
             elements: str
           assign_public_ip:
@@ -171,19 +171,20 @@ options:
         suboptions:
             container_name:
                 description:
-                  - container name for service discovery registration
+                  - Container name for service discovery registration.
                 type: str
             container_port:
                 description:
-                  - container port for service discovery registration
+                  - Container port for service discovery registration.
                 type: int
             arn:
                 description:
-                  - Service discovery registry ARN
+                  - Service discovery registry ARN.
                 type: str
     scheduling_strategy:
         description:
-          - The scheduling strategy, defaults to "REPLICA" if not given to preserve previous behavior
+          - The scheduling strategy.
+          - Defaults to C(REPLICA) if not given to preserve previous behavior.
         required: false
         choices: ["DAEMON", "REPLICA"]
         type: str

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -88,6 +88,7 @@ options:
           - Force deployment of service even if there are no changes.
         required: false
         type: bool
+        default: false
     deployment_configuration:
         description:
           - Optional parameters that control the deployment_configuration.

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -96,7 +96,7 @@ options:
     memory:
         description:
             - The amount (in MiB) of memory used by the task. If using the EC2 launch type, this field is optional and any value can be used.
-            - If using the Fargate launch type, this field is required and is limited by the cpu.
+            - If using the Fargate launch type, this field is required and is limited by the CPU.
         required: false
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -42,6 +42,7 @@ options:
             - Always create new task definition.
         required: False
         type: bool
+        default: false
     containers:
         description:
             - A list of containers definitions.

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -89,8 +89,8 @@ options:
   hard_modify:
     description:
       - Whether to destroy and recreate an existing cache cluster if necessary in order to modify its state.
+      - Defaults to C(false).
     type: bool
-    default: false
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -64,17 +64,17 @@ options:
     type: str
   cache_subnet_group:
     description:
-      - The subnet group name to associate with. Only use if inside a vpc.
-      - Required if inside a vpc
+      - The subnet group name to associate with. Only use if inside a VPC.
+      - Required if inside a VPC.
     type: str
   security_group_ids:
     description:
-      - A list of vpc security group IDs to associate with this cache cluster. Only use if inside a vpc.
+      - A list of VPC security group IDs to associate with this cache cluster. Only use if inside a VPC.
     type: list
     elements: str
   cache_security_groups:
     description:
-      - A list of cache security group names to associate with this cache cluster. Must be an empty list if inside a vpc.
+      - A list of cache security group names to associate with this cache cluster. Must be an empty list if inside a VPC.
     type: list
     elements: str
   zone:

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -50,12 +50,12 @@ options:
   deletion_protection:
     description:
       - Indicates whether deletion protection for the ELB is enabled.
-    default: no
+      - Defaults to C(false).
     type: bool
   http2:
     description:
       - Indicates whether to enable HTTP2 routing.
-    default: no
+      - Defaults to C(false).
     type: bool
   idle_timeout:
     description:

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -22,7 +22,7 @@ DOCUMENTATION = r'''
 ---
 module: elb_application_lb
 version_added: 1.0.0
-short_description: Manage an Application load balancer
+short_description: Manage an Application Load Balancer
 description:
     - Manage an AWS Application Elastic Load Balancer. See U(https://aws.amazon.com/blogs/aws/new-aws-application-load-balancer/) for details.
 requirements: [ boto3 ]
@@ -124,14 +124,14 @@ options:
     type: str
   purge_listeners:
     description:
-      - If yes, existing listeners will be purged from the ELB to match exactly what is defined by I(listeners) parameter. If the I(listeners) parameter is
-        not set then listeners will not be modified
+      - If C(yes), existing listeners will be purged from the ELB to match exactly what is defined by I(listeners) parameter.
+      - If the I(listeners) parameter is not set then listeners will not be modified.
     default: yes
     type: bool
   purge_tags:
     description:
-      - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter. If the I(tags) parameter is not set then
-        tags will not be modified.
+      - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter.
+      - If the I(tags) parameter is not set then tags will not be modified.
     default: yes
     type: bool
   subnets:
@@ -176,7 +176,7 @@ options:
     type: int
   purge_rules:
     description:
-      - When set to no, keep the existing load balancer rules in place. Will modify and add, but will not delete.
+      - When set to C(no), keep the existing load balancer rules in place. Will modify and add, but will not delete.
     default: yes
     type: bool
 extends_documentation_fragment:

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -110,8 +110,8 @@ options:
   cross_az_load_balancing:
     description:
       - Distribute load across all configured Availability Zones
+      - Defaults to C(false).
     type: bool
-    default: 'no'
   stickiness:
     description:
       - An associative array of stickiness policy settings. Policy will be applied to all listeners ( see example )

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -19,62 +19,62 @@ author:
 options:
   state:
     description:
-      - Create or destroy the ELB
+      - Create or destroy the ELB.
     choices: ["present", "absent"]
     required: true
     type: str
   name:
     description:
-      - The name of the ELB
+      - The name of the ELB.
     required: true
     type: str
   listeners:
     description:
-      - List of ports/protocols for this ELB to listen on (see example)
+      - List of ports/protocols for this ELB to listen on (see example).
     type: list
     elements: dict
   purge_listeners:
     description:
-      - Purge existing listeners on ELB that are not found in listeners
+      - Purge existing listeners on ELB that are not found in listeners.
     type: bool
-    default: 'yes'
+    default: true
   instance_ids:
     description:
-      - List of instance ids to attach to this ELB
+      - List of instance ids to attach to this ELB.
     type: list
     elements: str
   purge_instance_ids:
     description:
-      - Purge existing instance ids on ELB that are not found in instance_ids
+      - Purge existing instance ids on ELB that are not found in I(instance_ids).
     type: bool
-    default: 'no'
+    default: false
   zones:
     description:
-      - List of availability zones to enable on this ELB
+      - List of availability zones to enable on this ELB.
     type: list
     elements: str
   purge_zones:
     description:
-      - Purge existing availability zones on ELB that are not found in zones
+      - Purge existing availability zones on ELB that are not found in zones.
     type: bool
-    default: 'no'
+    default: false
   security_group_ids:
     description:
-      - A list of security groups to apply to the elb
+      - A list of security groups to apply to the ELB.
     type: list
     elements: str
   security_group_names:
     description:
-      - A list of security group names to apply to the elb
+      - A list of security group names to apply to the ELB.
     type: list
     elements: str
   health_check:
     description:
-      - An associative array of health check configuration settings (see example)
+      - An associative array of health check configuration settings (see example).
     type: dict
   access_logs:
     description:
-      - An associative array of access logs configuration settings (see example)
+      - An associative array of access logs configuration settings (see example).
     type: dict
   subnets:
     description:
@@ -83,49 +83,50 @@ options:
     elements: str
   purge_subnets:
     description:
-      - Purge existing subnet on ELB that are not found in subnets
+      - Purge existing subnets on ELB that are not found in subnets.
     type: bool
-    default: 'no'
+    default: false
   scheme:
     description:
-      - The scheme to use when creating the ELB. For a private VPC-visible ELB use 'internal'.
-        If you choose to update your scheme with a different value the ELB will be destroyed and
-        recreated. To update scheme you must use the option wait.
+      - The scheme to use when creating the ELB.
+      - For a private VPC-visible ELB use C(internal).
+      - If you choose to update your scheme with a different value the ELB will be destroyed and
+        recreated. To update scheme you must set I(wait=true).
     choices: ["internal", "internet-facing"]
     default: 'internet-facing'
     type: str
   validate_certs:
     description:
-      - When set to C(no), SSL certificates will not be validated for boto versions >= 2.6.0.
+      - When set to C(false), SSL certificates will not be validated for boto versions >= 2.6.0.
     type: bool
-    default: 'yes'
+    default: true
   connection_draining_timeout:
     description:
-      - Wait a specified timeout allowing connections to drain before terminating an instance
+      - Wait a specified timeout allowing connections to drain before terminating an instance.
     type: int
   idle_timeout:
     description:
-      - ELB connections from clients and to servers are timed out after this amount of time
+      - ELB connections from clients and to servers are timed out after this amount of time.
     type: int
   cross_az_load_balancing:
     description:
-      - Distribute load across all configured Availability Zones
+      - Distribute load across all configured Availability Zones.
       - Defaults to C(false).
     type: bool
   stickiness:
     description:
-      - An associative array of stickiness policy settings. Policy will be applied to all listeners ( see example )
+      - An associative array of stickiness policy settings. Policy will be applied to all listeners (see example).
     type: dict
   wait:
     description:
       - When specified, Ansible will check the status of the load balancer to ensure it has been successfully
         removed from AWS.
     type: bool
-    default: 'no'
+    default: false
   wait_timeout:
     description:
-      - Used in conjunction with wait. Number of seconds to wait for the elb to be terminated.
-        A maximum of 600 seconds (10 minutes) is allowed.
+      - Used in conjunction with wait. Number of seconds to wait for the ELB to be terminated.
+        A maximum of C(600) seconds (10 minutes) is allowed.
     default: 60
     type: int
   tags:

--- a/plugins/modules/elb_network_lb.py
+++ b/plugins/modules/elb_network_lb.py
@@ -21,12 +21,12 @@ options:
   cross_zone_load_balancing:
     description:
       - Indicates whether cross-zone load balancing is enabled.
-    default: false
+      - Defaults to C(false).
     type: bool
   deletion_protection:
     description:
       - Indicates whether deletion protection for the ELB is enabled.
-    default: false
+      - Defaults to C(false).
     type: bool
   listeners:
     description:

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -19,6 +19,7 @@ options:
     description:
       - The default behaviour for targets that are unused is to leave them registered. If instead you would like to remove them
         set I(deregister_unused) to yes.
+    default: false
     type: bool
   target_az:
     description:

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -12,28 +12,30 @@ module: elb_target
 version_added: 1.0.0
 short_description: Manage a target in a target group
 description:
-    - Used to register or deregister a target in a target group
+    - Used to register or deregister a target in a target group.
 author: "Rob White (@wimnat)"
 options:
   deregister_unused:
     description:
-      - The default behaviour for targets that are unused is to leave them registered. If instead you would like to remove them
-        set I(deregister_unused) to yes.
+      - The default behaviour for targets that are unused is to leave them registered.
+      - If instead you would like to remove them set I(deregister_unused=true).
     default: false
     type: bool
   target_az:
     description:
-      - An Availability Zone or all. This determines whether the target receives traffic from the load balancer nodes in the specified
+      - An Availability Zone or C(all). This determines whether the target receives traffic from the load balancer nodes in the specified
         Availability Zone or from all enabled Availability Zones for the load balancer. This parameter is not supported if the target
         type of the target group is instance.
     type: str
   target_group_arn:
     description:
-      - The Amazon Resource Name (ARN) of the target group. Mutually exclusive of I(target_group_name).
+      - The Amazon Resource Name (ARN) of the target group.
+      - Mutually exclusive of I(target_group_name).
     type: str
   target_group_name:
     description:
-      - The name of the target group. Mutually exclusive of I(target_group_arn).
+      - The name of the target group.
+      - Mutually exclusive of I(target_group_arn).
     type: str
   target_id:
     description:
@@ -56,7 +58,7 @@ options:
     type: str
   target_status_timeout:
     description:
-      - Maximum time in seconds to wait for target_status change
+      - Maximum time in seconds to wait for I(target_status) change.
     required: false
     default: 60
     type: int

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -33,17 +33,17 @@ options:
     type: str
   new_name:
     description:
-      - When state is present, this will update the name of the cert.
-      - The cert, key and cert_chain parameters will be ignored if this is defined.
+      - When I(state=present), this will update the name of the cert.
+      - The I(cert), I(key) and I(cert_chain) parameters will be ignored if this is defined.
     type: str
   new_path:
     description:
-      - When state is present, this will update the path of the cert.
+      - When I(state=present), this will update the path of the cert.
       - The I(cert), I(key) and I(cert_chain) parameters will be ignored if this is defined.
     type: str
   state:
     description:
-      - Whether to create(or update) or delete the certificate.
+      - Whether to create (or update) or delete the certificate.
       - If I(new_path) or I(new_name) is defined, specifying present will attempt to make an update these.
     required: true
     choices: [ "present", "absent" ]

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -72,7 +72,7 @@ options:
     description:
       - By default the module will not upload a certificate that is already uploaded into AWS.
       - If I(dup_ok=True), it will upload the certificate as long as the name is unique.
-    default: False
+      - Defaults to C(false).
     type: bool
 
 requirements: [ "boto" ]

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -53,8 +53,8 @@ options:
   alias:
     description:
       - Indicates if this is an alias record.
+      - Defaults to C(false).
     type: bool
-    default: false
   alias_hosted_zone_id:
     description:
       - The hosted zone identifier.

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -12,14 +12,14 @@ DOCUMENTATION = r'''
 ---
 module: route53
 version_added: 1.0.0
-short_description: add or delete entries in Amazons Route53 DNS service
+short_description: add or delete entries in Amazons Route 53 DNS service
 description:
-     - Creates and deletes DNS records in Amazons Route53 service
+     - Creates and deletes DNS records in Amazons Route 53 service.
 options:
   state:
     description:
       - Specifies the state of the resource record. As of Ansible 2.4, the I(command) option has been changed
-        to I(state) as default and the choices 'present' and 'absent' have been added, but I(command) still works as well.
+        to I(state) as default and the choices C(present) and C(absent) have been added, but I(command) still works as well.
     required: true
     aliases: [ 'command' ]
     choices: [ 'present', 'absent', 'get', 'create', 'delete' ]
@@ -67,7 +67,7 @@ options:
   value:
     description:
       - The new value when creating a DNS record.  YAML lists or multiple comma-spaced values are allowed for non-alias records.
-      - When deleting a record all values for the record must be specified or Route53 will not delete it.
+      - When deleting a record all values for the record must be specified or Route 53 will not delete it.
     type: list
     elements: str
   overwrite:
@@ -76,14 +76,14 @@ options:
     type: bool
   retry_interval:
     description:
-      - In the case that route53 is still servicing a prior request, this module will wait and try again after this many seconds.
-        If you have many domain names, the default of 500 seconds may be too long.
+      - In the case that Route 53 is still servicing a prior request, this module will wait and try again after this many seconds.
+        If you have many domain names, the default of C(500) seconds may be too long.
     default: 500
     type: int
   private_zone:
     description:
-      - If set to C(yes), the private zone matching the requested name within the domain will be used if there are both public and private zones.
-        The default is to use the public zone.
+      - If set to C(true), the private zone matching the requested name within the domain will be used if there are both public and private zones.
+      - The default is to use the public zone.
     type: bool
     default: false
   identifier:

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: sqs_queue
 version_added: 1.0.0
-short_description: Creates or deletes AWS SQS queues.
+short_description: Creates or deletes AWS SQS queues
 description:
   - Create or delete AWS SQS queues.
   - Update attributes on existing queues.

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -83,8 +83,9 @@ options:
     type: int
   content_based_deduplication:
     type: bool
-    description: Enables content-based deduplication. Used for FIFOs only.
-    default: false
+    description:
+      - Enables content-based deduplication. Used for FIFOs only.
+      - Defaults to C(false).
   tags:
     description:
       - Tag dict to apply to the queue (requires botocore 1.5.40 or above).


### PR DESCRIPTION
##### SUMMARY

Daily run picked up the following:

```
plugins/modules/aws_api_gateway.py:0:0: doc-default-does-not-match-spec: Argument 'tracing_enabled' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/aws_application_scaling_policy.py:0:0: doc-default-does-not-match-spec: Argument 'override_task_capacity' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/aws_direct_connect_connection.py:0:0: doc-default-does-not-match-spec: Argument 'forced_update' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/aws_direct_connect_link_aggregation_group.py:0:0: doc-default-does-not-match-spec: Argument 'delete_with_disassociation' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/aws_direct_connect_link_aggregation_group.py:0:0: doc-default-does-not-match-spec: Argument 'force_delete' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/aws_direct_connect_link_aggregation_group.py:0:0: doc-default-does-not-match-spec: Argument 'wait' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/cloudfront_distribution.py:0:0: doc-default-does-not-match-spec: Argument 'enabled' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/cloudfront_distribution.py:0:0: doc-default-does-not-match-spec: Argument 'ipv6_enabled' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/ec2_ami_copy.py:0:0: doc-default-does-not-match-spec: Argument 'encrypted' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/ec2_vpc_vpn.py:0:0: doc-default-does-not-match-spec: Argument 'purge_routes' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/ecs_ecr.py:0:0: doc-default-does-not-match-spec: Argument 'purge_lifecycle_policy' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/ecs_ecr.py:0:0: doc-default-does-not-match-spec: Argument 'purge_policy' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/ecs_service.py:0:0: doc-default-does-not-match-spec: Argument 'force_new_deployment' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/ecs_taskdefinition.py:0:0: doc-default-does-not-match-spec: Argument 'force_create' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/elasticache.py:0:0: doc-default-does-not-match-spec: Argument 'hard_modify' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/elb_application_lb.py:0:0: doc-default-does-not-match-spec: Argument 'deletion_protection' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/elb_application_lb.py:0:0: doc-default-does-not-match-spec: Argument 'http2' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/elb_classic_lb.py:0:0: doc-default-does-not-match-spec: Argument 'cross_az_load_balancing' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/elb_network_lb.py:0:0: doc-default-does-not-match-spec: Argument 'cross_zone_load_balancing' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/elb_network_lb.py:0:0: doc-default-does-not-match-spec: Argument 'deletion_protection' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/elb_target.py:0:0: doc-default-does-not-match-spec: Argument 'deregister_unused' in argument_spec defines default as (False) but documentation defines default as (None)
plugins/modules/iam_cert.py:0:0: doc-default-does-not-match-spec: Argument 'dup_ok' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/route53.py:0:0: doc-default-does-not-match-spec: Argument 'alias' in argument_spec defines default as (None) but documentation defines default as (False)
plugins/modules/sqs_queue.py:0:0: doc-default-does-not-match-spec: Argument 'content_based_deduplication' in argument_spec defines default as (None) but documentation defines default as (False)
```

Some additional doc-style fixups.

Fallout from ansible/ansible#72699

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/aws_api_gateway.py
plugins/modules/aws_application_scaling_policy.py
plugins/modules/aws_direct_connect_connection.py
plugins/modules/aws_direct_connect_link_aggregation_group.py
plugins/modules/cloudfront_distribution.py
plugins/modules/ec2_ami_copy.py
plugins/modules/ec2_vpc_vpn.py
plugins/modules/ecs_ecr.py
plugins/modules/ecs_service.py
plugins/modules/ecs_taskdefinition.py
plugins/modules/elasticache.py
plugins/modules/elb_application_lb.py
plugins/modules/elb_classic_lb.py
plugins/modules/elb_network_lb.py
plugins/modules/elb_target.py
plugins/modules/iam_cert.py
plugins/modules/route53.py
plugins/modules/sqs_queue.py

##### ADDITIONAL INFORMATION
