### PR TITLE
add metadata options to ec2 template

### DIFF
--- a/changelogs/fragments/322-ec2_launch_template-add-metadata_options.yml
+++ b/changelogs/fragments/322-ec2_launch_template-add-metadata_options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_launch_template - added ``metadata_options`` parameter to support changing the IMDS configuration for instances (https://github.com/ansible-collections/community.aws/pull/322).

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -325,6 +325,32 @@ options:
       U(http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-instance-metadata.html#instancedata-add-user-data)
       documentation on user-data.
     type: str
+  metadata_options:
+    description:
+    - Configure EC2 Metadata options.
+    - For more information see the IMDS documentation
+      U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
+    type: dict
+    version_added: 1.5.0
+    suboptions:
+      http_endpoint:
+        type: str
+        description: >
+          This parameter enables or disables the HTTP metadata endpoint on your instances.
+        choices: [enabled, disabled]
+        default: 'enabled'
+      http_put_response_hop_limit:
+        type: int
+        description: >
+          The desired HTTP PUT response hop limit for instance metadata requests.
+          The larger the number, the further instance metadata requests can travel.
+        default: 1
+      http_tokens:
+        type: str
+        description: >
+          The state of token usage for your instance metadata requests.
+        choices: [optional, required]
+        default: 'optional'
 '''
 
 EXAMPLES = '''
@@ -635,6 +661,14 @@ def main():
             options=dict(
                 enabled=dict(type='bool')
             ),
+        ),
+        metadata_options=dict(
+            type='dict',
+            options=dict(
+                http_endpoint=dict(choices=['enabled', 'disabled'], default='enabled'),
+                http_put_response_hop_limit=dict(type='int', default=1),
+                http_tokens=dict(choices=['optional', 'required'], default='optional')
+            )
         ),
         network_interfaces=dict(
             type='list',

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -1,0 +1,24 @@
+- block:
+  - name: metadata_options
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-test-metadata"
+      metadata_options:
+        http_put_response_hop_limit: 1
+        http_tokens: required
+      state: present
+    register: metadata_options_launch_template
+  - name: instance with metadata_options created with the right options
+    assert:
+      that:
+        - metadata_options_launch_template is changed
+        - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
+        - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
+  always:
+  - name: delete the template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-test-metadata"
+      state: absent
+    register: del_lt
+    retries: 10
+    until: del_lt is not failed
+    ignore_errors: true

--- a/tests/integration/targets/ec2_launch_template/tasks/main.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/main.yml
@@ -44,6 +44,7 @@
     - include_tasks: cpu_options.yml
     - include_tasks: iam_instance_role.yml
     - include_tasks: versions.yml
+    - include_tasks: instance-metadata.yml
 
   always:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Looking to add the ability to manage launch templates metadata options


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_launch_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
   - name: Configure launch template
      ec2_launch_template:
       ...
        metadata_options:
          http_tokens: required
          http_put_response_hop_limit: 1
```
