### PR TITLE
Add jittered_backoff to the iam_policy & iam_policy_info modules to handle AWS rate limiting

### DIFF
--- a/changelogs/fragments/324-add-jittered-backoff-to-iam_policy-modules.yaml
+++ b/changelogs/fragments/324-add-jittered-backoff-to-iam_policy-modules.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - iam_policy - Added jittered_backoff to handle AWS rate limiting (https://github.com/ansible-collections/community.aws/pull/324).
+  - iam_policy_info - Added jittered_backoff to handle AWS rate limiting (https://github.com/ansible-collections/community.aws/pull/324).

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -140,7 +140,6 @@ class Policy:
         self.state = state
         self.check_mode = check_mode
         self.changed = False
-        self.backoff_params = dict(retries=10, delay=3, backoff=1.5)
 
     @staticmethod
     def _iam_type():
@@ -236,19 +235,19 @@ class UserPolicy(Policy):
     def _iam_type():
         return 'user'
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _list(self, name):
         return self.client.list_user_policies(UserName=name)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _get(self, name, policy_name):
         return self.client.get_user_policy(UserName=name, PolicyName=policy_name)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _put(self, name, policy_name, policy_doc):
         return self.client.put_user_policy(UserName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _delete(self, name, policy_name):
         return self.client.delete_user_policy(UserName=name, PolicyName=policy_name)
 
@@ -259,19 +258,19 @@ class RolePolicy(Policy):
     def _iam_type():
         return 'role'
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _list(self, name):
         return self.client.list_role_policies(RoleName=name)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _get(self, name, policy_name):
         return self.client.get_role_policy(RoleName=name, PolicyName=policy_name)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _put(self, name, policy_name, policy_doc):
         return self.client.put_role_policy(RoleName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _delete(self, name, policy_name):
         return self.client.delete_role_policy(RoleName=name, PolicyName=policy_name)
 
@@ -282,19 +281,19 @@ class GroupPolicy(Policy):
     def _iam_type():
         return 'group'
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _list(self, name):
         return self.client.list_group_policies(GroupName=name)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _get(self, name, policy_name):
         return self.client.get_group_policy(GroupName=name, PolicyName=policy_name)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _put(self, name, policy_name, policy_doc):
         return self.client.put_group_policy(GroupName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
-    @AWSRetry.exponential_backoff(**self.backoff_params)
+    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _delete(self, name, policy_name):
         return self.client.delete_group_policy(GroupName=name, PolicyName=policy_name)
 

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -120,7 +120,7 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies, AWSRetry
 from ansible.module_utils.six import string_types
 
 
@@ -140,6 +140,7 @@ class Policy:
         self.state = state
         self.check_mode = check_mode
         self.changed = False
+        self.backoff_params = dict(retries=10, delay=3, backoff=1.5)
 
     @staticmethod
     def _iam_type():
@@ -235,15 +236,19 @@ class UserPolicy(Policy):
     def _iam_type():
         return 'user'
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _list(self, name):
         return self.client.list_user_policies(UserName=name)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _get(self, name, policy_name):
         return self.client.get_user_policy(UserName=name, PolicyName=policy_name)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _put(self, name, policy_name, policy_doc):
         return self.client.put_user_policy(UserName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _delete(self, name, policy_name):
         return self.client.delete_user_policy(UserName=name, PolicyName=policy_name)
 
@@ -254,15 +259,19 @@ class RolePolicy(Policy):
     def _iam_type():
         return 'role'
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _list(self, name):
         return self.client.list_role_policies(RoleName=name)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _get(self, name, policy_name):
         return self.client.get_role_policy(RoleName=name, PolicyName=policy_name)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _put(self, name, policy_name, policy_doc):
         return self.client.put_role_policy(RoleName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _delete(self, name, policy_name):
         return self.client.delete_role_policy(RoleName=name, PolicyName=policy_name)
 
@@ -273,15 +282,19 @@ class GroupPolicy(Policy):
     def _iam_type():
         return 'group'
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _list(self, name):
         return self.client.list_group_policies(GroupName=name)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _get(self, name, policy_name):
         return self.client.get_group_policy(GroupName=name, PolicyName=policy_name)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _put(self, name, policy_name, policy_doc):
         return self.client.put_group_policy(GroupName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
+    @AWSRetry.exponential_backoff(**self.backoff_params)
     def _delete(self, name, policy_name):
         return self.client.delete_group_policy(GroupName=name, PolicyName=policy_name)
 

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -235,21 +235,17 @@ class UserPolicy(Policy):
     def _iam_type():
         return 'user'
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _list(self, name):
-        return self.client.list_user_policies(UserName=name)
+        return self.client.list_user_policies(aws_retry=True, UserName=name)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _get(self, name, policy_name):
-        return self.client.get_user_policy(UserName=name, PolicyName=policy_name)
+        return self.client.get_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _put(self, name, policy_name, policy_doc):
-        return self.client.put_user_policy(UserName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
+        return self.client.put_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _delete(self, name, policy_name):
-        return self.client.delete_user_policy(UserName=name, PolicyName=policy_name)
+        return self.client.delete_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name)
 
 
 class RolePolicy(Policy):
@@ -258,21 +254,17 @@ class RolePolicy(Policy):
     def _iam_type():
         return 'role'
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _list(self, name):
-        return self.client.list_role_policies(RoleName=name)
+        return self.client.list_role_policies(aws_retry=True, RoleName=name)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _get(self, name, policy_name):
-        return self.client.get_role_policy(RoleName=name, PolicyName=policy_name)
+        return self.client.get_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _put(self, name, policy_name, policy_doc):
-        return self.client.put_role_policy(RoleName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
+        return self.client.put_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _delete(self, name, policy_name):
-        return self.client.delete_role_policy(RoleName=name, PolicyName=policy_name)
+        return self.client.delete_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name)
 
 
 class GroupPolicy(Policy):
@@ -281,21 +273,17 @@ class GroupPolicy(Policy):
     def _iam_type():
         return 'group'
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _list(self, name):
-        return self.client.list_group_policies(GroupName=name)
+        return self.client.list_group_policies(aws_retry=True, GroupName=name)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _get(self, name, policy_name):
-        return self.client.get_group_policy(GroupName=name, PolicyName=policy_name)
+        return self.client.get_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _put(self, name, policy_name, policy_doc):
-        return self.client.put_group_policy(GroupName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
+        return self.client.put_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name, PolicyDocument=policy_doc)
 
-    @AWSRetry.exponential_backoff(retries=10, delay=3, backoff=1.5)
     def _delete(self, name, policy_name):
-        return self.client.delete_group_policy(GroupName=name, PolicyName=policy_name)
+        return self.client.delete_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name)
 
 
 def main():
@@ -326,7 +314,7 @@ def main():
                          date='2022-06-01', collection_name='community.aws')
 
     args = dict(
-        client=module.client('iam'),
+        client=module.client('iam', retry_decorator=AWSRetry.jittered_backoff()),
         name=module.params.get('iam_name'),
         policy_name=module.params.get('policy_name'),
         policy_document=module.params.get('policy_document'),

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -85,6 +85,7 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible.module_utils.six import string_types
 
 
@@ -147,10 +148,10 @@ class UserPolicy(Policy):
         return 'user'
 
     def _list(self, name):
-        return self.client.list_user_policies(UserName=name)
+        return self.client.list_user_policies(aws_retry=True, UserName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_user_policy(UserName=name, PolicyName=policy_name)
+        return self.client.get_user_policy(aws_retry=True, UserName=name, PolicyName=policy_name)
 
 
 class RolePolicy(Policy):
@@ -160,10 +161,10 @@ class RolePolicy(Policy):
         return 'role'
 
     def _list(self, name):
-        return self.client.list_role_policies(RoleName=name)
+        return self.client.list_role_policies(aws_retry=True, RoleName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_role_policy(RoleName=name, PolicyName=policy_name)
+        return self.client.get_role_policy(aws_retry=True, RoleName=name, PolicyName=policy_name)
 
 
 class GroupPolicy(Policy):
@@ -173,10 +174,10 @@ class GroupPolicy(Policy):
         return 'group'
 
     def _list(self, name):
-        return self.client.list_group_policies(GroupName=name)
+        return self.client.list_group_policies(aws_retry=True, GroupName=name)
 
     def _get(self, name, policy_name):
-        return self.client.get_group_policy(GroupName=name, PolicyName=policy_name)
+        return self.client.get_group_policy(aws_retry=True, GroupName=name, PolicyName=policy_name)
 
 
 def main():
@@ -189,7 +190,7 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     args = dict(
-        client=module.client('iam'),
+        client=module.client('iam', retry_decorator=AWSRetry.jittered_backoff()),
         name=module.params.get('iam_name'),
         policy_name=module.params.get('policy_name'),
     )


### PR DESCRIPTION
##### SUMMARY
Add jittered_backoff to the `iam_policy` & `iam_policy_info` modules to handle AWS rate limiting to help avoid fatal errors in which no objects get retrieved or updated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`iam_policy`, `iam_policy_info`

##### ADDITIONAL INFORMATION
Most other modules include some form of the AWS backoff / exponential_backoff logic to handle rate limiting however this particular module isn't currently.
