### PR TITLE
Fix eip association when both instance id and private ip address are passed

### DIFF
--- a/changelogs/fragments/328-fix-ec2_eip-instance-id-private-ip-address.yml
+++ b/changelogs/fragments/328-fix-ec2_eip-instance-id-private-ip-address.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ec2_eip - fix eip association by instance id & private ip address due to case-sensitivity of the ``PrivateIpAddress`` parameter (https://github.com/ansible-collections/community.aws/pull/328)
+  - ec2_eip - fix eip association by instance id & private ip address due to case-sensitivity of the ``PrivateIpAddress`` parameter (https://github.com/ansible-collections/community.aws/pull/328).

--- a/changelogs/fragments/328-fix-ec2_eip-instance-id-private-ip-address.yml
+++ b/changelogs/fragments/328-fix-ec2_eip-instance-id-private-ip-address.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_eip - fix eip association by instance id & private ip address due to case-sensitivity of the ``PrivateIpAddress`` parameter (https://github.com/ansible-collections/community.aws/pull/328)

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -241,7 +241,7 @@ def associate_ip_and_device(ec2, module, address, private_ip_address, device_id,
                     AllowReassociation=allow_reassociation,
                 )
                 if private_ip_address:
-                    params['PrivateIPAddress'] = private_ip_address
+                    params['PrivateIpAddress'] = private_ip_address
                 if address['Domain'] == 'vpc':
                     params['AllocationId'] = address['AllocationId']
                 else:

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -569,6 +569,22 @@
         - instance_eip is success
         - eip_info.addresses[0].allocation_id is defined
         - eip_info.addresses[0].instance_id == '{{ instance_info.instances[0].instance_id }}'
+  - name: Attach eip to an EC2 instance with private Ip specified
+    ec2_eip:
+      device_id: '{{ instance_info.instances[0].instance_id }}'
+      private_ip_address: '{{ instance_info.instances[0].private_ip_address }}'
+      state: present
+      release_on_disassociation: yes
+    register: instance_eip
+  - ec2_eip_info:
+      filters:
+        public-ip: '{{ instance_eip.public_ip }}'
+    register: eip_info
+  - assert:
+      that:
+        - instance_eip is success
+        - eip_info.addresses[0].allocation_id is defined
+        - eip_info.addresses[0].instance_id == '{{ instance_info.instances[0].instance_id }}'
   # =====================================================
   - name: Cleanup IGW
     ec2_vpc_igw:


### PR DESCRIPTION
I assume there has recently been a change to the AWS API introducing case sensitivity to the `PrivateIpAddress` parameter of `AssociateAddress`. The `ec2_eip` module uses this parameter in two branches (instance id vs interface id) and only in the instance branch it uses `PrivateIPAddress` (note how it's `P` and not `p`).


This PR also adds a variant of an existing test case to cover the branch that triggered this failure.

## Example

```yaml
- name: Associate an Elastic IP with instance
  ec2_eip:
    device_id: "{{ ec2.instance_ids[0] }}"
    private_ip_address: "{{ ec2.private_ip_address }}"
    state: present
```

This has worked for me for a long time. But when running it today I got this error:
```
The full traceback is:                                                                                                
Traceback (most recent call last):                    
  File "/tmp/ansible_ec2_eip_payload_drz_g_cz/ansible_ec2_eip_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_eip.py", line 249, in associate_ip_and_device
  File "/tmp/ansible_ec2_eip_payload_drz_g_cz/ansible_ec2_eip_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/core.py", line 289, in deciding_wrapper
    return unwrapped(*args, **kwargs)                                                                                 
  File "/usr/lib/python3.9/site-packages/botocore/client.py", line 357, in _api_call                                   
    return self._make_api_call(operation_name, kwargs)                                                                
  File "/usr/lib/python3.9/site-packages/botocore/client.py", line 648, in _make_api_call
    request_dict = self._convert_to_request_dict(                                                                     
  File "/usr/lib/python3.9/site-packages/botocore/client.py", line 696, in _convert_to_request_dict                   
    request_dict = self._serializer.serialize_to_request(
  File "/usr/lib/python3.9/site-packages/botocore/validate.py", line 297, in serialize_to_request                      
    raise ParamValidationError(report=report.generate_report())                                                        
botocore.exceptions.ParamValidationError: Parameter validation failed:                                                 
Unknown parameter in input: "PrivateIPAddress", must be one of: AllocationId, InstanceId, PublicIp, AllowReassociation, DryRun, NetworkInterfaceId, PrivateIpAddress
```