### PR TITLE
Fixup ec2_eip tests - work around ec2_instance flakes

### DIFF
--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -571,11 +571,6 @@
         - eip_info.addresses[0].allocation_id is defined
         - eip_info.addresses[0].instance_id == '{{ instance_info.instances[0].instance_id }}'
   # =====================================================
-  - name: Cleanup IGW
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw
   - name: Cleanup instance
     ec2_instance:
       name: '{{ resource_prefix }}-instance'
@@ -584,6 +579,11 @@
     ec2_eip:
       state: absent
       public_ip: '{{ instance_eip.public_ip }}'
+  - name: Cleanup IGW
+    ec2_vpc_igw:
+      state: absent
+      vpc_id: '{{ vpc_result.vpc.id }}'
+    register: vpc_igw
   - name: Cleanup security group
     ec2_group:
       state: absent

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -65,7 +65,8 @@
       security_group: '{{ security_group.group_id }}'
       vpc_subnet_id: '{{ vpc_subnet_create.subnet.id }}'
       wait: no  ## Don't delay the tests, we'll check again before we need it
-    register: ec2_instance_result
+    register: create_ec2_instance_result
+
   # =====================================================
   - name: Look for signs of concurrent EIP tests.  Pause if they are running or their prefix comes before ours.
     vars:
@@ -573,12 +574,16 @@
   # =====================================================
   - name: Cleanup instance
     ec2_instance:
-      name: '{{ resource_prefix }}-instance'
+      instance_ids: '{{ create_ec2_instance_result.instance_ids }}'
       state: absent
   - name: Cleanup instance eip
     ec2_eip:
       state: absent
       public_ip: '{{ instance_eip.public_ip }}'
+    register: eip_cleanup
+    retries: 5
+    delay: 5
+    until: eip_cleanup is successful
   - name: Cleanup IGW
     ec2_vpc_igw:
       state: absent
@@ -643,6 +648,18 @@
       cidr_block: '{{ vpc_cidr }}'
   # =====================================================
   always:
+  - name: Cleanup instance (by id)
+    ec2_instance:
+      instance_ids: '{{ create_ec2_instance_result.instance_ids }}'
+      state: absent
+      wait: true
+    ignore_errors: true
+  - name: Cleanup instance (by name)
+    ec2_instance:
+      name: '{{ resource_prefix }}-instance'
+      state: absent
+      wait: true
+    ignore_errors: true
   - name: Cleanup ENI A
     ec2_eni:
       state: absent
@@ -653,20 +670,19 @@
       state: absent
       eni_id: '{{ eni_create_b.interface.id }}'
     ignore_errors: true
+  - name: Cleanup instance eip
+    ec2_eip:
+      state: absent
+      public_ip: '{{ instance_eip.public_ip }}'
+    retries: 5
+    delay: 5
+    until: eip_cleanup is successful
+    ignore_errors: true
   - name: Cleanup IGW
     ec2_vpc_igw:
       state: absent
       vpc_id: '{{ vpc_result.vpc.id }}'
     register: vpc_igw
-  - name: Cleanup instance
-    ec2_instance:
-      name: '{{ resource_prefix }}-instance'
-      state: absent
-    ignore_errors: true
-  - name: Cleanup instance eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ instance_eip.public_ip }}'
     ignore_errors: true
   - name: Cleanup security group
     ec2_group:

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -63,6 +63,7 @@
       name: '{{ resource_prefix }}-instance'
       image_id: '{{ ec2_amis.images[0].image_id }}'
       security_group: '{{ security_group.group_id }}'
+      vpc_subnet_id: '{{ vpc_subnet_create.subnet.id }}'
       wait: no  ## Don't delay the tests, we'll check again before we need it
     register: ec2_instance_result
   # =====================================================


### PR DESCRIPTION
##### SUMMARY

We're seeing some ec2_instance flakes which *appear* to be caused by filter based searches not consistently returning.  Work around these for now to unblock #328 

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

ec2_eip

##### ADDITIONAL INFORMATION
