### PR TITLE
Added 3 new Info Modules for SNS

### DIFF
--- a/plugins/modules/sns_platform_endpoint_info.py
+++ b/plugins/modules/sns_platform_endpoint_info.py
@@ -30,7 +30,7 @@ options:
 author:
   - "Davinder Pal <dpsangwal@gmail.com>"
 extends_documentation_fragment:
-  - amazon.aws.sns
+  - amazon.aws.ec2
   - amazon.aws.aws
 requirements:
   - boto3
@@ -66,14 +66,12 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
-# uncomment below for ansible 2.8 or lower
-# from ansible.module_utils.aws.core import AnsibleAWSModule
-
 def main():
 
+
     argument_spec = dict(
-      endpoint_arn=dict(required=True, aliases=['arn']),
-      enabled=dict(required=False,choices=['true', 'false']),
+        endpoint_arn=dict(required=True, aliases=['arn']),
+        enabled=dict(required=False, choices=['true', 'false']),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
@@ -82,22 +80,23 @@ def main():
     __default_return = []
 
     try:
-      paginator = sns.get_paginator('list_endpoints_by_platform_application')
-      iterator = paginator.paginate(PlatformApplicationArn=module.params['arn'])
-      for response in iterator:
-        __default_return += response['Endpoints']
+        paginator = sns.get_paginator('list_endpoints_by_platform_application')
+        iterator = paginator.paginate(PlatformApplicationArn=module.params['arn'])
+        for response in iterator:
+          __default_return += response['Endpoints']
     except (BotoCoreError, ClientError) as e:
-        module.fail_json_aws(e, msg='Failed to fetch sns platform endpoints')
+          module.fail_json_aws(e, msg='Failed to fetch sns platform endpoints')
 
     if module.params['enabled'] is not None:
-      __override_default_return = []
-      for endpoint in __default_return:
-        if endpoint['Attributes']['Enabled'] == module.params['enabled']:
-          __override_default_return.append(endpoint)
+        __override_default_return = []
+        for endpoint in __default_return:
+            if endpoint['Attributes']['Enabled'] == module.params['enabled']:
+                __override_default_return.append(endpoint)
 
-      module.exit_json(endpoints=__override_default_return)      
+        module.exit_json(endpoints=__override_default_return)
 
     module.exit_json(endpoints=__default_return)
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/sns_platform_endpoint_info.py
+++ b/plugins/modules/sns_platform_endpoint_info.py
@@ -27,7 +27,8 @@ options:
     required: false
     type: str
     choices: ['true', 'false']
-author: "Davinder Pal <dpsangwal@gmail.com>"
+author:
+  - "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws

--- a/plugins/modules/sns_platform_endpoint_info.py
+++ b/plugins/modules/sns_platform_endpoint_info.py
@@ -27,8 +27,7 @@ options:
     required: false
     type: str
     choices: ['true', 'false']
-author:
-  - "Davinder Pal <dpsangwal@gmail.com>"
+author: "Davinder Pal <dpsangwal@gmail.com>"
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws
@@ -82,7 +81,7 @@ def main():
         paginator = sns.get_paginator('list_endpoints_by_platform_application')
         iterator = paginator.paginate(PlatformApplicationArn=module.params['arn'])
         for response in iterator:
-          __default_return += response['Endpoints']
+            __default_return += response['Endpoints']
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Failed to fetch sns platform endpoints')
 

--- a/plugins/modules/sns_platform_endpoint_info.py
+++ b/plugins/modules/sns_platform_endpoint_info.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Davinder Pal <dpsangwal@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+module: community.aws.sns_platform_endpoint_info
+short_description: Get Infomation about AWS SNS Platforms.
+description:
+  - Get Information about AWS SNS Platform Endpoint.
+version_added: 1.4.0
+options:
+  endpoint_arn:
+    description:
+      - arn of sns platform application.
+    required: true
+    aliases: [ "arn" ]
+    type: str
+  enabled:
+    description:
+      - filter to look for enabled or disabled endpoints.
+    required: false
+    type: str
+    choices: ['true', 'false']
+author:
+  - "Davinder Pal <dpsangwal@gmail.com>"
+extends_documentation_fragment:
+  - amazon.aws.sns
+  - amazon.aws.aws
+requirements:
+  - boto3
+  - botocore
+"""
+
+EXAMPLES = """
+- name: Get list of Endpoints SNS platform Endpoints.
+  community.aws.sns_platform_endpoint_info:
+    arn: arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app
+
+- name: Get list of Endpoints SNS platform Endpoints but enabled only.
+  community.aws.sns_platform_endpoint_info:
+    arn: arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app
+    enabled: 'true'
+"""
+
+RETURN = """
+endpoints:
+  description: List of SNS Platform Endpoints.
+  returned: when success
+  type: list
+  sample: [{
+    "Attributes": {"Enabled": "true", "Token": "coaO_xxx6z-DK-"},
+    "EndpointArn": "arn:aws:sns:us-east-1:xxxxx:endpoint/GCM/xxxxx-platform-app/xxxxx-971fa6329ac4"
+  }]
+"""
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass    # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+
+# uncomment below for ansible 2.8 or lower
+# from ansible.module_utils.aws.core import AnsibleAWSModule
+
+def main():
+
+    argument_spec = dict(
+      endpoint_arn=dict(required=True, aliases=['arn']),
+      enabled=dict(required=False,choices=['true', 'false']),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec)
+    sns = module.client('sns')
+
+    __default_return = []
+
+    try:
+      paginator = sns.get_paginator('list_endpoints_by_platform_application')
+      iterator = paginator.paginate(PlatformApplicationArn=module.params['arn'])
+      for response in iterator:
+        __default_return += response['Endpoints']
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Failed to fetch sns platform endpoints')
+
+    if module.params['enabled'] is not None:
+      __override_default_return = []
+      for endpoint in __default_return:
+        if endpoint['Attributes']['Enabled'] == module.params['enabled']:
+          __override_default_return.append(endpoint)
+
+      module.exit_json(endpoints=__override_default_return)      
+
+    module.exit_json(endpoints=__default_return)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/sns_platform_endpoint_info.py
+++ b/plugins/modules/sns_platform_endpoint_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
-module: community.aws.sns_platform_endpoint_info
+module: sns_platform_endpoint_info
 short_description: Get Infomation about AWS SNS Platforms.
 description:
   - Get Information about AWS SNS Platform Endpoint.
@@ -54,7 +54,7 @@ endpoints:
   returned: when success
   type: list
   sample: [{
-    "Attributes": {"Enabled": "true", "Token": "coaO_xxx6z-DK-"},
+    "Attributes": {"Enabled": "true", "Token": "coaO_xxxxxxxxxxx"},
     "EndpointArn": "arn:aws:sns:us-east-1:xxxxx:endpoint/GCM/xxxxx-platform-app/xxxxx-971fa6329ac4"
   }]
 """
@@ -66,9 +66,8 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
+
 def main():
-
-
     argument_spec = dict(
         endpoint_arn=dict(required=True, aliases=['arn']),
         enabled=dict(required=False, choices=['true', 'false']),
@@ -85,7 +84,7 @@ def main():
         for response in iterator:
           __default_return += response['Endpoints']
     except (BotoCoreError, ClientError) as e:
-          module.fail_json_aws(e, msg='Failed to fetch sns platform endpoints')
+        module.fail_json_aws(e, msg='Failed to fetch sns platform endpoints')
 
     if module.params['enabled'] is not None:
         __override_default_return = []

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 module: sns_platform_info
-short_description: Get Infomation about AWS SNS Platforms.
+short_description: Get Information about AWS SNS Platforms.
 description:
   - Get Information about AWS SNS Platforms.
 version_added: 1.4.0
@@ -62,6 +62,17 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+
+
+@AWSRetry.exponential_backoff(retries=5, delay=5)
+def _platform_it(sns, module):
+    try:
+        paginator = sns.get_paginator('list_platform_applications')
+        iterator = paginator.paginate()
+        return iterator
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
 
 
 def main():
@@ -74,14 +85,11 @@ def main():
 
     __default_return = []
 
-    try:
-        paginator = sns.get_paginator('list_platform_applications')
-        platform_iterator = paginator.paginate()
-        for response in platform_iterator:
+    _it = _platform_it(sns, module)
+    if _it is not None:
+        for response in _it:
             for application in response['PlatformApplications']:
                 __default_return.append(camel_dict_to_snake_dict(application))
-    except (BotoCoreError, ClientError) as e:
-        module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
 
     if module.params['enabled'] is not None:
         __override_default_return = []

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -21,8 +21,7 @@ options:
     required: false
     type: str
     choices: ['true', 'false']
-author:
-  - "Davinder Pal <dpsangwal@gmail.com>"
+author: "Davinder Pal <dpsangwal@gmail.com>"
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws
@@ -50,7 +49,7 @@ platforms:
       "AppleCertificateExpirationDate": "2021-10-10T16:56:51Z",
       "Enabled": "true",
       "SuccessFeedbackSampleRate": "100"
-    }, 
+    },
     "PlatformApplicationArn": "arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app"
   }]
 """

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Davinder Pal <dpsangwal@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+module: community.aws.sns_platform_info
+short_description: Get Infomation about AWS SNS Platforms.
+description:
+  - Get Information about AWS SNS Platforms.
+version_added: 1.4.0
+options:
+  enabled:
+    description:
+      - filter to look for enabled or disabled endpoints.
+    required: false
+    type: str
+    choices: ['true', 'false']
+author:
+  - "Davinder Pal <dpsangwal@gmail.com>"
+extends_documentation_fragment:
+  - amazon.aws.sns
+  - amazon.aws.aws
+requirements:
+  - boto3
+  - botocore
+"""
+
+EXAMPLES = """
+- name: Get list of SNS platform applications.
+  community.aws.sns_platform_info:
+
+- name: Get list of SNS platform applications but enabled only.
+  community.aws.sns_platform_info:
+    enabled: 'true'
+"""
+
+RETURN = """
+platforms:
+  description: List of SNS Platform Applications.
+  returned: when success
+  type: list
+  sample: [{
+    {"Attributes": {
+      "AppleCertificateExpirationDate": "2021-10-10T16:56:51Z",
+      "Enabled": "true",
+      "SuccessFeedbackSampleRate": "100"
+    },
+    "PlatformApplicationArn": "arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app"
+  }]
+"""
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass    # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+
+# uncomment below for ansible 2.8 or lower
+# from ansible.module_utils.aws.core import AnsibleAWSModule
+
+def main():
+
+    argument_spec = dict(
+    enabled=dict(required=False,choices=['true', 'false']),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec)
+    sns = module.client('sns')
+
+    __default_return = []
+
+    try:
+      paginator = sns.get_paginator('list_platform_applications')
+      platform_iterator = paginator.paginate()
+      for response in platform_iterator:
+        __default_return += response['PlatformApplications']
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
+
+    if module.params['enabled'] is not None:
+      __override_default_return = []
+      for application in __default_return:
+        if application['Attributes']['Enabled'] == module.params['enabled']:
+          __override_default_return.append(application)
+
+      module.exit_json(platforms=__override_default_return)   
+
+    module.exit_json(platforms=__default_return)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -21,7 +21,8 @@ options:
     required: false
     type: str
     choices: ['true', 'false']
-author: "Davinder Pal <dpsangwal@gmail.com>"
+author:
+  - "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -24,7 +24,7 @@ options:
 author:
   - "Davinder Pal <dpsangwal@gmail.com>"
 extends_documentation_fragment:
-  - amazon.aws.sns
+  - amazon.aws.ec2
   - amazon.aws.aws
 requirements:
   - boto3
@@ -62,13 +62,10 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
-# uncomment below for ansible 2.8 or lower
-# from ansible.module_utils.aws.core import AnsibleAWSModule
-
 def main():
 
     argument_spec = dict(
-    enabled=dict(required=False,choices=['true', 'false']),
+        enabled=dict(required=False, choices=['true', 'false']),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
@@ -77,22 +74,23 @@ def main():
     __default_return = []
 
     try:
-      paginator = sns.get_paginator('list_platform_applications')
-      platform_iterator = paginator.paginate()
-      for response in platform_iterator:
-        __default_return += response['PlatformApplications']
+        paginator = sns.get_paginator('list_platform_applications')
+        platform_iterator = paginator.paginate()
+        for response in platform_iterator:
+            __default_return += response['PlatformApplications']
     except (BotoCoreError, ClientError) as e:
-        module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
+          module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
 
     if module.params['enabled'] is not None:
-      __override_default_return = []
-      for application in __default_return:
-        if application['Attributes']['Enabled'] == module.params['enabled']:
-          __override_default_return.append(application)
+        __override_default_return = []
+        for application in __default_return:
+            if application['Attributes']['Enabled'] == module.params['enabled']:
+              __override_default_return.append(application)
 
-      module.exit_json(platforms=__override_default_return)   
+        module.exit_json(platforms=__override_default_return)
 
     module.exit_json(platforms=__default_return)
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
-module: community.aws.sns_platform_info
+module: sns_platform_info
 short_description: Get Infomation about AWS SNS Platforms.
 description:
   - Get Information about AWS SNS Platforms.
@@ -17,7 +17,7 @@ version_added: 1.4.0
 options:
   enabled:
     description:
-      - filter to look for enabled or disabled endpoints.
+      - filter to look for enabled or disabled endpoints?
     required: false
     type: str
     choices: ['true', 'false']
@@ -46,11 +46,11 @@ platforms:
   returned: when success
   type: list
   sample: [{
-    {"Attributes": {
+    "Attributes": {
       "AppleCertificateExpirationDate": "2021-10-10T16:56:51Z",
       "Enabled": "true",
       "SuccessFeedbackSampleRate": "100"
-    },
+    }, 
     "PlatformApplicationArn": "arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app"
   }]
 """
@@ -62,8 +62,8 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
-def main():
 
+def main():
     argument_spec = dict(
         enabled=dict(required=False, choices=['true', 'false']),
     )
@@ -79,13 +79,13 @@ def main():
         for response in platform_iterator:
             __default_return += response['PlatformApplications']
     except (BotoCoreError, ClientError) as e:
-          module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
+        module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
 
     if module.params['enabled'] is not None:
         __override_default_return = []
         for application in __default_return:
             if application['Attributes']['Enabled'] == module.params['enabled']:
-              __override_default_return.append(application)
+                __override_default_return.append(application)
 
         module.exit_json(platforms=__override_default_return)
 

--- a/plugins/modules/sns_platform_info.py
+++ b/plugins/modules/sns_platform_info.py
@@ -46,12 +46,12 @@ platforms:
   returned: when success
   type: list
   sample: [{
-    "Attributes": {
-      "AppleCertificateExpirationDate": "2021-10-10T16:56:51Z",
-      "Enabled": "true",
-      "SuccessFeedbackSampleRate": "100"
+    "attributes": {
+      "apple_certificate_expiration_date": "2021-10-10T16:56:51Z",
+      "enabled": "true",
+      "success_feedback_sample_rate": "100"
     },
-    "PlatformApplicationArn": "arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app"
+    "platform_application_arn": "arn:aws:sns:us-east-1:xxxxx:app/APNS/xxxxx-platform-app"
   }]
 """
 
@@ -61,6 +61,7 @@ except ImportError:
     pass    # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def main():
@@ -77,14 +78,15 @@ def main():
         paginator = sns.get_paginator('list_platform_applications')
         platform_iterator = paginator.paginate()
         for response in platform_iterator:
-            __default_return += response['PlatformApplications']
+            for application in response['PlatformApplications']:
+                __default_return.append(camel_dict_to_snake_dict(application))
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Failed to fetch sns platform applications')
 
     if module.params['enabled'] is not None:
         __override_default_return = []
         for application in __default_return:
-            if application['Attributes']['Enabled'] == module.params['enabled']:
+            if application['attributes']['enabled'] == module.params['enabled']:
                 __override_default_return.append(application)
 
         module.exit_json(platforms=__override_default_return)

--- a/plugins/modules/sns_subscriptions_info.py
+++ b/plugins/modules/sns_subscriptions_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
-module: community.aws.sns_subscriptions_info
+module: sns_subscriptions_info
 short_description: Get Infomation about AWS SNS Subscriptions.
 description:
   - Get Information about AWS SNS Subscriptions.
@@ -61,8 +61,8 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
-def main():
 
+def main():
     argument_spec = dict(
         topic_arn=dict(required=False, aliases=['arn']),
     )

--- a/plugins/modules/sns_subscriptions_info.py
+++ b/plugins/modules/sns_subscriptions_info.py
@@ -17,12 +17,11 @@ version_added: 1.4.0
 options:
   topic_arn:
     description:
-      - topic arn related Subscriptions only?
+      - topic_arn subscriptions will be returned?
     required: false
     type: str
     aliases: [ "arn" ]
-author:
-  - "Davinder Pal <dpsangwal@gmail.com>"
+author: "Davinder Pal <dpsangwal@gmail.com>"
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws

--- a/plugins/modules/sns_subscriptions_info.py
+++ b/plugins/modules/sns_subscriptions_info.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Davinder Pal <dpsangwal@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+module: community.aws.sns_subscriptions_info
+short_description: Get Infomation about AWS SNS Subscriptions.
+description:
+  - Get Information about AWS SNS Subscriptions.
+version_added: 1.4.0
+options:
+  topic_arn:
+    description:
+      - topic arn related Subscriptions only?
+    required: false
+    type: str
+    aliases: [ "arn" ]
+author:
+  - "Davinder Pal <dpsangwal@gmail.com>"
+extends_documentation_fragment:
+  - amazon.aws.sns
+  - amazon.aws.aws
+requirements:
+  - boto3
+  - botocore
+"""
+
+EXAMPLES = """
+- name: Get list of SNS Subscriptions.
+  community.aws.sns_subscriptions_info:
+
+- name: Get list of SNS Subscriptions for given topic.
+  community.aws.sns_subscriptions_info:
+    arn: 'arn:aws:sns:us-east-1:xxx:test'
+"""
+
+RETURN = """
+subscriptions:
+  description: List of SNS Subscriptions.
+  returned: when success
+  type: list
+  sample: [{
+    "Endpoint": "arn:aws:sqs:us-east-1:xxxxx:test-endpoint",
+    "Owner": "xxxxx",
+    "Protocol": "sqs",
+    "SubscriptionArn": "arn:aws:sns:us-east-1:xxxxx:test-sub-arn:xxxxxxxxxxxx-524760c63010",
+    "TopicArn": "arn:aws:sns:us-east-1:xxxxx:test-topic-arn"
+  }]
+"""
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass    # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+
+# uncomment below for ansible 2.8 or lower
+# from ansible.module_utils.aws.core import AnsibleAWSModules
+
+def main():
+
+    argument_spec = dict(
+    topic_arn=dict(required=False, aliases=['arn']),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec)
+    sns = module.client('sns')
+
+    __default_return = []
+
+    try:
+      if module.params['topic_arn'] is not None:
+        paginator = sns.get_paginator('list_subscriptions_by_topic')
+        iterator = paginator.paginate(TopicArn=module.params['arn'])
+      else:
+        paginator = sns.get_paginator('list_subscriptions')
+        iterator = paginator.paginate()
+
+      for response in iterator:
+        __default_return += response['Subscriptions']
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Failed to fetch sns subscriptions')
+
+    module.exit_json(subscriptions=__default_return)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/sns_subscriptions_info.py
+++ b/plugins/modules/sns_subscriptions_info.py
@@ -24,7 +24,7 @@ options:
 author:
   - "Davinder Pal <dpsangwal@gmail.com>"
 extends_documentation_fragment:
-  - amazon.aws.sns
+  - amazon.aws.ec2
   - amazon.aws.aws
 requirements:
   - boto3
@@ -61,13 +61,10 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
-# uncomment below for ansible 2.8 or lower
-# from ansible.module_utils.aws.core import AnsibleAWSModules
-
 def main():
 
     argument_spec = dict(
-    topic_arn=dict(required=False, aliases=['arn']),
+        topic_arn=dict(required=False, aliases=['arn']),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
@@ -76,19 +73,20 @@ def main():
     __default_return = []
 
     try:
-      if module.params['topic_arn'] is not None:
-        paginator = sns.get_paginator('list_subscriptions_by_topic')
-        iterator = paginator.paginate(TopicArn=module.params['arn'])
-      else:
-        paginator = sns.get_paginator('list_subscriptions')
-        iterator = paginator.paginate()
+        if module.params['topic_arn'] is not None:
+            paginator = sns.get_paginator('list_subscriptions_by_topic')
+            iterator = paginator.paginate(TopicArn=module.params['arn'])
+        else:
+            paginator = sns.get_paginator('list_subscriptions')
+            iterator = paginator.paginate()
 
-      for response in iterator:
-        __default_return += response['Subscriptions']
+        for response in iterator:
+            __default_return += response['Subscriptions']
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Failed to fetch sns subscriptions')
 
     module.exit_json(subscriptions=__default_return)
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/sns_subscriptions_info.py
+++ b/plugins/modules/sns_subscriptions_info.py
@@ -46,11 +46,11 @@ subscriptions:
   returned: when success
   type: list
   sample: [{
-    "Endpoint": "arn:aws:sqs:us-east-1:xxxxx:test-endpoint",
-    "Owner": "xxxxx",
-    "Protocol": "sqs",
-    "SubscriptionArn": "arn:aws:sns:us-east-1:xxxxx:test-sub-arn:xxxxxxxxxxxx-524760c63010",
-    "TopicArn": "arn:aws:sns:us-east-1:xxxxx:test-topic-arn"
+    "endpoint": "arn:aws:sqs:us-east-1:xxxxx:test-endpoint",
+    "owner": "xxxxx",
+    "protocol": "sqs",
+    "subscription_arn": "arn:aws:sns:us-east-1:xxxxx:test-sub-arn:xxxxxxxxxxxx-524760c63010",
+    "topic_arn": "arn:aws:sns:us-east-1:xxxxx:test-topic-arn"
   }]
 """
 
@@ -60,6 +60,7 @@ except ImportError:
     pass    # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def main():
@@ -81,7 +82,8 @@ def main():
             iterator = paginator.paginate()
 
         for response in iterator:
-            __default_return += response['Subscriptions']
+            for sub in response['Subscriptions']:
+                __default_return.append(camel_dict_to_snake_dict(sub))
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Failed to fetch sns subscriptions')
 

--- a/plugins/modules/sns_subscriptions_info.py
+++ b/plugins/modules/sns_subscriptions_info.py
@@ -21,7 +21,8 @@ options:
     required: false
     type: str
     aliases: [ "arn" ]
-author: "Davinder Pal <dpsangwal@gmail.com>"
+author:
+  - "Davinder Pal (@116davinder) <dpsangwal@gmail.com>"
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws


### PR DESCRIPTION
##### SUMMARY
Added 3 New Info Modules for AWS SNS

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
* sns_platform_endpoint_info
* sns_platform_info
* sns_subscriptions_info

### Test Ansible Code
```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - name: "get list of all platforms"
      sns_platform_info:
    - name: 'get list of all platforms which are enabled'
      sns_platform_info:
        enabled: 'true'
      register: __
    - name: 'get all enabled endpoints for given platform arn'
      sns_platform_endpoint_info:
        arn: '{{ __.platforms[0].platform_application_arn }}'
        enabled: 'true'
    - name: "get all sns subscriptions"
      sns_subscriptions_info:
    - name: 'get all subscriptions for given sns topic arn'
      sns_subscriptions_info:
        arn: 'arn:aws:sns:us-east-1:xxxxxxx:test-topic-arn'
```
if this doesn't get merged then I have published same module in personal repository: https://github.com/116davinder/ansible.missing_collection