### PR TITLE
ecs_service - support setting deployment controller on a service

### DIFF
--- a/changelogs/fragments/340-deployment-controller.yml
+++ b/changelogs/fragments/340-deployment-controller.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_service - added parameter ``deployment_controller`` so service can be controlled by Code Deploy (https://github.com/ansible-collections/community.aws/pull/340).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -46,7 +46,8 @@ options:
         description:
           - The task definition the service will run.
           - This parameter is required when I(state=present).
-          - This parameter is ignored when updating a service with deployment controller is CODE_DEPLOY. The task definition is managed by Code Pipeline in that case and cannot be updated.
+          - This parameter is ignored when updating a service with a C(CODE_DEPLOY) deployment controller in which case
+            the task definition is managed by Code Pipeline and cannot be updated.
         required: false
         type: str
     load_balancers:
@@ -712,12 +713,13 @@ class EcsServiceManager:
             loadBalancers=load_balancers,
             clientToken=client_token,
             role=role,
-            deploymentController=deployment_controller,
             deploymentConfiguration=deployment_configuration,
             placementStrategy=placement_strategy
         )
         if network_configuration:
             params['networkConfiguration'] = network_configuration
+        if deployment_controller:
+            params['deploymentController'] = deployment_controller
         if launch_type:
             params['launchType'] = launch_type
         if platform_version:
@@ -940,7 +942,7 @@ def main():
                         if existing['deploymentController']['type'] != 'CODE_DEPLOY':
                             module.fail_json(msg="It is not possible to update the load balancers of an existing service")
 
-                    if existing['deploymentController']['type'] == 'CODE_DEPLOY':
+                    if existing.get('deploymentController', {}).get('type', None) == 'CODE_DEPLOY':
                         task_definition = ''
                         network_configuration = []
                     else:

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -941,10 +941,10 @@ def main():
                             module.fail_json(msg="It is not possible to update the load balancers of an existing service")
 
                     if existing['deploymentController']['type'] == 'CODE_DEPLOY':
-                        task_definition = '';
-                        network_configuration = [];
+                        task_definition = ''
+                        network_configuration = []
                     else:
-                        task_definition = module.params['task_definition'];
+                        task_definition = module.params['task_definition']
 
                     # update required
                     response = service_mgr.update_service(module.params['name'],


### PR DESCRIPTION
##### SUMMARY
Support setting platform version to 1.4.0 (LATEST is 1.3.0) and deployment controller.

The first allows access to new 1.4.0 features. The second change allows you to create a service that can be controlled with Code Deploy.

Example:

```
  - name: create a Fargate service
    community.aws.ecs_service:
      state: present
      name: "my-service"
      cluster: "my-cluster"
      platform_version: 1.4.0
      task_definition: "my-task"
      desired_count: "1"
      launch_type: FARGATE
      scheduling_strategy: REPLICA
      deployment_controller:
        type: CODE_DEPLOY
      load_balancers:
        - targetGroupArn: "arn:..."
          containerName: example
          containerPort: 80
      network_configuration:
        subnets:
          - "{{vpc_zone_a.subnet.id}}"
          - "{{vpc_zone_b.subnet.id}}"
        security_groups:
          - "sg-example"
        assign_public_ip: true
```

This fixes #338.

##### ISSUE TYPE
- Feature Pull Request