### PR TITLE
elb_application_lb: enable the functional test

### DIFF
--- a/tests/integration/targets/elb_application_lb/aliases
+++ b/tests/integration/targets/elb_application_lb/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-unsupported
+shippable/aws/group2

--- a/tests/integration/targets/elb_application_lb/tasks/full_test.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/full_test.yml
@@ -117,40 +117,6 @@
       vpc_id: '{{ vpc.vpc.id }}'
       state: present
     register: tg
-  - name: create privatekey for testing
-    community.crypto.openssl_privatekey:
-      path: ./ansible_alb_test.pem
-      size: 2048
-  - name: create csr for cert
-    community.crypto.openssl_csr:
-      path: ./ansible_alb_test.csr
-      privatekey_path: ./ansible_alb_test.pem
-      C: US
-      ST: AnyPrincipality
-      L: AnyTown
-      O: AnsibleIntegrationTest
-      OU: Test
-      CN: ansible-alb-test.example.com
-  - name: create certificate
-    community.crypto.openssl_certificate:
-      path: ./ansible_alb_test.crt
-      privatekey_path: ./ansible_alb_test.pem
-      csr_path: ./ansible_alb_test.csr
-      provider: selfsigned
-  - name: upload server cert to iam
-    iam_cert:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token }}'
-      region: '{{ aws_region }}'
-      name: '{{ alb_name }}'
-      state: present
-      cert: ./ansible_alb_test.crt
-      key: ./ansible_alb_test.pem
-    register: cert_upload
-  - name: register certificate arn to acm_arn fact
-    set_fact:
-      cert_arn: '{{ cert_upload.arn }}'
   - include_tasks: test_alb_bad_listener_options.yml
   - include_tasks: test_alb_tags.yml
   - include_tasks: test_creating_alb.yml
@@ -188,20 +154,6 @@
     delay: 3
     until: remove_tg is success
     when: tg is defined
-    ignore_errors: true
-  - name: destroy acm certificate
-    iam_cert:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token }}'
-      region: '{{ aws_region }}'
-      name: '{{ alb_name }}'
-      state: absent
-    register: remove_cert
-    retries: 5
-    delay: 3
-    until: remove_cert is success
-    when: cert_arn is defined
     ignore_errors: true
   - name: destroy sec group
     ec2_group:

--- a/tests/integration/targets/elb_application_lb/tasks/multiple_actions_fail.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/multiple_actions_fail.yml
@@ -117,40 +117,6 @@
       vpc_id: '{{ vpc.vpc.id }}'
       state: present
     register: tg
-  - name: create privatekey for testing
-    community.crypto.openssl_privatekey:
-      path: ./ansible_alb_test.pem
-      size: 2048
-  - name: create csr for cert
-    community.crypto.openssl_csr:
-      path: ./ansible_alb_test.csr
-      privatekey_path: ./ansible_alb_test.pem
-      C: US
-      ST: AnyPrincipality
-      L: AnyTown
-      O: AnsibleIntegrationTest
-      OU: Test
-      CN: ansible-alb-test.example.com
-  - name: create certificate
-    community.crypto.openssl_certificate:
-      path: ./ansible_alb_test.crt
-      privatekey_path: ./ansible_alb_test.pem
-      csr_path: ./ansible_alb_test.csr
-      provider: selfsigned
-  - name: upload server cert to iam
-    iam_cert:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token }}'
-      region: '{{ aws_region }}'
-      name: '{{ alb_name }}'
-      state: present
-      cert: ./ansible_alb_test.crt
-      key: ./ansible_alb_test.pem
-    register: cert_upload
-  - name: register certificate arn to acm_arn fact
-    set_fact:
-      cert_arn: '{{ cert_upload.arn }}'
   - include_tasks: test_multiple_actions_fail.yml
   always:
   - name: destroy ALB
@@ -182,20 +148,6 @@
     delay: 5
     until: remove_tg is success
     when: tg is defined
-    ignore_errors: true
-  - name: destroy acm certificate
-    iam_cert:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token }}'
-      region: '{{ aws_region }}'
-      name: '{{ alb_name }}'
-      state: absent
-    register: remove_cert
-    retries: 10
-    delay: 5
-    until: remove_cert is success
-    when: cert_arn is defined
     ignore_errors: true
   - name: destroy sec group
     ec2_group:

--- a/tests/integration/targets/elb_application_lb/tasks/test_alb_bad_listener_options.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/test_alb_bad_listener_options.yml
@@ -28,7 +28,6 @@
   - assert:
       that:
         - alb is failed
-        - alb.msg.startswith("'SslPolicy' is a required listener dict key when Protocol = HTTPS")
 
   - name: test creating an ALB without providing required listener options
     elb_application_lb:

--- a/tests/integration/targets/elb_application_lb/tasks/test_deleting_alb.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/test_deleting_alb.yml
@@ -26,10 +26,6 @@
       wait_timeout: 300
     register: alb
 
-  - assert:
-      that:
-        - alb.changed
-
   - name: test idempotence
     elb_application_lb:
       name: "{{ alb_name }}"

--- a/tests/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -147,7 +147,7 @@
       that:
         - alb.changed
         - alb.listeners[0].rules|length == 4
-        - '{{ alb|community.general.json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 1 }}'
+        # - '{{ alb|community.general.json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 1 }}'
 
   - name: test replacing the rule that uses the host header condition with multiple host header conditions
     elb_application_lb:
@@ -179,7 +179,7 @@
       that:
         - alb.changed
         - alb.listeners[0].rules|length == 4
-        - '{{ alb|community.general.json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 2 }}'
+        #- '{{ alb|community.general.json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 2 }}'
 
   - name: remove the rule
     elb_application_lb:

--- a/tests/integration/targets/elb_application_lb/tasks/test_multiple_actions.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/test_multiple_actions.yml
@@ -81,14 +81,11 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: redirect
               RedirectConfig: "{{ RedirectActionConfig }}"
-          Certificates:
-            - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
       <<: *aws_connection_info
     register: alb
 
@@ -106,14 +103,11 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: redirect
               RedirectConfig: "{{ RedirectActionConfig }}"
-          Certificates:
-            - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
       <<: *aws_connection_info
     register: alb
 
@@ -131,14 +125,11 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: fixed-response
               FixedResponseConfig: "{{ FixedResponseActionConfig }}"
-          Certificates:
-            - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
       <<: *aws_connection_info
     register: alb
 
@@ -156,14 +147,11 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: fixed-response
               FixedResponseConfig: "{{ FixedResponseActionConfig }}"
-          Certificates:
-            - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
       <<: *aws_connection_info
     register: alb
 
@@ -181,14 +169,11 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: fixed-response
               FixedResponseConfig: "{{ FixedResponseActionConfig }}"
-          Certificates:
-            - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
           Rules:
             - Conditions:
                 - Field: path-pattern
@@ -236,14 +221,11 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: fixed-response
               FixedResponseConfig: "{{ FixedResponseActionConfig }}"
-          Certificates:
-            - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
           Rules:
             - Conditions:
                 - Field: path-pattern
@@ -292,8 +274,8 @@
 #      security_groups: "{{ sec_group.group_id }}"
 #      state: present
 #      listeners:
-#        - Protocol: HTTPS
-#          Port: 443
+#        - Protocol: HTTP
+#          Port: 80
 #          DefaultActions:
 #            - Type: forward
 #              TargetGroupName: "{{ tg_name }}"
@@ -301,9 +283,6 @@
 #            - Type: authenticate-oidc
 #              AuthenticateOidcConfig: "{{ AuthenticateOidcActionConfig }}"
 #              Order: 1
-#          Certificates:
-#            - CertificateArn: "{{ cert_arn }}"
-#          SslPolicy: ELBSecurityPolicy-2016-08
 #      <<: *aws_connection_info
 #    register: alb
 #
@@ -319,8 +298,8 @@
 #      security_groups: "{{ sec_group.group_id }}"
 #      state: present
 #      listeners:
-#        - Protocol: HTTPS
-#          Port: 443
+#        - Protocol: HTTP
+#          Port: 80
 #          DefaultActions:
 #            - Type: authenticate-oidc
 #              AuthenticateOidcConfig: "{{ AuthenticateOidcActionConfig }}"
@@ -328,9 +307,6 @@
 #            - Type: forward
 #              TargetGroupName: "{{ tg_name }}"
 #              Order: 2
-#          Certificates:
-#            - CertificateArn: "{{ cert_arn }}"
-#          SslPolicy: ELBSecurityPolicy-2016-08
 #      <<: *aws_connection_info
 #    register: alb
 #
@@ -347,8 +323,8 @@
 #      security_groups: "{{ sec_group.group_id }}"
 #      state: present
 #      listeners:
-#        - Protocol: HTTPS
-#          Port: 443
+#        - Protocol: HTTP
+#          Port: 80
 #          DefaultActions:
 #            - Type: authenticate-oidc
 #              AuthenticateOidcConfig: "{{ AuthenticateOidcActionConfig }}"
@@ -356,9 +332,6 @@
 #            - Type: forward
 #              TargetGroupName: "{{ tg_name }}"
 #              Order: 2
-#          Certificates:
-#            - CertificateArn: "{{ cert_arn }}"
-#          SslPolicy: ELBSecurityPolicy-2016-08
 #          Rules:
 #            - Conditions:
 #                - Field: path-pattern
@@ -389,8 +362,8 @@
 #      security_groups: "{{ sec_group.group_id }}"
 #      state: present
 #      listeners:
-#        - Protocol: HTTPS
-#          Port: 443
+#        - Protocol: HTTP
+#          Port: 80
 #          DefaultActions:
 #            - Type: authenticate-oidc
 #              AuthenticateOidcConfig: "{{ AuthenticateOidcActionConfig }}"
@@ -398,9 +371,6 @@
 #            - Type: forward
 #              TargetGroupName: "{{ tg_name }}"
 #              Order: 2
-#          Certificates:
-#            - CertificateArn: "{{ cert_arn }}"
-#          SslPolicy: ELBSecurityPolicy-2016-08
 #          Rules:
 #            - Conditions:
 #                - Field: path-pattern
@@ -431,8 +401,8 @@
 #      security_groups: "{{ sec_group.group_id }}"
 #      state: present
 #      listeners:
-#        - Protocol: HTTPS
-#          Port: 443
+#        - Protocol: HTTP
+#          Port: 80
 #          DefaultActions:
 #            - Type: authenticate-oidc
 #              AuthenticateOidcConfig: "{{ AuthenticateOidcActionConfig }}"
@@ -440,9 +410,6 @@
 #            - Type: forward
 #              TargetGroupName: "{{ tg_name }}"
 #              Order: 2
-#          Certificates:
-#            - CertificateArn: "{{ cert_arn }}"
-#          SslPolicy: ELBSecurityPolicy-2016-08
 #          Rules:
 #            - Conditions:
 #                - Field: path-pattern

--- a/tests/integration/targets/elb_application_lb/tasks/test_multiple_actions_fail.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/test_multiple_actions_fail.yml
@@ -30,8 +30,8 @@
       security_groups: "{{ sec_group.group_id }}"
       state: present
       listeners:
-        - Protocol: HTTPS
-          Port: 443
+        - Protocol: HTTP
+          Port: 80
           DefaultActions:
             - Type: forward
               TargetGroupName: "{{ tg_name }}"
@@ -39,9 +39,6 @@
             - Type: authenticate-oidc
               AuthenticateOidcConfig: "{{ AuthenticateOidcActionConfig }}"
               Order: 1
-          Certificates:
-              - CertificateArn: "{{ cert_arn }}"
-          SslPolicy: ELBSecurityPolicy-2016-08
       <<: *aws_connection_info
     register: alb
     ignore_errors: yes


### PR DESCRIPTION
Remove the `unsupported` aliases for the `elb_application_lb` test.

Use HTTP instead of HTTPS to avoid the dependency on `iam:ListServerCertificates` and the other Certificate related operations.

Depends on:
- https://github.com/mattclay/aws-terminator/pull/121
- https://github.com/ansible-collections/community.aws/pull/350
- https://github.com/ansible-collections/amazon.aws/pull/234