### PR TITLE
elb_application_lb: also clean up the associate listeners

### DIFF
--- a/changelogs/fragments/350_elb_application_lb_purges_listeners.yaml
+++ b/changelogs/fragments/350_elb_application_lb_purges_listeners.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- elb_application_lb - during the removal of an instance, the associated listeners are also removed.

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -589,6 +589,11 @@ def create_or_update_elb(elb_obj):
 def delete_elb(elb_obj):
 
     if elb_obj.elb:
+        listeners_obj = ELBListeners(elb_obj.connection, elb_obj.module, elb_obj.elb['LoadBalancerArn'])
+        for listener_to_delete in [i['ListenerArn'] for i in listeners_obj.current_listeners]:
+            listener_obj = ELBListener(elb_obj.connection, elb_obj.module, listener_to_delete, elb_obj.elb['LoadBalancerArn'])
+            listener_obj.delete()
+
         elb_obj.delete()
 
     elb_obj.module.exit_json(changed=elb_obj.changed)


### PR DESCRIPTION
state=`absent`: Properly remove the associated listeners before the final
removal of the object.

See: https://github.com/ansible/ansible/issues/49291