### PR TITLE
aws_ssm signed url using v2 and thus aws_ssm generates incompatible curl request to download s3 object for ansible python

### DIFF
--- a/changelogs/fragments/352-fix-aws-region-and-v4-signature-for-s3-boto-client.yml
+++ b/changelogs/fragments/352-fix-aws-region-and-v4-signature-for-s3-boto-client.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - fix the generation of CURL URL used to download Ansible Python file from S3 bucket by ```_get_url()``` due to due to non-assignment of aws region in the URL and not using V4 signature as specified for AWS S3 signature URL by ```_get_boto_client()``` in (https://github.com/ansible-collections/community.aws/pull/352). 

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -521,6 +521,7 @@ class Connection(ConnectionBase):
             aws_session_token=aws_session_token,
             region_name=region_name,
             config=Config(signature_version="s3v4")
+        )
         return client
 
     @_ssm_retry

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -162,7 +162,6 @@ EXAMPLES = r'''
 import os
 import getpass
 import json
-import os
 import pty
 import random
 import re

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -497,10 +497,7 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method):
         ''' Generate URL for get_object / put_object '''
-        if self.get_option('region') is None:
-            region_name = 'us-east-1'
-        else:
-            region_name = self.get_option('region')
+        region_name = self.get_option('region') or 'us-east-1'
         client = self._get_boto_client('s3', region_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -176,6 +176,7 @@ try:
 except ImportError as e:
     HAS_BOTO_3_ERROR = str(e)
     HAS_BOTO_3 = False
+from botocore.client import Config
 
 from functools import wraps
 from ansible import constants as C
@@ -496,7 +497,11 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method):
         ''' Generate URL for get_object / put_object '''
-        client = self._get_boto_client('s3')
+        if self.get_option('region') is None:
+            region_name = 'us-east-1'
+        else:
+            region_name = self.get_option('region')
+        client = self._get_boto_client('s3', region_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 
     def _get_boto_client(self, service, region_name=None):
@@ -514,7 +519,8 @@ class Connection(ConnectionBase):
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
-            region_name=region_name)
+            region_name=region_name,
+            config=Config(signature_version="s3v4")
         return client
 
     @_ssm_retry


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Issue is with botocore which still uses V2 signature by default instead of V4 signature. This result in malformed CURL http url to download Ansible python script from S3. Issue is documented in botocore https://github.com/boto/botocore/issues/2109.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Include fix to #351

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ssm connection
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
