### PR TITLE
Return all infos of a VPC peering connection in ec2_vpc_peer module

### DIFF
--- a/changelogs/fragments/355-ec2_vpc_peer_improvements.yml
+++ b/changelogs/fragments/355-ec2_vpc_peer_improvements.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vpc_peer - More return info added, also simplified module code a bit and extended tests (https://github.com/ansible-collections/community.aws/pull/355)

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -486,7 +486,7 @@ def remove_peer_connection(client, module):
         module.exit_json(msg='Connection in deleted state.', changed=False, peering_id=pcx_id)
     if peering_conn['Status']['Code'] == 'rejected':
         module.exit_json(
-            msg='Connection has been rejected. State cannot be changed and will be removed automatically by AWS', 
+            msg='Connection has been rejected. State cannot be changed and will be removed automatically by AWS',
             changed=False,
             peering_id=pcx_id
         )

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -224,7 +224,19 @@ peering_id:
 vpc_peering_connection:
   description: The details of the VPC peering connection as returned by Boto3 (snake cased).
   returned: success
-  type: dict
+  type: complex
+  contains:
+    vpc_peering_connection_id:
+      type: str
+      sample: pcx-034223d7c0aec3cde
+    accepter_vpc_info:
+      type: dict
+    requester_vpc_info:
+      type: dict
+    tags:
+      type: dict
+    status:
+      type: dict
 '''
 
 try:
@@ -353,9 +365,9 @@ def remove_peer_connection(client, module):
     else:
         pcx_id = pcx_id or peering_conn['VpcPeeringConnectionId']
 
-    if peering_conn[0]['Status']['Code'] == 'deleted':
+    if peering_conn['Status']['Code'] == 'deleted':
         module.exit_json(msg='Connection in deleted state.', changed=False)
-    if peering_conn[0]['Status']['Code'] == 'rejected':
+    if peering_conn['Status']['Code'] == 'rejected':
         module.exit_json(msg='Connection has been rejected.  State cannot be changed and will be removed automatically by AWS', changed=False)
 
     try:

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -482,11 +482,11 @@ def main():
         (changed, results) = accept_reject(state, client, module)
 
     formatted_results = camel_dict_to_snake_dict(results)
-    # Turn the boto3 result in to ansible friendly tag dictionary
-    for peer in formatted_results:
-        peer['tags'] = boto3_tag_list_to_ansible_dict(peer.get('tags', []))
+    # Turn the resource tags from boto3 into an ansible friendly tag dictionary
+    formatted_results['tags'] = boto3_tag_list_to_ansible_dict(formatted_results.get('tags', []))
 
     module.exit_json(changed=changed, vpc_peering_connection=formatted_results, peering_id=results['VpcPeeringConnectionId'])
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -261,9 +261,9 @@ def tags_changed(pcx_id, client, module):
     tags = dict()
     if module.params.get('tags'):
         tags = module.params.get('tags')
-    pcx = find_pcx_by_id(pcx_id, client, module)
-    if pcx['VpcPeeringConnections']:
-        pcx_values = [t.values() for t in pcx['VpcPeeringConnections'][0]['Tags']]
+    peering_connection = get_peering_connection_by_id(pcx_id, client, module)
+    if peering_connection['Tags']
+        pcx_values = [t.values() for t in peering_connection['Tags']
         pcx_tags = [item for sublist in pcx_values for item in sublist]
         tag_values = [[key, str(value)] for key, value in tags.items()]
         tags = [item for sublist in tag_values for item in sublist]
@@ -431,13 +431,6 @@ def create_tags(pcx_id, client, module):
 def delete_tags(pcx_id, client, module):
     try:
         client.delete_tags(aws_retry=True, Resources=[pcx_id])
-    except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=str(e))
-
-
-def find_pcx_by_id(pcx_id, client, module):
-    try:
-        return client.describe_vpc_peering_connections(aws_retry=True, VpcPeeringConnectionIds=[pcx_id])
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -371,7 +371,7 @@ def remove_peer_connection(client, module):
 
 def get_peering_connection_by_id(peering_id, client, module):
     params = dict()
-    params['VpcPeeringConnectionIds'] = peering_id
+    params['VpcPeeringConnectionIds'] = [peering_id]
     try:
         vpc_peering_connection = client.describe_vpc_peering_connections(aws_retry=True, **params)
         return vpc_peering_connection['VpcPeeringConnections'][0]

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -236,6 +236,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -330,7 +330,7 @@ def create_peer_connection(client, module):
         if module.params.get('tags'):
             create_tags(pcx_id, client, module)
         changed = True
-        return (changed, peering_conn)
+        return (changed, peering_conn['VpcPeeringConnection'])
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg=str(e))
 

--- a/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
@@ -103,22 +103,6 @@
         - vpc_peer is successful
         - vpc_peer.peering_id == peer_id_1
 
-  - name: Accespt local VPC peering connection from destination VPC
-    ec2_vpc_peer:
-      peering_id: '{{ vpc_peer.peering_id }}'
-      state: accept
-      tags:
-        Name: '{{ connection_name }}'
-    register: vpc_peer_accept
-
-  - name: Assert success
-    assert:
-      tath:
-        - vpc_peer_accept is successful
-        - vpc_peer_accept is changed
-        - vpc_peer_accept.peering_id == vpc_peer.peering_id
-        - vpc_peer_accept.vpc_peering_connection.accepter_vpc_info.cidr_block == vpc_2_cidr
-
   - name: Get details on specific VPC peer
     ec2_vpc_peering_info:
       peer_connection_ids:
@@ -271,6 +255,8 @@
         - action_peer is changed
         - action_peer is successful
         - action_peer.peering_id == peer_id_1
+        - action_peer.vpc_peering_connection.accepter_vpc_info.cidr_block == vpc_2_cidr
+        - action_peer.vpc_peering_connection.vpc_peering_connection_id == peer_id_1
 
   - name: Get details on specific VPC peer
     ec2_vpc_peering_info:
@@ -340,6 +326,7 @@
         - action_peer is not changed
         - action_peer is successful
         - action_peer.peering_id == peer_id_1
+        - action_peer.vpc_peering_connection.vpc_peering_connection_id == peer_id_1
 
   - name: delete a local VPC peering Connection
     ec2_vpc_peer:
@@ -351,6 +338,7 @@
       that:
         - delete_peer is changed
         - delete_peer is successful
+        - "'peering_id' in delete_peer"
 
   - name: Get details on specific VPC peer
     ec2_vpc_peering_info:
@@ -456,6 +444,7 @@
         - reject_peer is not changed
         - reject_peer is successful
         - reject_peer.peering_id == peer_id_2
+        - reject_peer.vpc_peering_connection.vpc_peering_connection_id == peer_id_2
 
   - name: delete a local VPC peering Connection
     ec2_vpc_peer:

--- a/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
@@ -65,27 +65,7 @@
     set_fact:
       connection_name: 'Peering connection for VPC {{ vpc_1 }} to VPC {{ vpc_2 }}'
 
-  - name: Create local account VPC peering Connection
-    ec2_vpc_peer:
-      vpc_id: '{{ vpc_1 }}'
-      peer_vpc_id: '{{ vpc_2 }}'
-      state: present
-      tags:
-        Name: 'Peering connection for VPC {{ vpc_1 }} to VPC {{ vpc_2 }}'
-    register: vpc_peer
-  - name: Assert success
-    assert:
-      that:
-        - vpc_peer is changed
-        - vpc_peer is successful
-        - "'peering_id' in vpc_peer"
-        - vpc_peer.peering_id.startswith('pcx-')
-
-  - name: Store Connection ID
-    set_fact:
-      peer_id_1: '{{ vpc_peer.peering_id }}'
-
-  - name: (re-) Create local account VPC peering Connection (idempotency)
+  - name: Create local account VPC peering Connection request
     ec2_vpc_peer:
       vpc_id: '{{ vpc_1 }}'
       peer_vpc_id: '{{ vpc_2 }}'
@@ -93,12 +73,51 @@
       tags:
         Name: '{{ connection_name }}'
     register: vpc_peer
+
+  - name: Assert success
+    assert:
+      that:
+        - vpc_peer is changed
+        - vpc_peer is successful
+        - "'peering_id' in vpc_peer"
+        - vpc_peer.vpc_peering_connection.requester_vpc_info.cidr_block == vpc_1_cidr
+        - vpc_peer.peering_id.startswith('pcx-')
+
+  - name: Store Connection ID
+    set_fact:
+      peer_id_1: '{{ vpc_peer.peering_id }}'
+
+  - name: (re-) Create local account VPC peering Connection request (idempotency)
+    ec2_vpc_peer:
+      vpc_id: '{{ vpc_1 }}'
+      peer_vpc_id: '{{ vpc_2 }}'
+      state: present
+      tags:
+        Name: '{{ connection_name }}'
+    register: vpc_peer
+
   - name: Assert success
     assert:
       that:
         - vpc_peer is not changed
         - vpc_peer is successful
         - vpc_peer.peering_id == peer_id_1
+
+  - name: Accespt local VPC peering connection from destination VPC
+    ec2_vpc_peer:
+      peering_id: '{{ vpc_peer.peering_id }}'
+      state: accept
+      tags:
+        Name: '{{ connection_name }}'
+    register: vpc_peer_accept
+
+  - name: Assert success
+    assert:
+      tath:
+        - vpc_peer_accept is successful
+        - vpc_peer_accept is changed
+        - vpc_peer_accept.peering_id == vpc_peer.peering_id
+        - vpc_peer_accept.vpc_peering_connection.accepter_vpc_info.cidr_block == vpc_2_cidr
 
   - name: Get details on specific VPC peer
     ec2_vpc_peering_info:


### PR DESCRIPTION
##### SUMMARY
While boto3 returns a whole lot of useful information on a VPC peering connection, this module threw those away and only returned the ID. This PR changes that to pass through all information, which is also quite valuable when updating routing tables etc.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_peer module

##### ADDITIONAL INFORMATION

- [x] Add propper testing
- [x] Add better docs?
