### PR TITLE
add uptime parameter for ec2_instance_info module in minutes 

### DIFF
--- a/changelogs/fragments/356_add_minimum_uptime_parameter.yaml
+++ b/changelogs/fragments/356_add_minimum_uptime_parameter.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- adding minimum_uptime and alias uptime to filter instances that have only been online for certain duration of time in minutes
+- ec2_instance_info - added ``minimum_uptime`` option with alias ``uptime`` for filtering instances that have only been online for certain duration of time in minutes (https://github.com/ansible-collections/community.aws/pull/356).

--- a/changelogs/fragments/356_add_minimum_uptime_parameter.yaml
+++ b/changelogs/fragments/356_add_minimum_uptime_parameter.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- adding minimum_uptime and alias uptime to filter instances that have only been online for certain duration of time in minutes

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
@@ -1,0 +1,61 @@
+---
+- block:
+  - name: "create t3.nano instance"
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-t3nano-1"
+      region: "{{ ec2_region }}"
+      image_id: "{{ ec2_ami_image }}"
+      tags:
+        TestId: "{{ ec2_instance_tag_TestId }}"
+      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+      instance_type: t3.nano
+      wait: yes
+
+  - name: "check ec2 instance"
+    ec2_instance_info:
+      filters:
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+        instance-state-name: [ "running"]
+    register: instance_facts
+
+  - name: "Confirm existence of instance id."
+    assert:
+      that:
+        - "{{ instance_facts.instances | length }} == 1"
+
+  - name: "check using uptime 100 hours - should fail"
+    ec2_instance_info:
+      region: "{{ ec2_region }}"
+      uptime: 6000
+      filters:
+        instance-state-name: [ "running"]
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+    register: instance_facts
+
+  - name: "Confirm there is no running instance"
+    assert:
+      that:
+        - "{{ instance_facts.instances | length }} == 0"
+
+  - name: "check using uptime 1 minute"
+    ec2_instance_info:
+      region: "{{ ec2_region }}"
+      uptime: 1
+      filters:
+        instance-state-name: [ "running"]
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+    register: instance_facts
+
+  - name: "Confirm there is one running instance"
+    assert:
+      that:
+        - "{{ instance_facts.instances | length }} == 1"
+
+  always:
+  - name: "Terminate instances"
+    ec2_instance:
+      state: absent
+      filters:
+        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
+      wait: yes
+    ignore_errors: yes

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
@@ -2,7 +2,7 @@
 - block:
   - name: "create t3.nano instance"
     ec2_instance:
-      name: "{{ resource_prefix }}-test-t3nano-1"
+      name: "{{ resource_prefix }}-test-uptime"
       region: "{{ ec2_region }}"
       image_id: "{{ ec2_ami_image }}"
       tags:
@@ -14,7 +14,7 @@
   - name: "check ec2 instance"
     ec2_instance_info:
       filters:
-        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+        "tag:Name": "{{ resource_prefix }}-test-uptime"
         instance-state-name: [ "running"]
     register: instance_facts
 
@@ -23,13 +23,13 @@
       that:
         - "{{ instance_facts.instances | length }} == 1"
 
-  - name: "check using uptime 100 hours - should fail"
+  - name: "check using uptime 100 hours - should find nothing"
     ec2_instance_info:
       region: "{{ ec2_region }}"
       uptime: 6000
       filters:
         instance-state-name: [ "running"]
-        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+        "tag:Name": "{{ resource_prefix }}-test-uptime"
     register: instance_facts
 
   - name: "Confirm there is no running instance"
@@ -37,13 +37,18 @@
       that:
         - "{{ instance_facts.instances | length }} == 0"
 
+  - name: Sleep for 61 seconds and continue with play
+    wait_for:
+      timeout: 61
+    delegate_to: localhost
+
   - name: "check using uptime 1 minute"
     ec2_instance_info:
       region: "{{ ec2_region }}"
       uptime: 1
       filters:
         instance-state-name: [ "running"]
-        "tag:Name": "{{ resource_prefix }}-test-t3nano-1"
+        "tag:Name": "{{ resource_prefix }}-test-uptime"
     register: instance_facts
 
   - name: "Confirm there is one running instance"


### PR DESCRIPTION

##### SUMMARY
with tons of help from Yanis, we now have uptime in there

this PR is based on the PR https://github.com/ansible-collections/community.aws/pull/316 

example:

```
    - name: grab info
      community.aws.ec2_instance_info:
        region: "{{ ec2_region }}"
        uptime: 10200
        filters:
          instance-state-name: [ "running" ]
      register: ec2_node_info
```

this would only register instances that have been up for 10200 minutes (or 170 hours or ~7 days)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_instance_info 

##### ADDITIONAL INFORMATION
see https://github.com/ansible-collections/community.aws/pull/316 for the commentary on the last PR where I fixed information for @jillr and @gravesm 