### PR TITLE
ec2_vpc_route_table: Don't fail if a route was already created.

### DIFF
--- a/changelogs/fragments/359-fix-ec2_vpc_route_table.yml
+++ b/changelogs/fragments/359-fix-ec2_vpc_route_table.yml
@@ -1,2 +1,2 @@
-bug_fixes:
+bugfixes:
   - ec2_vpc_route_table - catch RouteAlreadyExists error when rerunning same task twice to make module idempotent

--- a/changelogs/fragments/359-fix-ec2_vpc_route_table.yml
+++ b/changelogs/fragments/359-fix-ec2_vpc_route_table.yml
@@ -1,0 +1,2 @@
+bug_fixes:
+  - ec2_vpc_route_table - catch RouteAlreadyExists error when rerunning same task twice to make module idempotent

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -492,20 +492,16 @@ def ensure_routes(connection=None, module=None, route_table=None, route_specs=No
 
         for route_spec in route_specs_to_recreate:
             try:
-                connection.replace_route(
-                    aws_retry=True,
-                    RouteTableId=route_table['RouteTableId'],
-                    **route_spec)
+                connection.replace_route(aws_retry=True, RouteTableId=route_table['RouteTableId'], **route_spec)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e, msg="Couldn't recreate route")
 
         for route_spec in route_specs_to_create:
             try:
-                connection.create_route(
-                    aws_retry=True,
-                    RouteTableId=route_table['RouteTableId'],
-                    **route_spec)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                connection.create_route(aws_retry=True, RouteTableId=route_table['RouteTableId'], **route_spec)
+            except is_boto3_error_code('RouteAlreadyExists'):
+                changed = False
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e: # pylint: disable=duplicate-except
                 module.fail_json_aws(e, msg="Couldn't create route")
 
     return {'changed': bool(changed)}

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -501,7 +501,7 @@ def ensure_routes(connection=None, module=None, route_table=None, route_specs=No
                 connection.create_route(aws_retry=True, RouteTableId=route_table['RouteTableId'], **route_spec)
             except is_boto3_error_code('RouteAlreadyExists'):
                 changed = False
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e: # pylint: disable=duplicate-except
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
                 module.fail_json_aws(e, msg="Couldn't create route")
 
     return {'changed': bool(changed)}


### PR DESCRIPTION
##### SUMMARY
Fixes #357 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_route_table

##### ADDITIONAL INFORMATION
Catches error if route already exists. Not sure if all params get compared though for that exception to happen.
