### PR TITLE
Bulk import cleanup

### DIFF
--- a/changelogs/fragments/360-imports-cleanup.yml
+++ b/changelogs/fragments/360-imports-cleanup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- various community.aws modules - cleanup of Python imports (https://github.com/ansible-collections/community.aws/pull/360).

--- a/plugins/modules/aws_config_aggregation_authorization.py
+++ b/plugins/modules/aws_config_aggregation_authorization.py
@@ -55,7 +55,6 @@ RETURN = '''#'''
 
 try:
     import botocore
-    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # handled by AnsibleAWSModule
 

--- a/plugins/modules/aws_config_delivery_channel.py
+++ b/plugins/modules/aws_config_delivery_channel.py
@@ -68,7 +68,6 @@ RETURN = '''#'''
 
 try:
     import botocore
-    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # handled by AnsibleAWSModule
 

--- a/plugins/modules/aws_config_delivery_channel.py
+++ b/plugins/modules/aws_config_delivery_channel.py
@@ -72,10 +72,11 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 # this waits for an IAM role to become fully available, at the cost of

--- a/plugins/modules/aws_config_delivery_channel.py
+++ b/plugins/modules/aws_config_delivery_channel.py
@@ -72,8 +72,10 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 # this waits for an IAM role to become fully available, at the cost of

--- a/plugins/modules/aws_config_recorder.py
+++ b/plugins/modules/aws_config_recorder.py
@@ -82,7 +82,6 @@ RETURN = '''#'''
 
 try:
     import botocore
-    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # handled by AnsibleAWSModule
 

--- a/plugins/modules/aws_config_recorder.py
+++ b/plugins/modules/aws_config_recorder.py
@@ -86,10 +86,11 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def resource_exists(client, module, params):

--- a/plugins/modules/aws_config_recorder.py
+++ b/plugins/modules/aws_config_recorder.py
@@ -86,8 +86,10 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def resource_exists(client, module, params):

--- a/plugins/modules/aws_config_rule.py
+++ b/plugins/modules/aws_config_rule.py
@@ -110,7 +110,6 @@ RETURN = '''#'''
 
 try:
     import botocore
-    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # handled by AnsibleAWSModule
 

--- a/plugins/modules/aws_config_rule.py
+++ b/plugins/modules/aws_config_rule.py
@@ -114,10 +114,11 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def rule_exists(client, module, params):

--- a/plugins/modules/aws_config_rule.py
+++ b/plugins/modules/aws_config_rule.py
@@ -114,8 +114,10 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def rule_exists(client, module, params):

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -296,10 +296,10 @@ stack_set:
 
 '''  # NOQA
 
-import time
 import datetime
-import uuid
 import itertools
+import time
+import uuid
 
 try:
     import boto3
@@ -309,13 +309,14 @@ except ImportError:
     # handled by AnsibleAWSModule
     pass
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AWSRetry,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     ansible_dict_to_boto3_tag_list,
-                                                                     camel_dict_to_snake_dict,
-                                                                     )
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
 from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def create_stack_set(module, stack_params, cfn):

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -310,13 +310,13 @@ except ImportError:
     pass
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def create_stack_set(module, stack_params, cfn):

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -302,8 +302,6 @@ import time
 import uuid
 
 try:
-    import boto3
-    import botocore.exceptions
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     # handled by AnsibleAWSModule

--- a/plugins/modules/cloudfront_origin_access_identity.py
+++ b/plugins/modules/cloudfront_origin_access_identity.py
@@ -121,14 +121,9 @@ location:
 '''
 
 import datetime
-from functools import partial
-import json
-import traceback
 
 try:
-    import botocore
     from botocore.exceptions import ClientError, BotoCoreError
-    from botocore.signers import CloudFrontSigner
 except ImportError:
     pass  # caught by imported AnsibleAWSModule
 

--- a/plugins/modules/cloudfront_origin_access_identity.py
+++ b/plugins/modules/cloudfront_origin_access_identity.py
@@ -132,9 +132,10 @@ try:
 except ImportError:
     pass  # caught by imported AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class CloudFrontOriginAccessIdentityServiceManager(object):

--- a/plugins/modules/cloudfront_origin_access_identity.py
+++ b/plugins/modules/cloudfront_origin_access_identity.py
@@ -120,9 +120,6 @@ location:
 
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 import datetime
 from functools import partial
 import json
@@ -130,10 +127,14 @@ import traceback
 
 try:
     import botocore
-    from botocore.signers import CloudFrontSigner
     from botocore.exceptions import ClientError, BotoCoreError
+    from botocore.signers import CloudFrontSigner
 except ImportError:
     pass  # caught by imported AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class CloudFrontOriginAccessIdentityServiceManager(object):

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -100,13 +100,16 @@ metric_filters:
     ]
 
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError, WaiterError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.core import get_boto3_client_method_parameters
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def metricTransformationHandler(metricTransformations, originMetricTransformations=None):

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -106,10 +106,11 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.core import get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def metricTransformationHandler(metricTransformations, originMetricTransformations=None):

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -101,16 +101,9 @@ metric_filters:
 
 """
 
-try:
-    from botocore.exceptions import ClientError, BotoCoreError, WaiterError
-except ImportError:
-    pass  # caught by AnsibleAWSModule
-
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.core import get_boto3_client_method_parameters
 
 
 def metricTransformationHandler(metricTransformations, originMetricTransformations=None):

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -65,8 +65,6 @@ current_status:
   - { "AttributeName": "deploy_timestamp", "Enabled": true }
 '''
 
-import traceback
-
 try:
     import botocore
 except ImportError:

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -135,15 +135,16 @@ image_id:
   sample: ami-e689729e
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
-from ansible.module_utils._text import to_native
-
 try:
     from botocore.exceptions import ClientError, NoCredentialsError, WaiterError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils._text import to_native
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 
 
 def copy_image(module, ec2):

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -136,7 +136,7 @@ image_id:
 '''
 
 try:
-    from botocore.exceptions import ClientError, NoCredentialsError, WaiterError, BotoCoreError
+    from botocore.exceptions import ClientError, WaiterError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
 

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -141,9 +141,9 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 
 

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -110,8 +110,6 @@ gateway.customer_gateways:
 '''
 
 try:
-    from botocore.exceptions import ClientError
-    import boto3
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -116,9 +116,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class Ec2CustomerGatewayManager:

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -84,7 +84,6 @@ try:
     import boto.ec2
     import boto.ec2.autoscale
     import boto.ec2.elb
-    from boto.regioninfo import RegionInfo
 except ImportError:
     pass  # Handled by HAS_BOTO
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -803,12 +803,10 @@ import time
 import uuid
 
 try:
-    import boto3
     import botocore.exceptions
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible.module_utils._text import to_bytes
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -795,12 +795,12 @@ instances:
             sample: vpc-0011223344
 '''
 
+from collections import namedtuple
 import re
-import uuid
 import string
 import textwrap
 import time
-from collections import namedtuple
+import uuid
 
 try:
     import boto3
@@ -808,18 +808,18 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible.module_utils.six import string_types
-from ansible.module_utils.six.moves.urllib import parse as urlparse
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils._text import to_native
+from ansible.module_utils.six import string_types
+from ansible.module_utils.six.moves.urllib import parse as urlparse
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
 
 module = None

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -810,6 +810,8 @@ except ImportError:
 
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.urllib import parse as urlparse
 
@@ -818,9 +820,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
 
 module = None
 

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -507,9 +507,8 @@ instances:
             sample: vpc-0011223344
 '''
 
-import traceback
 import datetime
-
+import traceback
 
 try:
     import boto3

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -508,10 +508,8 @@ instances:
 '''
 
 import datetime
-import traceback
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError
 except ImportError:

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -517,10 +517,11 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def list_ec2_instances(connection, module):

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -152,7 +152,6 @@ user_data:
 '''
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError
 except ImportError:

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -158,8 +158,9 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def list_launch_configs(connection, module):

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -112,13 +112,11 @@ snapshot_id:
 import traceback
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError, WaiterError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -119,9 +119,9 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def copy_snapshot(module, ec2):

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -114,11 +114,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def date_handler(obj):

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -114,10 +114,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 
 def date_handler(obj):

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -113,7 +113,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -116,7 +116,6 @@ import traceback
 
 try:
     import botocore
-    import boto3
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -111,7 +111,6 @@ attributes:
 '''
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError, EndpointConnectionError
 except ImportError:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -107,7 +107,6 @@ status:
 import time
 
 try:
-    import boto3
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -103,6 +103,7 @@ status:
     type: str
     sample: ACTIVE
 '''
+
 import time
 
 try:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -213,9 +213,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils._text import to_text
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils._text import to_text
 
 
 class EcsTaskManager:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -214,9 +214,9 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils._text import to_text
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class EcsTaskManager:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -214,7 +214,6 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -116,7 +116,6 @@ except ImportError:
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 
-# import module snippets
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -114,10 +114,10 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_text
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def create(module, conn, name, group_family, description):

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -108,7 +108,6 @@ changed:
 import traceback
 
 try:
-    import boto3
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -165,7 +165,6 @@ load_balancers:
 import traceback
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError, NoCredentialsError
 except ImportError:

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -172,11 +172,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def get_elb_listeners(connection, module, elb_arn):

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -172,6 +172,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -90,7 +90,6 @@ try:
     import boto.ec2
     import boto.ec2.autoscale
     import boto.ec2.elb
-    from boto.regioninfo import RegionInfo
 except ImportError:
     pass  # Handled by HAS_BOTO
 

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -111,8 +111,8 @@ RETURN = '''
 
 '''
 
-import traceback
 from time import time, sleep
+import traceback
 
 try:
     import boto3
@@ -124,8 +124,8 @@ except ImportError:
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.jittered_backoff(retries=10, delay=10, catch_extra_error_codes=['TargetGroupNotFound'])

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -122,10 +122,10 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.jittered_backoff(retries=10, delay=10, catch_extra_error_codes=['TargetGroupNotFound'])

--- a/plugins/modules/elb_target.py
+++ b/plugins/modules/elb_target.py
@@ -115,7 +115,6 @@ from time import time, sleep
 import traceback
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -217,6 +217,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -217,11 +217,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def get_target_group_attributes(connection, module, target_group_arn):

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -210,7 +210,6 @@ target_groups:
 import traceback
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError, NoCredentialsError
 except ImportError:

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -67,8 +67,9 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def list_mfa_devices(connection, module):

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -61,7 +61,6 @@ EXAMPLES = r'''
 '''
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError
 except ImportError:

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -80,7 +80,6 @@ upload_date:
 
 
 try:
-    import boto3
     import botocore
     import botocore.exceptions
 except ImportError:

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -102,7 +102,6 @@ iam_users:
 '''
 
 try:
-    import botocore
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -101,14 +101,15 @@ iam_users:
             sample: "test_user"
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
-
 try:
     import botocore
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -107,9 +107,10 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -115,10 +115,8 @@ lambda_stream_events:
 '''
 
 import re
-import sys
 
 try:
-    import boto3
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -123,9 +123,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -126,10 +126,9 @@ try:
 except ImportError:
     pass  # Handled by HAS_BOTO
 
-# import module snippets
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 # Things that can't get changed:

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -118,9 +118,7 @@ EXAMPLES = '''
 import uuid
 
 try:
-    import boto
     import boto.ec2
-    from boto import route53
     from boto.route53 import Route53Connection, exception
     from boto.route53.healthcheck import HealthCheck
 except ImportError:

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -204,6 +204,7 @@ EXAMPLES = r'''
         start_record_name: "host1.workshop.test.io"
       register: RECORDS
 '''
+
 try:
     import boto
     import botocore

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -206,9 +206,7 @@ EXAMPLES = r'''
 '''
 
 try:
-    import boto
     import botocore
-    import boto3
 except ImportError:
     pass  # Handled by HAS_BOTO and HAS_BOTO3
 

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -208,13 +208,11 @@ EXAMPLES = r'''
 try:
     import botocore
 except ImportError:
-    pass  # Handled by HAS_BOTO and HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def get_hosted_zone(client, module):
@@ -459,10 +457,6 @@ def main():
     )
     if module._name == 'route53_facts':
         module.deprecate("The 'route53_facts' module has been renamed to 'route53_info'", date='2021-12-01', collection_name='community.aws')
-
-    # Validate Requirements
-    if not (HAS_BOTO or HAS_BOTO3):
-        module.fail_json(msg='json and boto/boto3 is required.')
 
     try:
         route53 = module.client('route53')

--- a/plugins/modules/s3_metrics_configuration.py
+++ b/plugins/modules/s3_metrics_configuration.py
@@ -95,8 +95,6 @@ EXAMPLES = r'''
 '''
 
 try:
-    import boto3
-    import botocore
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/s3_metrics_configuration.py
+++ b/plugins/modules/s3_metrics_configuration.py
@@ -101,8 +101,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 
 
 def _create_metrics_configuration(mc_id, filter_prefix, filter_tags):

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -168,9 +168,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def _create_redirect_dict(url):

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -162,7 +162,6 @@ routing_rules:
 import time
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError, ParamValidationError
 except ImportError:

--- a/plugins/modules/sns.py
+++ b/plugins/modules/sns.py
@@ -131,7 +131,6 @@ message_id:
 """
 
 import json
-import traceback
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -80,7 +80,6 @@ EXAMPLES = '''
 '''
 
 try:
-    import boto3
     import botocore
     from botocore.exceptions import ClientError
 except ImportError:


### PR DESCRIPTION
##### SUMMARY

Various modules were importing things and not using them.  Clean this up.
- Move everything to sorted imports (one import per line)
- Pull camel_dict_to_snake_dict/snake_dict_to_camel_dict from ansible.module_utils.common.dict_transformations
- Remove unused imports

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_config_aggregation_authorization.py
plugins/modules/aws_config_delivery_channel.py
plugins/modules/aws_config_recorder.py
plugins/modules/aws_config_rule.py
plugins/modules/cloudformation_stack_set.py
plugins/modules/cloudfront_origin_access_identity.py
plugins/modules/cloudwatchlogs_log_group_metric_filter.py
plugins/modules/dynamodb_ttl.py
plugins/modules/ec2_ami_copy.py
plugins/modules/ec2_customer_gateway.py
plugins/modules/ec2_elb.py
plugins/modules/ec2_instance.py
plugins/modules/ec2_instance_info.py
plugins/modules/ec2_lc_info.py
plugins/modules/ec2_snapshot_copy.py
plugins/modules/ec2_vpc_endpoint_info.py
plugins/modules/ec2_vpc_vgw.py
plugins/modules/ecs_attribute.py
plugins/modules/ecs_cluster.py
plugins/modules/ecs_taskdefinition.py
plugins/modules/elasticache_parameter_group.py
plugins/modules/elb_application_lb_info.py
plugins/modules/elb_instance.py
plugins/modules/elb_target.py
plugins/modules/elb_target_group_info.py
plugins/modules/iam_mfa_device_info.py
plugins/modules/iam_server_certificate_info.py
plugins/modules/iam_user_info.py
plugins/modules/lambda_event.py
plugins/modules/route53_health_check.py
plugins/modules/route53_info.py
plugins/modules/s3_metrics_configuration.py
plugins/modules/s3_website.py
plugins/modules/sns.py
plugins/modules/sts_session_token.py

##### ADDITIONAL INFORMATION
