### PR TITLE
ec2_vpc_endpoint - deprecate policy_file

### DIFF
--- a/changelogs/fragments/366-ec2_vpc_endpoint-policy_file.yml
+++ b/changelogs/fragments/366-ec2_vpc_endpoint-policy_file.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- ec2_vpc_endpoint - deprecate the policy_file option and recommend using policy with a lookup (https://github.com/ansible-collections/community.aws/pull/366).

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -44,6 +44,9 @@ options:
         on how to use it properly. Cannot be used with I(policy).
       - Option when creating an endpoint. If not provided AWS will
         utilise a default policy which provides full access to the service.
+      - This option has been deprecated and will be removed after 2022-12-01
+        to maintain the existing functionality please use the I(policy) option
+        and a file lookup.
     required: false
     aliases: [ "policy_path" ]
     type: path
@@ -351,6 +354,11 @@ def main():
 
     # Validate Requirements
     state = module.params.get('state')
+
+    if module.params.get('policy_file'):
+        module.deprecate('The policy_file option has been deprecated and'
+                         ' will be removed after 2022-12-01',
+                         date='2022-12-01', collection_name='community.aws')
 
     try:
         ec2 = module.client('ec2')

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -15,6 +15,7 @@ plugins/modules/ec2_instance_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_lc_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_metric_alarm.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_placement_group_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_igw_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_nacl_info.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

Reading policy from policy_file uses a simple open and doesn't follow the standard lookup paths.  Recommend people use policy with a lookup

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_endpoint

##### ADDITIONAL INFORMATION