### PR TITLE
Make iam module more predictable and idempotent …

### DIFF
--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -742,7 +742,7 @@ def main():
                 (user_groups, changed) = set_users_groups(
                     module, iam, name, groups, been_updated, new_name)
             module.exit_json(
-                user_meta=meta, groups=user_groups, keys=keys, changed=changed)
+                user_meta=meta, groups=user_groups, user_name=meta['created_user']['user_name'], keys=keys, changed=changed)
 
         elif state in ['present', 'update'] and user_exists:
             if update_pw == 'on_create':
@@ -778,7 +778,7 @@ def main():
                                  created_keys=new_key, user_meta=user_meta)
             elif new_name and not new_path and not been_updated:
                 module.exit_json(
-                    changed=changed, groups=user_groups, old_user_name=orig_name, new_user_name=new_name, keys=key_list,
+                    changed=changed, groups=user_groups, old_user_name=orig_name, user_name=new_name, new_user_name=new_name, keys=key_list,
                     created_keys=new_key, user_meta=user_meta)
             elif new_name and not new_path and been_updated:
                 module.exit_json(
@@ -802,7 +802,7 @@ def main():
                 try:
                     set_users_groups(module, iam, name, '')
                     name, changed = delete_user(module, iam, name)
-                    module.exit_json(deleted_user=name, changed=changed)
+                    module.exit_json(deleted_user=name, user_name=name, changed=changed)
 
                 except Exception as ex:
                     module.fail_json(changed=changed, msg=str(ex))


### PR DESCRIPTION
…on returning the user_name it creates/deletes

##### SUMMARY
Currently dependending on what the module does (create/update/delete) one has to find the returned user_name in different places (or it won't be returned at all). To make this behaviour more consistent, this patch makes sure that the user name is always returned under the `user_name` key.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iam.py

##### ADDITIONAL INFORMATION
I have gist here with a playbook showcasing the issue: https://gist.github.com/stefanhorning/a948b9f63a5db8a2a38fc988080a13b2

Run it without my patch and you will get arbitrary output (defined/undefined) for the user_name param. Run it with my patch and it will behave predictably and consistent.
