### PR TITLE
Fix passing an instance profile arn to ec2_launch_template

### DIFF
--- a/changelogs/fragments/371-ec2_launch_template-profile-arn.yml
+++ b/changelogs/fragments/371-ec2_launch_template-profile-arn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_launch_template - fixes parameter validation failure when passing a instance profile ARN instead of just the role name (https://github.com/ansible-collections/community.aws/pull/371).

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -410,7 +410,7 @@ except ImportError:
 
 def determine_iam_role(module, name_or_arn):
     if re.match(r'^arn:aws:iam::\d+:instance-profile/[\w+=/,.@-]+$', name_or_arn):
-        return name_or_arn
+        return {'arn': name_or_arn}
     iam = module.client('iam', retry_decorator=AWSRetry.jittered_backoff())
     try:
         role = iam.get_instance_profile(InstanceProfileName=name_or_arn, aws_retry=True)

--- a/tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
@@ -73,6 +73,36 @@
           - 'template_with_updated_role is not changed'
           - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
 
+    - name: Update instance with original instance_role (pass profile ARN)
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_image }}"
+        instance_type: t2.micro
+        # By default an instance profile will be created with the same name as the role
+        iam_instance_profile: '{{ iam_role.arn.replace(":role/", ":instance-profile/") }}'
+      register: template_with_updated_role
+
+    - assert:
+        that:
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_role.default_template.version_number < template_with_updated_role.default_template.version_number'
+          - 'template_with_updated_role is changed'
+          - 'template_with_updated_role is not failed'
+
+    - name: Re-set with same new instance_role (pass profile ARN)
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_image }}"
+        instance_type: t2.micro
+        iam_instance_profile: '{{ iam_role.arn.replace(":role/", ":instance-profile/") }}'
+      register: template_with_updated_role
+
+    - assert:
+        that:
+          - 'template_with_updated_role is not changed'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+
   always:
     - name: delete launch template
       ec2_launch_template:


### PR DESCRIPTION
##### SUMMARY

If the string given on the iam_instance_profile looked like an arn, the
wrong structure format was being returned. boto3 expects a dict of the
format { arn: "{{ arn }}" } but the bare arn string was returned instead.

This fixes this error:
```
Couldn't create subsequent launch template version: Parameter validation failed:
Invalid type for parameter LaunchTemplateData.IamInstanceProfile, value: arn:aws:iam::[...]:instance-profile/[...], type: <class 'str'>, valid types: <class 'dict'>
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.aws.ec2_launch_template