### PR TITLE
Add tag query to lambda_info module

### DIFF
--- a/docs/community.aws.lambda_info_module.rst
+++ b/docs/community.aws.lambda_info_module.rst
@@ -222,6 +222,36 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>max_items</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Maximum number of items to return for various get/list requests.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>next_marker</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Some requests might return a maximum number of entries - EG 100 or the number specified by max_items. If the number of entries exceeds this maximum another request can be sent using the NextMarker entry from the first response to get the next page of results.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>region</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -33,6 +33,16 @@ options:
     description:
       - When I(query=mappings), this is the Amazon Resource Name (ARN) of the Amazon Kinesis or DynamoDB stream.
     type: str
+  max_items:
+    description:
+      - Maximum number of items to return for various get/list requests.
+    type: int
+  next_marker:
+    description:
+      - "Some requests might return a maximum number of entries - EG 100 or the number specified by max_items.
+      If the number of entries exceeds this maximum another request can be sent using the NextMarker entry
+      from the first response to get the next page of results."
+    type: str
 author: Pierre Jodouin (@pjodouin)
 requirements:
     - boto3

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -21,7 +21,7 @@ options:
   query:
     description:
       - Specifies the resource type for which to gather information.  Leave blank to retrieve all information.
-    choices: [ "aliases", "all", "config", "mappings", "policy", "versions" ]
+    choices: [ "aliases", "all", "config", "mappings", "policy", "versions", "tags" ]
     default: "all"
     type: str
   function_name:
@@ -169,6 +169,7 @@ def all_details(client, module):
         lambda_info[function_name].update(policy_details(client, module)[function_name])
         lambda_info[function_name].update(version_details(client, module)[function_name])
         lambda_info[function_name].update(mapping_details(client, module)[function_name])
+        lambda_info[function_name].update(tags_details(client, module)[function_name])
     else:
         lambda_info.update(config_details(client, module))
 
@@ -213,6 +214,7 @@ def config_details(client, module):
 
         functions = dict()
         for func in lambda_info.pop('function_list', []):
+            func['tags'] = client.get_function(FunctionName=func['FunctionName']).get('Tags', {})
             functions[func['FunctionName']] = camel_dict_to_snake_dict(func)
         return functions
 
@@ -321,6 +323,32 @@ def version_details(client, module):
     return {function_name: camel_dict_to_snake_dict(lambda_info)}
 
 
+def tags_details(client, module):
+    """
+    Returns tag details for one or all lambda functions.
+
+    :param client: AWS API client reference (boto3)
+    :param module: Ansible module reference
+    :return dict:
+    """
+
+    lambda_info = dict()
+
+    function_name = module.params.get('function_name')
+    if function_name:
+        try:
+            lambda_info.update(tags=client.get_function(FunctionName=function_name).get('Tags', {}))
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                lambda_info.update(function={})
+            else:
+                module.fail_json_aws(e, msg="Trying to get {0} tags".format(function_name))
+    else:
+        module.fail_json(msg='Parameter function_name required for query=tags.')
+
+    return {function_name: camel_dict_to_snake_dict(lambda_info)}
+
+
 def main():
     """
     Main entry point.
@@ -329,7 +357,9 @@ def main():
     """
     argument_spec = dict(
         function_name=dict(required=False, default=None, aliases=['function', 'name']),
-        query=dict(required=False, choices=['aliases', 'all', 'config', 'mappings', 'policy', 'versions'], default='all'),
+        query=dict(required=False, choices=['aliases', 'all', 'config', 'mappings', 'policy', 'versions', 'tags'], default='all'),
+        max_items=dict(required=False, type='int'),
+        next_marker=dict(required=False),
         event_source_arn=dict(required=False, default=None)
     )
 
@@ -359,6 +389,7 @@ def main():
         mappings='mapping_details',
         policy='policy_details',
         versions='version_details',
+        tags='tags_details',
     )
 
     this_module_function = globals()[invocations[module.params['query']]]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR to add tags query into the `lambda_info` module. It is helpful to be able to query the Lambda function's tag list so we can integrate future actions.
This PR also fix some missing parameter

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- lambda_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
