### PR TITLE
Fix UnboundLocalError in sqs_queue

### DIFF
--- a/changelogs/fragments/389-sqs-queue-UnboundLocalError.yml
+++ b/changelogs/fragments/389-sqs-queue-UnboundLocalError.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- sqs_queue - fix UnboundLocalError when passing a boolean parameter (https://github.com/ansible-collections/community.aws/issues/172).

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -375,7 +375,7 @@ def update_sqs_queue(module, client, queue_url):
 
         if isinstance(new_value, bool):
             new_value = str(new_value).lower()
-            existing_value = str(existing_value).lower()
+            value = str(value).lower()
 
         if new_value == value:
             continue

--- a/tests/integration/targets/sqs_queue/tasks/main.yml
+++ b/tests/integration/targets/sqs_queue/tasks/main.yml
@@ -104,3 +104,25 @@
         with_items:
           - { name: "{{ create_result.name }}" }
           - { name: "{{ dead_letter_queue.name }}" }
+  - name: Test FIFO queue
+    block:
+      - name: Creating FIFO queue
+        sqs_queue:
+          name: "{{ resource_prefix }}{{ 1000 | random }}"
+          queue_type: fifo
+          content_based_deduplication: yes
+        register: create_result
+      - name: Assert queue created with configuration
+        assert:
+          that:
+            - create_result.changed
+    always:
+      - name: Cleaning up queue
+        sqs_queue:
+          name: "{{ item.name }}"
+          state: absent
+        register: delete_result
+        retries: 3
+        delay: 3
+        with_items:
+          - { name: "{{ create_result.name }}" }


### PR DESCRIPTION
##### SUMMARY
The variable `existing_value` is nowhere to be found, but looks like
this might have been missed in a rename. Changing to `value`.

Fixes #172

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
sqs_queue

##### ADDITIONAL INFORMATION
See details in #172
