### PR TITLE
Move community.aws tests from ec2 to ec2_instance

### DIFF
--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/tasks/main.yml
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/tasks/main.yml
@@ -73,14 +73,12 @@
         seconds: 10
 
     - name: Create Linux EC2 instance
-      ec2:
+      ec2_instance:
         instance_type: "{{instance_type}}"
-        image: "{{linux_ami_id}}"
+        image_id: "{{linux_ami_id}}"
         wait: "yes"
-        count: 1
-        instance_profile_name: "{{role_output.iam_role.role_name}}"
-        instance_tags:
-          Name: "{{resource_prefix}}-integration-test-aws-ssm-linux"
+        instance_role: "{{role_output.iam_role.role_name}}"
+        name: "{{resource_prefix}}-integration-test-aws-ssm-linux"
         user_data: |
                     #!/bin/sh
                     sudo systemctl start amazon-ssm-agent
@@ -88,14 +86,12 @@
       register: linux_output
 
     - name: Create Windows EC2 instance
-      ec2:
+      ec2_instance:
         instance_type: "{{instance_type}}"
-        image: "{{windows_ami_id}}"
+        image_id: "{{windows_ami_id}}"
         wait: "yes"
-        count: 1
-        instance_profile_name: "{{role_output.iam_role.role_name}}"
-        instance_tags:
-          Name: "{{resource_prefix}}-integration-test-aws-ssm-windows"
+        instance_role: "{{role_output.iam_role.role_name}}"
+        name: "{{resource_prefix}}-integration-test-aws-ssm-windows"
         user_data: |
                     <powershell>
                     Invoke-WebRequest -Uri "https://amazon-ssm-us-east-1.s3.amazonaws.com/latest/windows_amd64/AmazonSSMAgentSetup.exe" -OutFile "C:\AmazonSSMAgentSetup.exe"

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/ec2_linux_vars_to_delete.yml.j2
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/ec2_linux_vars_to_delete.yml.j2
@@ -1,2 +1,2 @@
 ---
-linux_instance_id: {{linux_output.instance_ids[0]}}
+linux_instance_id: {{ linux_output.instances[0].instance_id }}

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/ec2_windows_vars_to_delete.yml.j2
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/ec2_windows_vars_to_delete.yml.j2
@@ -1,2 +1,2 @@
 ---
-windows_instance_id: {{windows_output.instance_ids[0]}}
+windows_instance_id: {{ windows_output.instances[0].instance_id }}

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/inventory-linux.aws_ssm.j2
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/inventory-linux.aws_ssm.j2
@@ -1,5 +1,5 @@
 [aws_ssm]
-{{linux_output.instance_ids[0]}} ansible_aws_ssm_instance_id={{linux_output.instance_ids[0]}} ansible_aws_ssm_region={{aws_region}}
+{{ linux_output.instances[0].instance_id }} ansible_aws_ssm_instance_id={{ linux_output.instances[0].instance_id }} ansible_aws_ssm_region={{ aws_region }}
 
 [aws_ssm:vars]
 ansible_connection=aws_ssm

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/inventory-windows.aws_ssm.j2
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/inventory-windows.aws_ssm.j2
@@ -1,5 +1,5 @@
 [aws_ssm]
-{{windows_output.instance_ids[0]}} ansible_aws_ssm_instance_id={{windows_output.instance_ids[0]}} ansible_aws_ssm_region={{aws_region}}
+{{ windows_output.instances[0].instance_id }} ansible_aws_ssm_instance_id={{ windows_output.instances[0].instance_id }} ansible_aws_ssm_region={{ aws_regioni }}
 
 [aws_ssm:vars]
 ansible_shell_type=powershell

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown/tasks/main.yml
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown/tasks/main.yml
@@ -51,6 +51,7 @@
         instance_ids:
           - "{{windows_instance_id}}"
         state: absent
+        wait: True
       ignore_errors: yes
       when: ec2_windows_vars_file.stat.exists == true
 
@@ -59,6 +60,7 @@
         instance_ids:
           - "{{linux_instance_id}}"
         state: absent
+        wait: True
       ignore_errors: yes
       when: ec2_linux_vars_file.stat.exists == true
 

--- a/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown/tasks/main.yml
+++ b/tests/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown/tasks/main.yml
@@ -47,7 +47,7 @@
       when: iam_role_vars_file.stat.exists == true
 
     - name: Terminate Windows EC2 instances that were previously launched
-      ec2:
+      ec2_instance:
         instance_ids:
           - "{{windows_instance_id}}"
         state: absent
@@ -55,7 +55,7 @@
       when: ec2_windows_vars_file.stat.exists == true
 
     - name: Terminate Linux EC2 instances that were previously launched
-      ec2:
+      ec2_instance:
         instance_ids:
           - "{{linux_instance_id}}"
         state: absent

--- a/tests/integration/targets/elb_target/playbooks/roles/elb_lambda_target/defaults/main.yml
+++ b/tests/integration/targets/elb_target/playbooks/roles/elb_lambda_target/defaults/main.yml
@@ -1,5 +1,5 @@
 resource_shortprefix: 'ansible-test-{{ resource_prefix | regex_search("([0-9]+)$") }}'
-lambda_role_name: '{{ resource_shortprefix }}-elb-target-lambda'
-#lambda_role_name: '{{ resource_prefix }}-elb-target-lambda'
-lambda_name: '{{ resource_prefix }}-elb-target-lambda'
+lambda_role_name: '{{ resource_shortprefix }}-elb-target'
+#lambda_role_name: '{{ resource_prefix }}-elb-target'
+lambda_name: '{{ resource_prefix }}-elb-target'
 elb_target_group_name: '{{ resource_shortprefix }}-elb-tg'

--- a/tests/integration/targets/elb_target/playbooks/roles/elb_target/tasks/main.yml
+++ b/tests/integration/targets/elb_target/playbooks/roles/elb_target/tasks/main.yml
@@ -129,17 +129,14 @@
           Description: "Created by {{ resource_prefix }}"
 
     - name: set up ec2 instance to use as a target
-      ec2:
-        group_id: "{{ sg.group_id }}"
+      ec2_instance:
+        name: "{{ resource_prefix }}-inst"
+        security_group: "{{ sg.group_id }}"
         instance_type: t3.micro
-        image: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_image }}"
         vpc_subnet_id: "{{ subnet_2.subnet.id }}"
-        instance_tags:
-          Name: "{{ resource_prefix }}-inst"
-        exact_count: 1
-        count_tag:
-          Name: "{{ resource_prefix }}-inst"
-        assign_public_ip: true
+        network:
+          assign_public_ip: true
         volumes: []
         wait: true
         ebs_optimized: false
@@ -153,6 +150,9 @@
             - "service httpd start"
             - echo "HELLO ANSIBLE" > /var/www/html/index.html
       register: ec2
+
+    - set_fact:
+        instance_id: "{{ ec2.instances[0].instance_id }}"
 
     - name: create an application load balancer
       elb_application_lb:
@@ -180,7 +180,7 @@
     - name: register an instance to unused target group
       elb_target:
         target_group_name: "{{ tg_name }}"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: present
       register: result
 
@@ -189,14 +189,14 @@
         that:
           - result.changed
           - result.target_group_arn
-          - result.target_health_descriptions.target.id == ec2.instance_ids[0]
+          - result.target_health_descriptions.target.id == instance_id
 
     # ============================================================
 
     - name: test idempotence
       elb_target:
         target_group_name: "{{ tg_name }}"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: present
       register: result
 
@@ -210,7 +210,7 @@
     - name: remove an unused target
       elb_target:
         target_group_name: "{{ tg_name }}"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: absent
         deregister_unused: true
       register: result
@@ -226,7 +226,7 @@
     - name: register an instance to used target group and wait until healthy
       elb_target:
         target_group_name: "{{ tg_name }}-used"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: present
         target_status: healthy
         target_status_timeout: 400
@@ -237,7 +237,7 @@
         that:
           - result.changed
           - result.target_group_arn
-          - result.target_health_descriptions.target.id == ec2.instance_ids[0]
+          - result.target_health_descriptions.target.id == instance_id
           - result.target_health_descriptions.target_health == healthy_state
 
     # ============================================================
@@ -245,7 +245,7 @@
     - name: remove a target from used target group
       elb_target:
         target_group_name: "{{ tg_name }}-used"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: absent
         target_status: unused
         target_status_timeout: 400
@@ -261,7 +261,7 @@
     - name: test idempotence
       elb_target:
         target_group_name: "{{ tg_name }}-used"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: absent
       register: result
 
@@ -275,7 +275,7 @@
     - name: register an instance to used target group and wait until healthy again to test deregistering differently
       elb_target:
         target_group_name: "{{ tg_name }}-used"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: present
         target_status: healthy
         target_status_timeout: 400
@@ -286,13 +286,13 @@
         that:
           - result.changed
           - result.target_group_arn
-          - result.target_health_descriptions.target.id == ec2.instance_ids[0]
+          - result.target_health_descriptions.target.id == instance_id
           - result.target_health_descriptions.target_health == healthy_state
 
     - name: start deregisteration but don't wait
       elb_target:
         target_group_name: "{{ tg_name }}-used"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: absent
       register: result
 
@@ -305,7 +305,7 @@
     - name: now wait for target to finish deregistering
       elb_target:
         target_group_name: "{{ tg_name }}-used"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: absent
         target_status: unused
         target_status_timeout: 400
@@ -325,20 +325,9 @@
       debug: msg="********** Tearing down elb_target test dependencies **********"
 
     - name: remove ec2 instance
-      ec2:
-        group_id: "{{ sg.group_id }}"
-        instance_type: t2.micro
-        image: "{{ ec2_ami_image }}"
-        vpc_subnet_id: "{{ subnet_2.subnet.id }}"
-        instance_tags:
-          Name: "{{ resource_prefix }}-inst"
-        exact_count: 0
-        count_tag:
-          Name: "{{ resource_prefix }}-inst"
-        assign_public_ip: true
-        volumes: []
-        wait: true
-        ebs_optimized: false
+      ec2_instance:
+        name: "{{ resource_prefix }}-inst"
+        state: absent
       ignore_errors: true
 
     - name: remove testing target groups

--- a/tests/integration/targets/elb_target/playbooks/roles/elb_target/tasks/main.yml
+++ b/tests/integration/targets/elb_target/playbooks/roles/elb_target/tasks/main.yml
@@ -328,6 +328,7 @@
       ec2_instance:
         name: "{{ resource_prefix }}-inst"
         state: absent
+        wait: True
       ignore_errors: true
 
     - name: remove testing target groups
@@ -469,5 +470,6 @@
       register: removed
       retries: 10
       until: removed is not failed
+      ignore_errors: true
 
     # ============================================================

--- a/tests/integration/targets/elb_target_info/playbooks/roles/elb_target_info/tasks/main.yml
+++ b/tests/integration/targets/elb_target_info/playbooks/roles/elb_target_info/tasks/main.yml
@@ -136,17 +136,14 @@
           Description: "Created by {{ resource_prefix }}"
 
     - name: set up ec2 instance to use as a target
-      ec2:
-        group_id: "{{ sg.group_id }}"
-        instance_type: t2.micro
-        image: "{{ ec2_ami_image }}"
+      ec2_instance:
+        name: "{{ resource_prefix }}-inst"
+        security_group: "{{ sg.group_id }}"
+        instance_type: t3.micro
+        image_id: "{{ ec2_ami_image }}"
         vpc_subnet_id: "{{ subnet_2.subnet.id }}"
-        instance_tags:
-          Name: "{{ resource_prefix }}-inst"
-        exact_count: 1
-        count_tag:
-          Name: "{{ resource_prefix }}-inst"
-        assign_public_ip: true
+        network:
+          assign_public_ip: true
         volumes: []
         wait: true
         ebs_optimized: false
@@ -160,6 +157,9 @@
             - "service httpd start"
             - echo "HELLO ANSIBLE" > /var/www/html/index.html
       register: ec2
+
+    - set_fact:
+        instance_id: "{{ ec2.instances[0].instance_id }}"
 
     - name: create an application load balancer
       elb_application_lb:
@@ -195,14 +195,14 @@
     - name: register with the ALB
       elb_target:
         target_group_name: "{{ tg_name }}-inst"
-        target_id: "{{ ec2.instance_ids[0] }}"
+        target_id: "{{ instance_id }}"
         state: present
         target_status: "initial"
 
     - name: register with the NLB IP target group
       elb_target:
         target_group_name: "{{ tg_name }}-ip"
-        target_id: "{{ ec2.instances[0].private_ip }}"
+        target_id: "{{ ec2.instances[0].private_ip_address }}"
         state: present
         target_status: "initial"
 
@@ -213,7 +213,7 @@
     # ============================================================
     - name: gather facts
       elb_target_info:
-        instance_id: "{{ ec2.instance_ids[0]}}"
+        instance_id: "{{ instance_id }}"
       register: target_facts
 
     - assert:
@@ -228,13 +228,13 @@
     - name: register with unused target group
       elb_target:
         target_group_name: "{{ tg_name }}-idle"
-        target_id: "{{ ec2.instance_ids[0]}}"
+        target_id: "{{ instance_id }}"
         state: present
         target_status: "unused"
 
     - name: gather facts again, including the idle group
       elb_target_info:
-        instance_id: "{{ ec2.instance_ids[0]}}"
+        instance_id: "{{ instance_id }}"
       register: target_facts
 
     - assert:
@@ -247,7 +247,7 @@
 
     - name: gather facts again, this time excluding the idle group
       elb_target_info:
-        instance_id: "{{ ec2.instance_ids[0]}}"
+        instance_id: "{{ instance_id }}"
         get_unused_target_groups: false
       register: target_facts
 
@@ -263,14 +263,14 @@
       elb_target:
         target_group_name: "{{ tg_name }}-ip"
         target_port: 22
-        target_id: "{{ ec2.instances[0].private_ip }}"
+        target_id: "{{ ec2.instances[0].private_ip_address }}"
         state: present
         target_status: "healthy"
         target_status_timeout: 400
 
     - name: gather facts
       elb_target_info:
-        instance_id: "{{ ec2.instance_ids[0] }}"
+        instance_id: "{{ instance_id }}"
         get_unused_target_groups: false
       register: target_facts
 
@@ -305,7 +305,7 @@
     - name: wait for all targets to deregister simultaneously
       elb_target_info:
         get_unused_target_groups: false
-        instance_id: "{{ ec2.instance_ids[0] }}"
+        instance_id: "{{ instance_id }}"
       register: target_facts
       until: (target_facts.instance_target_groups | length) == 0
       retries: 60
@@ -328,7 +328,7 @@
     - name: wait for registration
       elb_target_info:
         get_unused_target_groups: false
-        instance_id: "{{ ec2.instance_ids[0] }}"
+        instance_id: "{{ instance_id }}"
       register: target_facts
       until: >
                 (target_facts.instance_target_groups |
@@ -361,20 +361,9 @@
       debug: msg="********** Tearing down elb_target_info test dependencies **********"
 
     - name: remove ec2 instance
-      ec2:
-        group_id: "{{ sg.group_id }}"
-        instance_type: t2.micro
-        image: "{{ ec2_ami_image }}"
-        vpc_subnet_id: "{{ subnet_2.subnet.id }}"
-        instance_tags:
-          Name: "{{ resource_prefix }}-inst"
-        exact_count: 0
-        count_tag:
-          Name: "{{ resource_prefix }}-inst"
-        assign_public_ip: true
-        volumes: []
-        wait: true
-        ebs_optimized: false
+      ec2_instance:
+        name: "{{ resource_prefix }}-inst"
+        state: absent
       ignore_errors: true
 
     - name: remove application load balancer

--- a/tests/integration/targets/elb_target_info/playbooks/roles/elb_target_info/tasks/main.yml
+++ b/tests/integration/targets/elb_target_info/playbooks/roles/elb_target_info/tasks/main.yml
@@ -364,6 +364,7 @@
       ec2_instance:
         name: "{{ resource_prefix }}-inst"
         state: absent
+        wait: True
       ignore_errors: true
 
     - name: remove application load balancer
@@ -492,5 +493,6 @@
       register: removed
       retries: 10
       until: removed is not failed
+      ignore_errors: True
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY

The ec2 module is boto v2 based and we want to deprecate it.  Move our tests over to ec2_instance

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

elb_target
elb_target_info
aws_ssm connection plugin

##### ADDITIONAL INFORMATION
