### PR TITLE
Added assignPublicIp param in network_configuration

### DIFF
--- a/changelogs/fragments/395_add_assign_public_ip.yaml
+++ b/changelogs/fragments/395_add_assign_public_ip.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ecs_task - added ``assign_public_ip`` option for network_configuration (https://github.com/ansible-collections/community.aws/pull/395).

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -406,7 +406,7 @@ def main():
     service_mgr = EcsExecManager(module)
 
     if module.params['network_configuration']:
-        if module.params['network_configuration']['assignPublicIp'] and not service_mgr.ecs_api_handles_network_configuration_assignIp():
+        if 'assignPublicIp' in module.params['network_configuration'] and not service_mgr.ecs_api_handles_network_configuration_assignIp():
             module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
         elif not service_mgr.ecs_api_handles_network_configuration():
             module.fail_json(msg='botocore needs to be version 1.7.44 or higher to use network configuration')

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -70,6 +70,7 @@ options:
             assign_public_ip:
                 description: Whether the task's elastic network interface receives a public IP address.
                 type: bool
+                version_added: 1.5.0
             subnets:
                 description: A list of subnet IDs to which the task is attached.
                 type: list

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -338,29 +338,26 @@ class EcsExecManager:
         return response['task']
 
     def ecs_api_handles_launch_type(self):
-        from distutils.version import LooseVersion
         # There doesn't seem to be a nice way to inspect botocore to look
         # for attributes (and networkConfiguration is not an explicit argument
         # to e.g. ecs.run_task, it's just passed as a keyword argument)
-        return LooseVersion(botocore.__version__) >= LooseVersion('1.8.4')
+        return self.module.botocore_at_least('1.8.4')
 
     def ecs_task_long_format_enabled(self):
         account_support = self.ecs.list_account_settings(name='taskLongArnFormat', effectiveSettings=True)
         return account_support['settings'][0]['value'] == 'enabled'
 
     def ecs_api_handles_tags(self):
-        from distutils.version import LooseVersion
         # There doesn't seem to be a nice way to inspect botocore to look
         # for attributes (and networkConfiguration is not an explicit argument
         # to e.g. ecs.run_task, it's just passed as a keyword argument)
-        return LooseVersion(botocore.__version__) >= LooseVersion('1.12.46')
+        return self.module.botocore_at_least('1.12.46')
 
     def ecs_api_handles_network_configuration(self):
-        from distutils.version import LooseVersion
         # There doesn't seem to be a nice way to inspect botocore to look
         # for attributes (and networkConfiguration is not an explicit argument
         # to e.g. ecs.run_task, it's just passed as a keyword argument)
-        return LooseVersion(botocore.__version__) >= LooseVersion('1.7.44')
+        return self.module.botocore_at_least('1.7.44')
 
 
 def main():
@@ -470,4 +467,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -405,10 +405,10 @@ def main():
 
     service_mgr = EcsExecManager(module)
 
-    if module.params['network_configuration'] and not service_mgr.ecs_api_handles_network_configuration():
+    if module.params['network_configuration']:
         if module.params['network_configuration']['assignPublicIp'] and not service_mgr.ecs_api_handles_network_configuration_assignIp():
             module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
-        else:
+        elif not service_mgr.ecs_api_handles_network_configuration():
             module.fail_json(msg='botocore needs to be version 1.7.44 or higher to use network configuration')
 
     if module.params['launch_type'] and not service_mgr.ecs_api_handles_launch_type():

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -268,13 +268,13 @@ class EcsExecManager:
                     self.module.fail_json_aws(e, msg="Couldn't look up security groups")
             result['securityGroups'] = groups
         if 'assign_public_ip' in network_config:
-           if self.module.botocore_at_least('1.8.4'):
-               if network_config['assign_public_ip'] is True:
+            if self.module.botocore_at_least('1.8.4'):
+                if network_config['assign_public_ip'] is True:
                     result['assignPublicIp'] = "ENABLED"
-               else:
+                else:
                     result['assignPublicIp'] = "DISABLED"
-           else:
-               self.module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
+            else:
+                self.module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
 
         return dict(awsvpcConfiguration=result)
 

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -356,7 +356,7 @@ class EcsExecManager:
         # for attributes (and networkConfiguration is not an explicit argument
         # to e.g. ecs.run_task, it's just passed as a keyword argument)
         return self.module.botocore_at_least('1.7.44')
-    
+
     def ecs_api_handles_network_configuration_assignIp(self):
         # There doesn't seem to be a nice way to inspect botocore to look
         # for attributes (and networkConfiguration is not an explicit argument

--- a/tests/integration/targets/ecs_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/full_test.yml
@@ -772,7 +772,6 @@
             - '{{ setup_sg.group_id }}'
           assign_public_ip: false
         started_by: ansible_user
-        <<: *aws_connection_info
       register: fargate_run_task_output_with_assign_ip
 
 

--- a/tests/integration/targets/ecs_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/full_test.yml
@@ -759,6 +759,22 @@
         started_by: ansible_user
       register: fargate_run_task_output_with_tags
 
+      - name: create fargate ECS task with run task and assign public ip disable
+      ecs_task:
+        operation: run
+        cluster: "{{ ecs_cluster_name }}"
+        task_definition: "{{ ecs_task_name }}-vpc"
+        launch_type: FARGATE
+        count: 1
+        network_configuration:
+          subnets: "{{ setup_subnet.results | community.general.json_query('[].subnet.id') }}"
+          security_groups:
+            - '{{ setup_sg.group_id }}'
+          assign_public_ip: false
+        started_by: ansible_user
+        <<: *aws_connection_info
+      register: fargate_run_task_output_with_tags
+
 
     # ============================================================
     # End tests for Fargate

--- a/tests/integration/targets/ecs_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/full_test.yml
@@ -773,7 +773,7 @@
           assign_public_ip: false
         started_by: ansible_user
         <<: *aws_connection_info
-      register: fargate_run_task_output_with_tags
+      register: fargate_run_task_output_with_assign_ip
 
 
     # ============================================================

--- a/tests/integration/targets/ecs_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/full_test.yml
@@ -759,7 +759,7 @@
         started_by: ansible_user
       register: fargate_run_task_output_with_tags
 
-      - name: create fargate ECS task with run task and assign public ip disable
+    - name: create fargate ECS task with run task and assign public ip disable
       ecs_task:
         operation: run
         cluster: "{{ ecs_cluster_name }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes: #319 
Added assignPublicIp support in `network_configuration` to the existing ecs_task module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
- ecs_task
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: RUN a task on Fargate with public ip assigned
  community.aws.ecs_task:
      operation: run
      count: 2
      cluster: console-sample-app-static-cluster
      task_definition: console-sample-app-static-taskdef
      task: "arn:aws:ecs:us-west-2:172139249013:task/3f8353d1-29a8-4689-bbf6-ad79937ffe8a"
      started_by: ansible_user
      launch_type: FARGATE
      network_configuration:
        assign_public_ip: yes
        subnets:
        - subnet-abcd1234
  register: task_output

```
