### PR TITLE
ec2_vpc_nacl: add IPv6 support

### DIFF
--- a/changelogs/fragments/398-ec2-vpc-nacl-add-ipv6.yaml
+++ b/changelogs/fragments/398-ec2-vpc-nacl-add-ipv6.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_vpc_nacl - add support for IPv6 (https://github.com/ansible-collections/community.aws/pull/398).

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
@@ -62,7 +62,7 @@
         ingress:
           - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
           - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-          - [205, 'ipv6-tcp', 'allow', '::/0', null, null, 80, 80]
+          - [205, 'tcp', 'allow', '::/0', null, null, 80, 80]
           - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
           - [305, 'ipv6-icmp', 'allow', '::/0', 0, 8]
         egress:
@@ -70,20 +70,24 @@
           - [105, 'all', 'allow', '::/0', null, null, null, null]
         state: 'present'
       register: nacl
-      # FIXME: Currently IPv6 rules are not supported - uncomment assertion when
-      # fixed (and add some nacl_info tests)
-      ignore_errors: yes
+
+    - assert:
+       that:
+         - nacl.changed
+         - nacl.nacl_id == nacl_id
+
     - name: get network ACL facts (test that it works with ipv6 entries)
       ec2_vpc_nacl_info:
         nacl_ids:
           - "{{ nacl_id }}"
       register: nacl_facts
 
-
-    #- assert:
-    #    that:
-    #      - nacl.changed
-    #      - nacl.nacl_id == nacl_id
+    - name: assert the nacl has the correct attributes
+      assert:
+        that:
+          - nacl_facts.nacls | length == 1
+          - nacl_facts.nacls[0].ingress | length == 5
+          - nacl_facts.nacls[0].egress | length == 2
 
     - name: purge ingress entries
       ec2_vpc_nacl:
@@ -99,14 +103,11 @@
           - [105, 'all', 'allow', '::/0', null, null, null, null]
         state: 'present'
       register: nacl
-      # FIXME: Currently IPv6 rules are not supported - uncomment assertion when
-      # fixed (and add some nacl_info tests)
-      ignore_errors: yes
 
-    #- assert:
-    #    that:
-    #      - nacl.changed
-    #      - nacl.nacl_id == nacl_id
+    - assert:
+       that:
+         - nacl.changed
+         - nacl.nacl_id == nacl_id
 
     - name: purge egress entries
       ec2_vpc_nacl:
@@ -124,6 +125,19 @@
     - assert:
         that:
           - nacl.changed
+
+    - name: get network ACL facts (test that removed entries are gone)
+      ec2_vpc_nacl_info:
+        nacl_ids:
+          - "{{ nacl_id }}"
+      register: nacl_facts
+
+    - name: assert the nacl has the correct attributes
+      assert:
+        that:
+          - nacl_facts.nacls | length == 1
+          - nacl_facts.nacls[0].ingress | length == 0
+          - nacl_facts.nacls[0].egress | length == 0
 
     # ============================================================
     - name: remove subnet ipv6 cidr (expected changed=true)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for IPv6 in `ec2_vpc_nacl`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This follows an old PR: https://github.com/ansible/ansible/pull/50004.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_nacl.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I'm not a Python programmer and will be happy to receive feedback on this PR 😃.

In this PR, I have:

- updated `ec2_vpc_nacl.py` to detect if the provided CIDR is an IPv6 or not and provide the correct value to boto.
- updated the ipv6 tests of `ec2_vpc_nacl` module.

It seems to me that the tests are failing for an unrelated reason to this PR as reported in https://github.com/ansible-collections/community.aws/issues/153.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
