### PR TITLE
Fix parameter validation in ecs_task

### DIFF
--- a/changelogs/fragments/402-ecs_task-mandatory_params.yml
+++ b/changelogs/fragments/402-ecs_task-mandatory_params.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- ecs_task - use `required_if` to enforce mandatory parameters based on specified operation (https://github.com/ansible-collections/community.aws/pull/402).

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -19,6 +19,9 @@ options:
     operation:
         description:
             - Which task operation to execute.
+            - When I(operation=run) I(task_definition) must be set.
+            - When I(operation=start) both I(task_definition) and I(container_instances) must be set.
+            - When I(operation=stop) both I(task_definition) and I(task) must be set.
         required: True
         choices: ['run', 'start', 'stop']
         type: str
@@ -345,28 +348,24 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True,
-                              required_if=[('launch_type', 'FARGATE', ['network_configuration'])])
+                              required_if=[
+                                  ('launch_type', 'FARGATE', ['network_configuration']),
+                                  ('operation', 'run', ['task_definition']),
+                                  ('operation', 'start', ['task_definition', 'container_instances']),
+                                  ('operation', 'stop', ['task_definition', 'task']),
+                              ]
+                             )
 
     # Validate Inputs
     if module.params['operation'] == 'run':
-        if module.params['task_definition'] is None:
-            module.fail_json(msg="To run a task, a task_definition must be specified")
         task_to_list = module.params['task_definition']
         status_type = "RUNNING"
 
     if module.params['operation'] == 'start':
-        if module.params['task_definition'] is None:
-            module.fail_json(msg="To start a task, a task_definition must be specified")
-        if module.params['container_instances'] is None:
-            module.fail_json(msg="To start a task, container instances must be specified")
         task_to_list = module.params['task']
         status_type = "RUNNING"
 
     if module.params['operation'] == 'stop':
-        if module.params['task'] is None:
-            module.fail_json(msg="To stop a task, a task must be specified")
-        if module.params['task_definition'] is None:
-            module.fail_json(msg="To stop a task, a task definition must be specified")
         task_to_list = module.params['task_definition']
         status_type = "STOPPED"
 

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -351,10 +351,12 @@ def main():
                               required_if=[
                                   ('launch_type', 'FARGATE', ['network_configuration']),
                                   ('operation', 'run', ['task_definition']),
-                                  ('operation', 'start', ['task_definition', 'container_instances']),
+                                  ('operation', 'start', [
+                                      'task_definition',
+                                      'container_instances'
+                                  ]),
                                   ('operation', 'stop', ['task_definition', 'task']),
-                              ]
-                             )
+                              ])
 
     # Validate Inputs
     if module.params['operation'] == 'run':

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -25,7 +25,7 @@ options:
     cluster:
         description:
             - The name of the cluster to run the task on.
-        required: False
+        required: True
         type: str
     task_definition:
         description:
@@ -332,7 +332,7 @@ class EcsExecManager:
 def main():
     argument_spec = dict(
         operation=dict(required=True, choices=['run', 'start', 'stop']),
-        cluster=dict(required=False, type='str'),  # R S P
+        cluster=dict(required=True, type='str'),  # R S P
         task_definition=dict(required=False, type='str'),  # R* S*
         overrides=dict(required=False, type='dict'),  # R S
         count=dict(required=False, type='int'),  # R

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -29,7 +29,7 @@ options:
         type: str
     task_definition:
         description:
-            - The task definition to start or run.
+            - The task definition to start, run or stop.
         required: False
         type: str
     overrides:
@@ -44,7 +44,7 @@ options:
         type: int
     task:
         description:
-            - The task to stop.
+            - The ARN of the task to stop.
         required: False
         type: str
     container_instances:
@@ -349,23 +349,23 @@ def main():
 
     # Validate Inputs
     if module.params['operation'] == 'run':
-        if 'task_definition' not in module.params and module.params['task_definition'] is None:
+        if module.params['task_definition'] is None:
             module.fail_json(msg="To run a task, a task_definition must be specified")
         task_to_list = module.params['task_definition']
         status_type = "RUNNING"
 
     if module.params['operation'] == 'start':
-        if 'task_definition' not in module.params and module.params['task_definition'] is None:
+        if module.params['task_definition'] is None:
             module.fail_json(msg="To start a task, a task_definition must be specified")
-        if 'container_instances' not in module.params and module.params['container_instances'] is None:
+        if module.params['container_instances'] is None:
             module.fail_json(msg="To start a task, container instances must be specified")
         task_to_list = module.params['task']
         status_type = "RUNNING"
 
     if module.params['operation'] == 'stop':
-        if 'task' not in module.params and module.params['task'] is None:
+        if module.params['task'] is None:
             module.fail_json(msg="To stop a task, a task must be specified")
-        if 'task_definition' not in module.params and module.params['task_definition'] is None:
+        if module.params['task_definition'] is None:
             module.fail_json(msg="To stop a task, a task definition must be specified")
         task_to_list = module.params['task_definition']
         status_type = "STOPPED"


### PR DESCRIPTION
##### SUMMARY
Fixes incorrect logic in parameter validation.

```python
if 'task_definition' not in module.params and module.params['task_definition'] is None:
    module.fail_json(msg="To stop a task, a task definition must be specified")
```
This will not evaluate to true even if `task_definition` not provided because `module.params['task_definiton'] = None` by default. Which means the condition 'task_definition' not in module.params is always false.


Fixes #401 


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ecs_task
