### PR TITLE
fix wrong element spec for rules param in aws_s3_cors

### DIFF
--- a/changelogs/fragments/404-fix-dict-element-for-rule-param-in-aws-s3-cors.yml
+++ b/changelogs/fragments/404-fix-dict-element-for-rule-param-in-aws-s3-cors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_s3_cors - fix element type for rules parameter. (https://github.com/ansible-collections/community.aws/pull/408).

--- a/plugins/modules/aws_s3_cors.py
+++ b/plugins/modules/aws_s3_cors.py
@@ -25,7 +25,7 @@ options:
     description:
       - Cors rules to put on the s3 bucket
     type: list
-    elements: str
+    elements: dict
   state:
     description:
       - Create or remove cors on the s3 bucket

--- a/plugins/modules/aws_s3_cors.py
+++ b/plugins/modules/aws_s3_cors.py
@@ -147,7 +147,7 @@ def main():
 
     argument_spec = dict(
         name=dict(required=True, type='str'),
-        rules=dict(type='list', elements='str'),
+        rules=dict(type='list', elements='dict'),
         state=dict(type='str', choices=['present', 'absent'], required=True)
     )
 


### PR DESCRIPTION
##### SUMMARY
Closes: #404 



##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
aws_s3_cors

##### ADDITIONAL INFORMATION

Element type of `rules` is type `dict`.
