### PR TITLE
ec2_launch_template - scrub None parameters from what we'll pass to create_launch_config

### DIFF
--- a/changelogs/fragments/230-ec2_launch_template-None-types.yml
+++ b/changelogs/fragments/230-ec2_launch_template-None-types.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_launch_template - ensure that empty parameters are properly removed before passing to AWS (https://github.com/ansible-collections/community.aws/issues/230). 

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -398,6 +398,7 @@ from ansible.module_utils.common.dict_transformations import snake_dict_to_camel
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.core import scrub_none_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
@@ -512,6 +513,7 @@ def create_or_update(module, template_options):
     template, template_versions = existing_templates(module)
     out = {}
     lt_data = params_to_launch_data(module, dict((k, v) for k, v in module.params.items() if k in template_options))
+    lt_data = scrub_none_parameters(lt_data, descend_into_lists=True)
     if not (template or template_versions):
         # create a full new one
         try:

--- a/tests/integration/targets/ec2_launch_template/tasks/main.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/main.yml
@@ -45,6 +45,7 @@
     - include_tasks: iam_instance_role.yml
     - include_tasks: versions.yml
     - include_tasks: instance-metadata.yml
+    - include_tasks: network_interfaces.yml
 
   always:
 

--- a/tests/integration/targets/ec2_launch_template/tasks/network_interfaces.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/network_interfaces.yml
@@ -1,0 +1,53 @@
+- block:
+  - name: network_interfaces
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-test-nic"
+      state: present
+      network_interfaces:
+        - device_index: 0
+          associate_public_ip_address: false
+          delete_on_termination: true
+        - device_index: 1
+          associate_public_ip_address: true
+          delete_on_termination: false
+          ipv6_address_count: 1
+    register: nic_template
+  - name: instance with network_interfaces created with the right settings
+    assert:
+      that:
+        - nic_template is changed
+        - nic_template.default_template.launch_template_data.network_interfaces[0].associate_public_ip_address == False
+        - nic_template.default_template.launch_template_data.network_interfaces[0].delete_on_termination == True
+        - nic_template.default_template.launch_template_data.network_interfaces[0].device_index == 0
+        - nic_template.default_template.launch_template_data.network_interfaces[1].associate_public_ip_address == True
+        - nic_template.default_template.launch_template_data.network_interfaces[1].delete_on_termination == False
+        - nic_template.default_template.launch_template_data.network_interfaces[1].device_index == 1
+        - nic_template.default_template.launch_template_data.network_interfaces[1].ipv6_address_count == 1
+
+  - name: network_interfaces
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-test-nic"
+      state: present
+      network_interfaces:
+        - device_index: 0
+          associate_public_ip_address: false
+          delete_on_termination: true
+        - device_index: 1
+          associate_public_ip_address: true
+          delete_on_termination: false
+          ipv6_address_count: 1
+    register: nic_template
+  - name: instance with network_interfaces created with the right settings
+    assert:
+      that:
+        - nic_template is not changed
+
+  always:
+  - name: delete the template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-test-nic"
+      state: absent
+    register: del_lt
+    retries: 10
+    until: del_lt is not failed
+    ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Because we now define suboptions for network configuration we need to make sure that when some of them are None we remove them.

Depends on: https://github.com/ansible-collections/amazon.aws/pull/262

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_launch_template

##### ADDITIONAL INFORMATION

todo:
- [x] changelog
- [x] integration tests