### PR TITLE
rds_instance: map Tags parameters from dict to list on restore_db_instance_from_db_snapshot method

### DIFF
--- a/changelogs/fragments/414-rds_instance-tags-on-creation-from-snapshot.yml
+++ b/changelogs/fragments/414-rds_instance-tags-on-creation-from-snapshot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- rds_instance - fixes bug preventing the use of tags when creating an RDS instance from a snapshot (https://github.com/ansible-collections/community.aws/issues/530).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -844,7 +844,7 @@ def get_parameters(client, module, parameters, method_name):
     if parameters.get('ProcessorFeatures') == [] and not method_name == 'modify_db_instance':
         parameters.pop('ProcessorFeatures')
 
-    if method_name == 'create_db_instance' or method_name == 'create_db_instance_read_replica':
+    if method_name in ['create_db_instance', 'create_db_instance_read_replica', 'restore_db_instance_from_db_snapshot']:
         if parameters.get('Tags'):
             parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
 


### PR DESCRIPTION
##### SUMMARY

Map the `parameters['Tags']` from dict to list with `ansible_dict_to_boto3_tag_list` on `restore_db_instance_from_db_snapshot` method, additionally to existing `create_db_instance` and `create_db_instance_read_replica` methods.

This change will fix the case when db is created from the snaphot and the `tags` parameter is specified on `rds_instance` module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rds_instance.py

##### ADDITIONAL INFORMATION

Before the fix, the error is thrown by module:

```
fatal: [rds -> 127.0.0.1]: FAILED! => changed=false 
  boto3_version: 1.11.6
  botocore_version: 1.14.6
  msg: |-
    Unexpected failure for method restore_db_instance_from_db_snapshot with parameters {'Engine': 'MySQL', 'AutoMinorVersionUpgrade': False, 'VpcSecurityGroupIds': ['sg-12345'], 'StorageType': 'gp2', 'DBInstanceIdentifier': 'examplemysql', 'DBInstanceClass': 'db.t3.small', 'DBName': 'examplemysql', 'DBSubnetGroupName': 'subnetgroup', 'MultiAZ': False, 'DBParameterGroupName': 'examplemysql-pg', 'DBSnapshotIdentifier': 'examplemysql-snapshot', 'Tags': {'foo': 'bar', 'env': 'dev'}}: Parameter validation failed:
    Invalid type for parameter Tags, value: {'foo': 'bar', 'env': 'dev'}, type: <class 'dict'>, valid types: <class 'list'>, <class 'tuple'>
```
