### PR TITLE
Enable AWSRetry on aws_region_info

### DIFF
--- a/changelogs/fragments/422-aws_region_info-retry.yml
+++ b/changelogs/fragments/422-aws_region_info-retry.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_region_info - Add retries on common AWS failures (https://github.com/ansible-collections/community.aws/pull/422).

--- a/plugins/modules/aws_region_info.py
+++ b/plugins/modules/aws_region_info.py
@@ -58,7 +58,9 @@ regions:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
@@ -86,6 +88,7 @@ def main():
 
     try:
         regions = connection.describe_regions(
+            aws_retry=True,
             Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
         )
     except (BotoCoreError, ClientError) as e:


### PR DESCRIPTION
##### SUMMARY

While the decorator was added to aws_region_info we didn't add the aws_retry=True to the client call.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_region_info

##### ADDITIONAL INFORMATION
