### PR TITLE
Fix state=get on route53 module (Issue #423)

### DIFF
--- a/changelogs/fragments/406-route53-state-get.yml
+++ b/changelogs/fragments/406-route53-state-get.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- route53 - fix when using `state=get` on private DNS zones and add tests to cover this scenario (https://github.com/ansible-collections/community.aws/pull/424).
+- route53 - fix when using ``state=get`` on private DNS zones and add tests to cover this scenario (https://github.com/ansible-collections/community.aws/pull/424).

--- a/changelogs/fragments/406-route53-state-get.yml
+++ b/changelogs/fragments/406-route53-state-get.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- route53 - fix when using `state=get` on private DNS zones and add tests to cover this scenario (https://github.com/ansible-collections/community.aws/pull/424).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -423,6 +423,17 @@ def get_zone_id_by_name(route53, module, zone_name, want_private, want_vpc_id):
     return None
 
 
+def get_hosted_zone_nameservers(route53, zone_id):
+    hosted_zone_name = route53.get_hosted_zone(aws_retry=True, Id=zone_id)['HostedZone']['Name']
+    resource_records_sets = _list_record_sets(route53, HostedZoneId=zone_id)
+
+    nameservers_records = list(
+        filter(lambda record: record['Name'] == hosted_zone_name and record['Type'] == 'NS', resource_records_sets)
+    )[0]['ResourceRecords']
+
+    return [ns_record['Value'] for ns_record in nameservers_records]
+
+
 def main():
     argument_spec = dict(
         state=dict(type='str', required=True, choices=['absent', 'create', 'delete', 'get', 'present'], aliases=['command']),
@@ -564,7 +575,7 @@ def main():
             ns = aws_record.get('values', [])
         else:
             # Retrieve name servers associated to the zone.
-            ns = route53.get_hosted_zone(aws_retry=True, Id=zone_id)['DelegationSet']['NameServers']
+            ns = get_hosted_zone_nameservers(route53, zone_id)
 
         module.exit_json(changed=False, set=aws_record, nameservers=ns)
 

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -52,6 +52,20 @@
         - qdn is not failed
         - qdn is changed
 
+  - name: Get A record using 'get' method of route53 module
+    route53:
+      state: get
+      zone: "{{ zone_one }}"
+      record: "qdn_test.{{ zone_one }}"
+      type: A
+    register: get_result
+  - assert:
+      that:
+        - get_result.nameservers|length > 0
+        - get_result.set.Name == "qdn_test.{{ zone_one }}"
+        - get_result.set.ResourceRecords[0].Value == "1.2.3.4"
+        - get_result.set.Type == "A"
+
   - name: Create same A record using zone non-qualified domain
     route53:
       state: present


### PR DESCRIPTION
https://github.com/ansible-collections/community.aws/issues/423 This bug was introduced when refactoring from boto to boto3 library. This happens because the method "get_hosted_zone" only returns the DelegationSet when the DNS zone is external. Therefore this breaks when trying to get internal records.

The solution is to search for getting DNS records of type ''NS'' with the same name as the hosted zone.

Also, I added a test to cover this case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- route53