### PR TITLE
Yet more integration test aliases file cleanup

### DIFF
--- a/tests/integration/targets/aws_acm/aliases
+++ b/tests/integration/targets/aws_acm/aliases
@@ -1,4 +1,7 @@
-cloud/aws
-aws_acm_info
-shippable/aws/group2
+# reason: unknown
 unstable
+
+cloud/aws
+shippable/aws/group2
+
+aws_acm_info

--- a/tests/integration/targets/aws_acm/aliases
+++ b/tests/integration/targets/aws_acm/aliases
@@ -1,4 +1,4 @@
-# reason: unknown
+# https://github.com/ansible/ansible/issues/67788
 unstable
 
 cloud/aws

--- a/tests/integration/targets/aws_config/aliases
+++ b/tests/integration/targets/aws_config/aliases
@@ -1,6 +1,6 @@
 # reason: missing-policy
 # We don't have CI or 'unsupported' policy for AWS config
-disabled
+unsupported
 
 cloud/aws
 shippable/aws/group2

--- a/tests/integration/targets/aws_eks_cluster/aliases
+++ b/tests/integration/targets/aws_eks_cluster/aliases
@@ -1,4 +1,7 @@
-# reason: unknown
+# reason: missing-policy
+# We don't have CI or 'unsupported' policy for AWS config
+# reason: slow
+# Starting up an EKS cluster is a slow process, tests can take 40 minutes
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,4 +1,5 @@
 # Various race conditions - likely needs waiters
+# https://github.com/ansible-collections/community.aws/issues/433
 unstable
 
 cloud/aws

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,5 +1,7 @@
-cloud/aws
-aws_kms_info
-shippable/aws/group2
 # Various race conditions - likely needs waiters
 unstable
+
+cloud/aws
+shippable/aws/group2
+
+aws_kms_info

--- a/tests/integration/targets/aws_secret/aliases
+++ b/tests/integration/targets/aws_secret/aliases
@@ -1,4 +1,6 @@
 # reason: missing-policy
+# reason: broken
+# The tests for configuring secret rotation seem to be missing a permission
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/aws_secret/aliases
+++ b/tests/integration/targets/aws_secret/aliases
@@ -1,6 +1,6 @@
 # reason: missing-policy
 # reason: broken
 # The tests for configuring secret rotation seem to be missing a permission
-unsupported
+disabled
 
 cloud/aws

--- a/tests/integration/targets/aws_step_functions_state_machine/aliases
+++ b/tests/integration/targets/aws_step_functions_state_machine/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 shippable/aws/group2
+
 aws_step_functions_state_machine_execution

--- a/tests/integration/targets/aws_waf_web_acl/aliases
+++ b/tests/integration/targets/aws_waf_web_acl/aliases
@@ -1,6 +1,6 @@
 # reason: broken
 # ansible/ansible#38258
-unsupported
+disabled
 
 cloud/aws
 

--- a/tests/integration/targets/cloudformation_exports_info/aliases
+++ b/tests/integration/targets/cloudformation_exports_info/aliases
@@ -1,4 +1,5 @@
-cloud/aws
-shippable/aws/group3
 # https://github.com/ansible-collections/community.aws/issues/157
 unstable
+
+cloud/aws
+shippable/aws/group3

--- a/tests/integration/targets/cloudwatchlogs/aliases
+++ b/tests/integration/targets/cloudwatchlogs/aliases
@@ -1,4 +1,5 @@
 cloud/aws
 shippable/aws/group1
+
 cloudwatchlogs_log_group
 cloudwatchlogs_log_group_metric_filter

--- a/tests/integration/targets/connection/aliases
+++ b/tests/integration/targets/connection/aliases
@@ -1,1 +1,2 @@
+# Used to test basic operation once a connection plugin has established a connection
 hidden

--- a/tests/integration/targets/ec2_asg/aliases
+++ b/tests/integration/targets/ec2_asg/aliases
@@ -1,6 +1,6 @@
 # reason: slow
-# reason: broken
 # Tests take around 30 minutes
-unsupported
+# reason: broken
+disabled
 
 cloud/aws

--- a/tests/integration/targets/ec2_eip/aliases
+++ b/tests/integration/targets/ec2_eip/aliases
@@ -1,4 +1,5 @@
-cloud/aws
-shippable/aws/group2
 # https://github.com/ansible-collections/community.aws/issues/159
 unstable
+
+cloud/aws
+shippable/aws/group2

--- a/tests/integration/targets/ec2_instance/aliases
+++ b/tests/integration/targets/ec2_instance/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 shippable/aws/group3
+
 ec2_instance_info

--- a/tests/integration/targets/ec2_transit_gateway/aliases
+++ b/tests/integration/targets/ec2_transit_gateway/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 shippable/aws/group2
+
 ec2_transit_gateway_info

--- a/tests/integration/targets/ec2_vpc_endpoint/aliases
+++ b/tests/integration/targets/ec2_vpc_endpoint/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 shippable/aws/group2
+
 ec2_vpc_endpoint_info

--- a/tests/integration/targets/ec2_vpc_igw/aliases
+++ b/tests/integration/targets/ec2_vpc_igw/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 shippable/aws/group2
+
 ec2_vpc_igw_info

--- a/tests/integration/targets/ec2_vpc_nacl/aliases
+++ b/tests/integration/targets/ec2_vpc_nacl/aliases
@@ -1,5 +1,7 @@
-ec2_vpc_nacl_info
-cloud/aws
-shippable/aws/group2
 # https://github.com/ansible-collections/community.aws/issues/153
 unstable
+
+cloud/aws
+shippable/aws/group2
+
+ec2_vpc_nacl_info

--- a/tests/integration/targets/ec2_vpc_route_table/aliases
+++ b/tests/integration/targets/ec2_vpc_route_table/aliases
@@ -1,5 +1,7 @@
 # reason: boto2
 # ec2_vpc_route_table_info is currently boto v2 based which means it can't handle API rate limiting
+# https://github.com/ansible-collections/community.aws/issues/277 with AWSRetry
+# would likely fix the issue.
 unstable
 
 cloud/aws

--- a/tests/integration/targets/ec2_vpc_route_table/aliases
+++ b/tests/integration/targets/ec2_vpc_route_table/aliases
@@ -1,4 +1,8 @@
+# reason: boto2
+# ec2_vpc_route_table_info is currently boto v2 based which means it can't handle API rate limiting
+unstable
+
 cloud/aws
 shippable/aws/group2
-unstable
+
 ec2_vpc_route_table_info

--- a/tests/integration/targets/ec2_vpc_vgw/aliases
+++ b/tests/integration/targets/ec2_vpc_vgw/aliases
@@ -1,4 +1,5 @@
-cloud/aws
-shippable/aws/group2
 # https://github.com/ansible-collections/community.aws/issues/154
 unstable
+
+cloud/aws
+shippable/aws/group2

--- a/tests/integration/targets/ec2_vpc_vpn_info/aliases
+++ b/tests/integration/targets/ec2_vpc_vpn_info/aliases
@@ -1,4 +1,5 @@
-cloud/aws
-shippable/aws/group3
 # https://github.com/ansible-collections/community.aws/issues/156
 unstable
+
+cloud/aws
+shippable/aws/group3

--- a/tests/integration/targets/ecs_ecr/aliases
+++ b/tests/integration/targets/ecs_ecr/aliases
@@ -1,2 +1,5 @@
+# reason: boto2
+unstable
+
 cloud/aws
 shippable/aws/group2

--- a/tests/integration/targets/elb_classic_lb/aliases
+++ b/tests/integration/targets/elb_classic_lb/aliases
@@ -1,2 +1,7 @@
+# reason: boto2
+# elb_classic_lb is boto2 based which means that it handles rate limiting poorly
+# https://github.com/ansible-collections/community.aws/issues/430
+unstable
+
 cloud/aws
 shippable/aws/group2

--- a/tests/integration/targets/elb_network_lb/aliases
+++ b/tests/integration/targets/elb_network_lb/aliases
@@ -1,4 +1,4 @@
-# reason:
+# reason: unknown
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/elb_network_lb/aliases
+++ b/tests/integration/targets/elb_network_lb/aliases
@@ -1,4 +1,6 @@
-# reason: unknown
-unsupported
+# reason: missing-policy
+# reason: broken
+# The SSL cert stored in the test has expired.  Should be dynamically generated.
+disabled
 
 cloud/aws

--- a/tests/integration/targets/elb_target/aliases
+++ b/tests/integration/targets/elb_target/aliases
@@ -1,3 +1,4 @@
 cloud/aws
-elb_target_group
 shippable/aws/group4
+
+elb_target_group

--- a/tests/integration/targets/lambda/aliases
+++ b/tests/integration/targets/lambda/aliases
@@ -1,4 +1,5 @@
 cloud/aws
 shippable/aws/group2
+
 execute_lambda
 lambda_info

--- a/tests/integration/targets/route53/aliases
+++ b/tests/integration/targets/route53/aliases
@@ -1,3 +1,4 @@
-route53_info
 cloud/aws
 shippable/aws/group2
+
+route53_info

--- a/tests/integration/targets/s3_logging/aliases
+++ b/tests/integration/targets/s3_logging/aliases
@@ -1,5 +1,7 @@
 # reason: unstable
+# reason: boto2
 # When running tests a failure rate of around 20% was observed
+# This will in part be because it's boto v2 based so handles API rate limiting poorly
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/s3_logging/aliases
+++ b/tests/integration/targets/s3_logging/aliases
@@ -1,7 +1,5 @@
 # reason: unstable
-# reason: boto2
-# When running tests a failure rate of around 20% was observed
-# This will in part be because it's boto v2 based so handles API rate limiting poorly
+# https://github.com/ansible/ansible/issues/63520
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/s3_sync/aliases
+++ b/tests/integration/targets/s3_sync/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 shippable/aws/group1
-


### PR DESCRIPTION
##### SUMMARY

- Mark ec2_classic_lb tests unstable
- General cleanup of the aliases files

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

Integration tests

##### ADDITIONAL INFORMATION