### PR TITLE
Fix ec2_launch_template to correctly remove all None types

### DIFF
--- a/changelogs/fragments/438-ec2-launch-template-dict-fix.yml
+++ b/changelogs/fragments/438-ec2-launch-template-dict-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove None types from dict in ec2_launch_template before passing them wrongly to boto create method.

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -482,13 +482,13 @@ def delete_template(module):
 
 
 def remove_none(obj):
-  if isinstance(obj, (list, tuple, set)):
-    return type(obj)(remove_none(x) for x in obj if x is not None)
-  elif isinstance(obj, dict):
-    return type(obj)((remove_none(k), remove_none(v))
-      for k, v in obj.items() if k is not None and v is not None)
-  else:
-    return obj
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(remove_none(x) for x in obj if x is not None)
+    elif isinstance(obj, dict):
+        return type(obj)((remove_none(k), remove_none(v))
+            for k, v in obj.items() if k is not None and v is not None)
+    else:
+        return obj
 
 
 def create_or_update(module, template_options):


### PR DESCRIPTION
 fixes issue #230

##### SUMMARY
When leaving module params blank the module would send None types in it's nested dics structure to boto, which then led to errors
This PR is fixing this by recursively removing all None types from the entire dict passed to boto.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
ec2_launch_template module

##### ADDITIONAL INFORMATION

Run this task for example with and without the fix and you will see what I mean:

```yaml
    - name: Create Launch Template to test Ansible ec2_launch_template module code
      ec2_launch_template:
        name: test-ansible-ec2-launch-template-module
        image_id: ami-XXX
        security_group_ids:
          - sg-XXXX
        instance_type: c5.large
        key_name: my_key
        instance_market_options:
          market_type: spot
          spot_options:
            max_price: 0.5
            spot_instance_type: one-time
            instance_interruption_behavior: terminate
        block_device_mappings:
          - device_name: /dev/sda1
            ebs:
              volume_type: gp2
              volume_size: 10
              delete_on_termination: true
              encrypted: true
          - device_name: /dev/sdb
            ebs:
              volume_type: gp2
              volume_size: 200
              delete_on_termination: true
              encrypted: true
        monitoring:
          enabled: false
        region: us-east-1
        state: present
      register: launch_template_result

    - name: Output result
      debug:
        var: launch_template_result
```

Of course replace XXX with your IDs. Find more test cases in https://github.com/ansible-collections/community.aws/issues/230