### PR TITLE
Cleanup aws_config tests

### DIFF
--- a/tests/integration/targets/aws_config/aliases
+++ b/tests/integration/targets/aws_config/aliases
@@ -1,5 +1,9 @@
 # reason: missing-policy
-# We don't have CI or 'unsupported' policy for AWS config
+# AWS Config will test that it's able to deliver using its assumed role.
+# Either we'll need to grant the role global access to S3/SNS/SQS or we'll need
+# some custom Managed Policies.
+# reason: serial
+# Only one Config Recorder per region per account is permitted
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/aws_config/defaults/main.yaml
+++ b/tests/integration/targets/aws_config/defaults/main.yaml
@@ -1,4 +1,4 @@
 ---
 config_s3_bucket: '{{ resource_prefix }}-config-records'
 config_sns_name: '{{ resource_prefix }}-delivery-channel-test-topic'
-config_role_name: 'config-recorder-test-{{ resource_prefix }}'
+config_role_name: 'ansible-test-{{ resource_prefix }}'

--- a/tests/integration/targets/aws_config/tasks/main.yaml
+++ b/tests/integration/targets/aws_config/tasks/main.yaml
@@ -158,7 +158,7 @@
     # ============================================================
     - name: Create Configuration Recorder for AWS Config
       aws_config_recorder:
-        name: test_configuration_recorder
+        name: '{{ resource_prefix }}-recorder'
         state: present
         role_arn: "{{ config_iam_role.arn }}"
         recording_group:
@@ -172,7 +172,7 @@
 
     - name: Create Delivery Channel for AWS Config
       aws_config_delivery_channel:
-        name: test_delivery_channel
+        name: '{{ resource_prefix }}-channel'
         state: present
         s3_bucket: "{{ config_s3_bucket }}"
         s3_prefix: "foo/bar"
@@ -186,7 +186,7 @@
 
     - name: Create Config Rule for AWS Config
       aws_config_rule:
-        name: test_config_rule
+        name: '{{ resource_prefix }}-rule'
         state: present
         description: 'This AWS Config rule checks for public write access on S3 buckets'
         scope:
@@ -206,7 +206,7 @@
     # ============================================================
     - name: Update Configuration Recorder
       aws_config_recorder:
-        name: test_configuration_recorder
+        name: '{{ resource_prefix }}-recorder'
         state: present
         role_arn: "{{ config_iam_role.arn }}"
         recording_group:
@@ -222,7 +222,7 @@
 
     - name: Update Delivery Channel
       aws_config_delivery_channel:
-        name: test_delivery_channel
+        name: '{{ resource_prefix }}-channel'
         state: present
         s3_bucket: "{{ config_s3_bucket }}"
         sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
@@ -235,7 +235,7 @@
 
     - name: Update Config Rule
       aws_config_rule:
-        name: test_config_rule
+        name: '{{ resource_prefix }}-rule'
         state: present
         description: 'This AWS Config rule checks for public write access on S3 buckets'
         scope:
@@ -255,7 +255,7 @@
     # ============================================================
     - name: Don't update Configuration Recorder
       aws_config_recorder:
-        name: test_configuration_recorder
+        name: '{{ resource_prefix }}-recorder'
         state: present
         role_arn: "{{ config_iam_role.arn }}"
         recording_group:
@@ -271,7 +271,7 @@
 
     - name: Don't update Delivery Channel
       aws_config_delivery_channel:
-        name: test_delivery_channel
+        name: '{{ resource_prefix }}-channel'
         state: present
         s3_bucket: "{{ config_s3_bucket }}"
         sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
@@ -284,7 +284,7 @@
 
     - name: Don't update Config Rule
       aws_config_rule:
-        name: test_config_rule
+        name: '{{ resource_prefix }}-rule'
         state: present
         description: 'This AWS Config rule checks for public write access on S3 buckets'
         scope:
@@ -305,7 +305,7 @@
     # ============================================================
     - name: Destroy Configuration Recorder
       aws_config_recorder:
-        name: test_configuration_recorder
+        name: '{{ resource_prefix }}-recorder'
         state: absent
       register: output
       ignore_errors: yes
@@ -316,7 +316,7 @@
 
     - name: Destroy Delivery Channel
       aws_config_delivery_channel:
-        name: test_delivery_channel
+        name: '{{ resource_prefix }}-channel'
         state: absent
         s3_bucket: "{{ config_s3_bucket }}"
         sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
@@ -330,7 +330,7 @@
 
     - name: Destroy Config Rule
       aws_config_rule:
-        name: test_config_rule
+        name: '{{ resource_prefix }}-rule'
         state: absent
         description: 'This AWS Config rule checks for public write access on S3 buckets'
         scope:


### PR DESCRIPTION
##### SUMMARY

- use the standard role/resource names
- test using updated policy (unsupported should work when using the additional 'unsupported' policies in aws-terminator

https://github.com/mattclay/aws-terminator/pull/133

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

aws_config

##### ADDITIONAL INFORMATION