### PR TITLE
ec2_vpc_nat_gateway_info: add retry decorator to solve RequestLimitExceeded error

### DIFF
--- a/changelogs/fragments/446-ec2_vpc_nat_gateway_info_stability.yml
+++ b/changelogs/fragments/446-ec2_vpc_nat_gateway_info_stability.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - ec2_vpc_nat_gateway_info - solve RequestLimitExceeded error by adding retry decorator (https://github.com/ansible-collections/community.aws/pull/446) 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Solve RequestLimitExceeded error by adding the retry decorator

```
"msg": "An error occurred (RequestLimitExceeded) when calling the DescribeNatGateways operation (reached max retries: 4): Request limit exceeded."
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_nat_gateway_info
