### PR TITLE
docs: Fix indentation in aws_config_recorder example

### DIFF
--- a/docs/community.aws.aws_config_recorder_module.rst
+++ b/docs/community.aws.aws_config_recorder_module.rst
@@ -365,8 +365,8 @@ Examples
         state: present
         role_arn: 'arn:aws:iam::123456789012:role/AwsConfigRecorder'
         recording_group:
-            all_supported: true
-            include_global_types: true
+          all_supported: true
+          include_global_types: true
 
 
 


### PR DESCRIPTION
The final block in the example is double-indented: this PR dedents the block to use the standard two-space indent.
