### PR TITLE
sns_topic: Allow canonical international-format phone numbers in SMS subscriptions

### DIFF
--- a/changelogs/fragments/454-sns_topic_fix_sms_endpoint_canonicalization.yaml
+++ b/changelogs/fragments/454-sns_topic_fix_sms_endpoint_canonicalization.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - sns_topic - Add `+` to allowable characters in SMS endpoints. `AWS SNS expects phone numbers in and canonicalizes to E.164 format <https://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html>`_. (https://github.com/ansible-collections/community.aws/pull/454)
+  - sns_topic - Add ``+`` to allowable characters in SMS endpoints (https://github.com/ansible-collections/community.aws/pull/454).

--- a/changelogs/fragments/454-sns_topic_fix_sms_endpoint_canonicalization.yaml
+++ b/changelogs/fragments/454-sns_topic_fix_sms_endpoint_canonicalization.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sns_topic - Add `+` to allowable characters in SMS endpoints. `AWS SNS expects phone numbers in and canonicalizes to E.164 format <https://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html>`_. (https://github.com/ansible-collections/community.aws/pull/454)

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -350,7 +350,7 @@ class SnsTopicManager(object):
 
     def _canonicalize_endpoint(self, protocol, endpoint):
         if protocol == 'sms':
-            return re.sub('[^0-9]*', '', endpoint)
+            return re.sub('[^0-9+]*', '', endpoint)
         return endpoint
 
     def _set_topic_subs(self):

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -349,6 +349,9 @@ class SnsTopicManager(object):
         return changed
 
     def _canonicalize_endpoint(self, protocol, endpoint):
+        # AWS SNS expects phone numbers in
+        # and canonicalizes to E.164 format
+        # See <https://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html>
         if protocol == 'sms':
             return re.sub('[^0-9+]*', '', endpoint)
         return endpoint


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds `+` to the list of acceptable characters in an SMS endpoint.
Fixes #453.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sns_topic