### PR TITLE
ec2_instance: wait on instance state, rather than status check

### DIFF
--- a/changelogs/fragments/461-ec2_instance-wait_sanity.yml
+++ b/changelogs/fragments/461-ec2_instance-wait_sanity.yml
@@ -1,0 +1,9 @@
+breaking_changes:
+    - ec2_instance - if plays require the old behavior of ``ec2_instance``, waiting for
+      EC2 instance monitoring status to become ``OK`` when launching a new instance,
+      the action will need to specify ``state: started`` (https://github.com/ansible-collections/community.aws/pull/461).
+bugfixes:
+    - ec2_instance - ``ec2_instance`` was waiting on EC2 instance monitoring status
+      to be ``OK`` when launching a new instance. This could cause a play to wait
+      multiple minutes for AWS's monitoring to complete status checks
+      (https://github.com/ansible-collections/community.aws/pull/461).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -29,14 +29,14 @@ options:
   state:
     description:
       - Goal state for the instances.
-      - I(state=present) ensures instances exist, but does not guarantee any state (e.g. running). Newly-launched instances will be run by EC2.
-      - I(state=running): I(state=present) + ensures the instances are running
-      - I(state=started): I(state=running) + waits for EC2 status checks to report OK if I(wait=true)
-      - I(state=stopped) ensures an existing instance is stopped.
-      - I(state=rebooted): convenience alias for I(state=stopped) immediately followed by I(state=running)
-      - I(state=restarted): convenience alias for I(state=stopped) immediately followed by I(state=started)
-      - I(state=terminated) ensures an existing instance is terminated.
-      - I(state=absent): alias for I(state=terminated)
+      - "I(state=present): ensures instances exist, but does not guarantee any state (e.g. running). Newly-launched instances will be run by EC2."
+      - "I(state=running): I(state=present) + ensures the instances are running"
+      - "I(state=started): I(state=running) + waits for EC2 status checks to report OK if I(wait=true)"
+      - "I(state=stopped): ensures an existing instance is stopped."
+      - "I(state=rebooted): convenience alias for I(state=stopped) immediately followed by I(state=running)"
+      - "I(state=restarted): convenience alias for I(state=stopped) immediately followed by I(state=started)"
+      - "I(state=terminated): ensures an existing instance is terminated."
+      - "I(state=absent): alias for I(state=terminated)"
     choices: [present, terminated, running, started, stopped, restarted, rebooted, absent]
     default: present
     type: str


### PR DESCRIPTION
##### SUMMARY
The `await_instances()` function was calling `module.client('ec2').get_waiter('instance_status_ok')` by default, which causes boto3 to wait on the `DescribeInstanceStatus` api to return "Ok". The status API is linked to [EC2's instance status checks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html#reporting_status), which lag the instance's real state by 3-5 minutes.

It's unlikely that most Ansible users who set `wait: true` want their playbooks to delay until EC2's status checks catch up. The more efficient approach is to use `wait_for` or `wait_for_connection`. What is useful, however, is to wait the short period of time necessary for EC2 to move an instance from `pending` to `running`.

Before this change, the `ec2_instance` module would wait for an "Ok" status check for newly-created instances *before* waiting for any other state change. This change makes the default `state: present` wait for `instance_exists`, and `state: running` wait for `instance_running`. `state: started` (previously just an alias for `state: running`) now will wait for `instance_status_ok` if `wait: true`.

The only, IMHO unlikely, scenario that this is a breaking change for is if an Ansible user had combined `state: present/running/started` and `wait: true` and is actually depending on the play to halt until EC2's status checks return OK. Based on my own informal survey of playbooks on GitHub, I did not see anyone using `ec2_instance` in this way. Most playbooks follow `ec2_instance` with `wait_for` or `wait_for_connection`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ec2_instance