### PR TITLE
More no_log changes

### DIFF
--- a/changelogs/fragments/471-no_log.yml
+++ b/changelogs/fragments/471-no_log.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- aws_secret - flag the ``secret`` paramter as containing sensitive data which shouldn't be logged (https://github.com/ansible-collections/community.aws/pull/471).

--- a/plugins/modules/aws_secret.py
+++ b/plugins/modules/aws_secret.py
@@ -334,7 +334,7 @@ def main():
             'description': dict(default=""),
             'kms_key_id': dict(),
             'secret_type': dict(choices=['binary', 'string'], default="string"),
-            'secret': dict(default=""),
+            'secret': dict(default="", no_log=True),
             'tags': dict(type='dict', default={}),
             'rotation_lambda': dict(),
             'rotation_interval': dict(type='int', default=30),

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -497,7 +497,7 @@ def main():
         mode=dict(choices=['push'], default='push'),
         file_change_strategy=dict(choices=['force', 'date_size', 'checksum'], default='date_size'),
         bucket=dict(required=True),
-        key_prefix=dict(required=False, default=''),
+        key_prefix=dict(required=False, default='', no_log=False),
         file_root=dict(required=True, type='path'),
         permission=dict(required=False, choices=['private', 'public-read', 'public-read-write', 'authenticated-read',
                                                  'aws-exec-read', 'bucket-owner-read', 'bucket-owner-full-control']),


### PR DESCRIPTION
##### SUMMARY

- aws_secret's `secret` parameter contains sensitive data and shouldn't be logged.
- s3_sync's `key_prefix` matches 'key' so triggers a false positive with the latest sanity tests

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_sync
aws_secret

##### ADDITIONAL INFORMATION

Thanks to @felixfontein for the heads up
https://github.com/ansible/ansible/pull/73508