### PR TITLE
[security] Fix missing no_log=True

### DIFF
--- a/changelogs/fragments/475-no_log-missing.yml
+++ b/changelogs/fragments/475-no_log-missing.yml
@@ -1,0 +1,4 @@
+security_fixes:
+- "aws_direct_connect_virtual_interface - mark the ``authentication_key`` parameter as ``no_log`` to avoid accidental leaking of secrets in logs (https://github.com/ansible-collections/community.aws/pull/475)."
+- "sts_assume_role - mark the ``mfa_token`` parameter as ``no_log`` to avoid accidental leaking of secrets in logs (https://github.com/ansible-collections/community.aws/pull/475)."
+- "sts_session_token - mark the ``mfa_token`` parameter as ``no_log`` to avoid accidental leaking of secrets in logs (https://github.com/ansible-collections/community.aws/pull/475)."

--- a/plugins/modules/aws_direct_connect_virtual_interface.py
+++ b/plugins/modules/aws_direct_connect_virtual_interface.py
@@ -484,7 +484,7 @@ def main():
         name=dict(),
         vlan=dict(type='int', default=100),
         bgp_asn=dict(type='int', default=65000),
-        authentication_key=dict(),
+        authentication_key=dict(no_log=True),
         amazon_address=dict(),
         customer_address=dict(),
         address_type=dict(),

--- a/plugins/modules/sts_assume_role.py
+++ b/plugins/modules/sts_assume_role.py
@@ -162,7 +162,7 @@ def main():
         external_id=dict(required=False, default=None),
         policy=dict(required=False, default=None),
         mfa_serial_number=dict(required=False, default=None),
-        mfa_token=dict(required=False, default=None)
+        mfa_token=dict(required=False, default=None, no_log=True)
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -129,7 +129,7 @@ def main():
     argument_spec = dict(
         duration_seconds=dict(required=False, default=None, type='int'),
         mfa_serial_number=dict(required=False, default=None),
-        mfa_token=dict(required=False, default=None),
+        mfa_token=dict(required=False, default=None, no_log=True),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)


### PR DESCRIPTION
##### SUMMARY
Fallout from the new `no_log` sanity tests. I've checked with @tremble and these seem to be really missing.

* aws_direct_connect_virtual_interface's `authentication_key` parameter is arguably secret (BGP Authentication Key)
* sts_assume_role's and sts_session_token's `mfa_token` is a one-time token; attackers could intercept the log call and use the token before it is used by the module.

CC @jillr @relrod

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_direct_connect_virtual_interface
sts_assume_role
sts_session_token
