### PR TITLE
fix KeyError: 'Tags' for ec2_instance

### DIFF
--- a/changelogs/fragments/476-ec2_instance_fix_key_error_when_instance_has_no_tags.yaml
+++ b/changelogs/fragments/476-ec2_instance_fix_key_error_when_instance_has_no_tags.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - fix key errors when instance has no tags (https://github.com/ansible-collections/community.aws/pull/476).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -889,7 +889,7 @@ def tower_callback_script(tower_conf, windows=False, passwd=None):
 
 def manage_tags(match, new_tags, purge_tags, ec2):
     changed = False
-    old_tags = boto3_tag_list_to_ansible_dict(match['Tags'])
+    old_tags = boto3_tag_list_to_ansible_dict(match.get('Tags', {}))
     tags_to_set, tags_to_delete = compare_aws_tags(
         old_tags, new_tags,
         purge_tags=purge_tags,
@@ -1559,7 +1559,7 @@ def change_instance_state(filters, desired_state, ec2=None):
 
 def pretty_instance(i):
     instance = camel_dict_to_snake_dict(i, ignore_list=['Tags'])
-    instance['tags'] = boto3_tag_list_to_ansible_dict(i['Tags'])
+    instance['tags'] = boto3_tag_list_to_ansible_dict(i.get('Tags', {}))
     return instance
 
 


### PR DESCRIPTION
##### SUMMARY
When you apply `ec2_instance` on existing ec2 instances that has no tags, `ec2_instance` throws key errors on 'Tags'.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION

```paste below
  File "/tmp/ansible_community.aws.ec2_instance_payload_tuiv6f2j/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1795, in <module>
  File "/tmp/ansible_community.aws.ec2_instance_payload_tuiv6f2j/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1777, in main
  File "/tmp/ansible_community.aws.ec2_instance_payload_tuiv6f2j/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 892, in manage_tags
KeyError: 'Tags'





  File "/tmp/ansible_community.aws.ec2_instance_payload_pgtqeywj/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1795, in <module>
  File "/tmp/ansible_community.aws.ec2_instance_payload_pgtqeywj/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1780, in main
  File "/tmp/ansible_community.aws.ec2_instance_payload_pgtqeywj/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1607, in ensure_present
  File "/tmp/ansible_community.aws.ec2_instance_payload_pgtqeywj/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1598, in handle_existing
  File "/tmp/ansible_community.aws.ec2_instance_payload_pgtqeywj/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1598, in <listcomp>
  File "/tmp/ansible_community.aws.ec2_instance_payload_pgtqeywj/ansible_community.aws.ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1562, in pretty_instance
KeyError: 'Tags'
```
