### PR TITLE
aws_acm - check mode

### DIFF
--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -362,30 +362,39 @@ def main():
             else:
                 module.debug("Existing certificate in ACM is different, overwriting")
 
-                # update cert in ACM
-                arn = acm.import_certificate(client, module,
-                                             certificate=module.params['certificate'],
-                                             private_key=module.params['private_key'],
-                                             certificate_chain=module.params['certificate_chain'],
-                                             arn=old_cert['certificate_arn'],
-                                             tags=tags)
+                if module.check_mode:
+                    arn = old_cert['certificate_arn']
+                    # note: returned domain will be the domain of the previous cert
+                else:
+                    # update cert in ACM
+                    arn = acm.import_certificate(client, module,
+                                                 certificate=module.params['certificate'],
+                                                 private_key=module.params['private_key'],
+                                                 certificate_chain=module.params['certificate_chain'],
+                                                 arn=old_cert['certificate_arn'],
+                                                 tags=tags)
                 domain = acm.get_domain_of_cert(client=client, module=module, arn=arn)
                 module.exit_json(certificate=dict(domain_name=domain, arn=arn), changed=True)
         else:  # len(certificates) == 0
             module.debug("No certificate in ACM. Creating new one.")
-            arn = acm.import_certificate(client=client,
-                                         module=module,
-                                         certificate=module.params['certificate'],
-                                         private_key=module.params['private_key'],
-                                         certificate_chain=module.params['certificate_chain'],
-                                         tags=tags)
-            domain = acm.get_domain_of_cert(client=client, module=module, arn=arn)
+            if module.check_mode:
+                arn = 'arn:aws:acm:us-east-1:123456789012:certificate/01234567-abcd-abcd-abcd-012345678901'
+                domain = 'example.com'
+            else:
+                arn = acm.import_certificate(client=client,
+                                             module=module,
+                                             certificate=module.params['certificate'],
+                                             private_key=module.params['private_key'],
+                                             certificate_chain=module.params['certificate_chain'],
+                                             tags=tags)
+                domain = acm.get_domain_of_cert(client=client, module=module, arn=arn)
 
             module.exit_json(certificate=dict(domain_name=domain, arn=arn), changed=True)
 
     else:  # state == absent
         for cert in certificates:
-            acm.delete_certificate(client, module, cert['certificate_arn'])
+            if not module.check_mode:
+                acm.delete_certificate(client, module, cert['certificate_arn'])
         module.exit_json(arns=[cert['certificate_arn'] for cert in certificates],
                          changed=(len(certificates) > 0))
 

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -207,7 +207,7 @@ certificate:
     arn:
       description: The ARN of the certificate in ACM
       type: str
-      returned: when I(state=present)
+      returned: when I(state=present) and not in check mode
       sample: "arn:aws:acm:ap-southeast-2:123456789012:certificate/01234567-abcd-abcd-abcd-012345678901"
     domain_name:
       description: The domain name encoded within the public certificate
@@ -378,8 +378,8 @@ def main():
         else:  # len(certificates) == 0
             module.debug("No certificate in ACM. Creating new one.")
             if module.check_mode:
-                arn = 'arn:aws:acm:us-east-1:123456789012:certificate/01234567-abcd-abcd-abcd-012345678901'
                 domain = 'example.com'
+                module.exit_json(certificate=dict(domain_name=domain), changed=True)
             else:
                 arn = acm.import_certificate(client=client,
                                              module=module,
@@ -389,7 +389,7 @@ def main():
                                              tags=tags)
                 domain = acm.get_domain_of_cert(client=client, module=module, arn=arn)
 
-            module.exit_json(certificate=dict(domain_name=domain, arn=arn), changed=True)
+                module.exit_json(certificate=dict(domain_name=domain, arn=arn), changed=True)
 
     else:  # state == absent
         for cert in certificates:

--- a/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
+++ b/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
@@ -23,17 +23,15 @@
     aws_acm:
       name_tag: '{{ item.name }}'
       state: absent
-    with_nested:
-      - '{{ local_certs }}'
-      - [True, False]
+    with_items: '{{ local_certs }}'
   - name: ensure absent cert which doesn't exist - second time
     aws_acm:
       name_tag: '{{ item[0].name }}'
       state: absent
-    changed_when: '{{ item[1] }}'
+    check_mode: '{{ item[1] }}'
     with_nested:
       - '{{ local_certs }}'
-      - [True, False]
+      - [true, false]
     register: absent_start_two
   - name: check no change when ensuring absent cert is absent
     assert:
@@ -53,7 +51,7 @@
     assert:
       that:
         - (list_tag.certificates | length) == 0
-        -  not list_tag.changed
+        - not list_tag.changed
   - name: check directory was made
     assert:
       that:
@@ -304,10 +302,10 @@
     - 0
     - 1
   - name: test deletion with check mode detected change
-      assert:
-        that:
-          - delete_both_check.changed
-          - (check_del_one.certificates | length) == 2
+    assert:
+      that:
+        - delete_both_check.changed
+        - (check_del_one.certificates | length) == 2
   - name: delete certs 1 and 2 real
     aws_acm:
       state: absent

--- a/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
+++ b/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
@@ -10,6 +10,11 @@
     aws_acm_info: null
     register: list_all
     failed_when: list_all.certificates is not defined
+  - name: list certs with check mode
+    aws_acm_info: null
+    register: list_all_check
+    failed_when: (list_all.certificates != list_all_check.certificates) or list_all_check.changed
+    check_mode: yes # read-only task, should work the same as with no
   - name: ensure absent cert which doesn't exist - first time
     aws_acm:
       name_tag: '{{ item.name }}'
@@ -22,13 +27,24 @@
     with_items: '{{ local_certs }}'
     register: absent_start_two
     failed_when: absent_start_two.changed
+  - name: ensure absent cert which doesn't exist, in check mode
+    aws_acm:
+      name_tag: '{{ item.name }}'
+      state: absent
+    with_items: '{{ local_certs }}'
+    check_mode: yes # read-only task, should work the same as with no
+    register: absent_check
+    failed_when: absent_check.changed
   - name: list cert which shouldn't exist
     aws_acm_info:
       tags:
-        Name: '{{ item.name }}'
+        Name: '{{ item[0].name }}'
     register: list_tag
-    with_items: '{{ local_certs }}'
-    failed_when: list_tag.certificates | length > 0
+    check_mode: '{{ item[1] }}'
+    with_nested:
+      - '{{ local_certs }}'
+      - [ False, True ] # read-only task, should work the same with check mode or not
+    failed_when: (list_tag.certificates | length > 0) or list_tag.changed
   - name: check directory was made
     assert:
       that:
@@ -54,6 +70,23 @@
       privatekey_path: '{{ item.priv_key }}'
       signature_algorithms:
       - sha256WithRSAEncryption
+  - name: upload certificate with check mode
+    aws_acm:
+      name_tag: '{{ item.name }}'
+      certificate: '{{ lookup(''file'', item.cert ) }}'
+      private_key: '{{ lookup(''file'', item.priv_key ) }}'
+      state: present
+    check_mode: yes
+    register: upload_check
+    with_items: '{{ local_certs }}'
+    failed_when: not upload_check.changed
+  - name: check cert was not really uploaded in check mode
+    aws_acm_info:
+      tags:
+        Name: '{{ item.name }}'
+    register: list_after_check_mode_upload
+    with_items: '{{ local_certs }}'
+    failed_when: list_after_check_mode_upload | length > 0
   - name: upload certificates first time
     aws_acm:
       name_tag: '{{ item.name }}'
@@ -61,6 +94,7 @@
       private_key: '{{ lookup(''file'', item.priv_key ) }}'
       state: present
     register: upload
+    check_mode: no
     with_items: '{{ local_certs }}'
     until: upload is succeeded
     retries: 5
@@ -95,6 +129,13 @@
       fetch_after_up_result: '{{ item }}'
       upload_result: '{{ item.item }}'
       original_cert: '{{ item.item.item }}'
+  - name: fetch data about cert just uploaded, by ARN, check mode
+    aws_acm_info:
+      certificate_arn: '{{ item.certificate.arn }}'
+    check_mode: yes
+    register: fetch_after_up_check
+    with_items: '{{ upload.results }}'
+    failed_when: fetch_after_up_check.changed or (fetch_after_up_check.certificates != fetch_after_up.certificates)
   - name: fetch data about cert just uploaded, by name
     aws_acm_info:
       tags:
@@ -148,7 +189,30 @@
     register: upload2
     with_items: '{{ local_certs }}'
     failed_when: upload2.changed
-  - name: update first cert with body of the second, first time
+  - name: update first cert with body of the second, first time, check mode
+    aws_acm:
+      state: present
+      name_tag: '{{ local_certs[0].name }}'
+      certificate: '{{ lookup(''file'', local_certs[1].cert ) }}'
+      private_key: '{{ lookup(''file'', local_certs[1].priv_key ) }}'
+    check_mode: yes
+    register: overwrite_check
+    failed_when: (not overwrite_check.changed)
+  - name: check previous tasks did not change real cert
+    aws_acm_info:
+      tags:
+        Name: '{{ local_certs[0].name }}'
+    register: fetch_after_overwrite_check
+  - name: check update with check mode did not change real cert
+    assert:
+      that:
+      - fetch_after_overwrite_check.certificates | length == 1
+      - fetch_after_overwrite_check.certificates[0].certificate_arn == fetch_after_up.results[0].certificates[0].certificate_arn
+      - fetch_after_overwrite_check.certificates[0].domain_name == local_certs[0].domain
+      - (fetch_after_overwrite_check.certificates[0].certificate | replace( ' ', '' ) | replace( '\n', '')) == (lookup('file', local_certs[0].cert )| replace( ' ', '' ) | replace( '\n', ''))
+      - '''Name'' in fetch_after_overwrite_check.certificates[0].tags'
+      - fetch_after_overwrite_check.certificates[0].tags['Name'] == local_certs[0].name
+  - name: update first cert with body of the second, first real time
     aws_acm:
       state: present
       name_tag: '{{ local_certs[0].name }}'
@@ -206,7 +270,23 @@
       - overwrite2.certificate.arn == upload.results[0].certificate.arn
       - overwrite2.certificate.domain_name == local_certs[1].domain
       - not overwrite2.changed
-  - name: delete certs 1 and 2
+  - name: delete certs 1 and 2 in check mode
+    aws_acm:
+      state: absent
+      domain_name: '{{ local_certs[1].domain }}'
+    check_mode: yes
+    register: delete_both_check
+    failed_when: not delete_both_check.changed
+  - name: fetch info for certs 1 and 2
+    aws_acm_info:
+      tags:
+        Name: '{{ local_certs[item].name }}'
+    register: check_del_one_check
+    with_items:
+    - 0
+    - 1
+    failed_when: (check_del_one.certificates | length) == 0
+  - name: delete certs 1 and 2 real
     aws_acm:
       state: absent
       domain_name: '{{ local_certs[1].domain }}'
@@ -270,6 +350,13 @@
       - delete_third.arns is defined
       - delete_third.arns | length == 0
       - not delete_third.changed
+  - name: delete cert 3 again, check mode
+    aws_acm:
+      state: absent
+      domain_name: '{{ local_certs[2].domain }}'
+    check_mode: yes
+    register: delete_third_check
+    failed_when: delete_third_check.changed
   - name: check directory was made
     assert:
       that:

--- a/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
+++ b/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
@@ -9,32 +9,37 @@
   - name: list certs
     aws_acm_info: null
     register: list_all
-    failed_when: list_all.certificates is not defined
   - name: list certs with check mode
     aws_acm_info: null
     register: list_all_check
-    failed_when: (list_all.certificates != list_all_check.certificates) or list_all_check.changed
     check_mode: yes # read-only task, should work the same as with no
+  - name: check certificate listing worked
+    assert:
+      that:
+        - list_all.certificates is defined
+        - list_all_check.certificates is defined
+        - list_all.certificates == list_all_check.certificates
   - name: ensure absent cert which doesn't exist - first time
     aws_acm:
       name_tag: '{{ item.name }}'
       state: absent
-    with_items: '{{ local_certs }}'
+    with_nested:
+      - '{{ local_certs }}'
+      - [True, False]
   - name: ensure absent cert which doesn't exist - second time
     aws_acm:
-      name_tag: '{{ item.name }}'
+      name_tag: '{{ item[0].name }}'
       state: absent
-    with_items: '{{ local_certs }}'
+    changed_when: '{{ item[1] }}'
+    with_nested:
+      - '{{ local_certs }}'
+      - [True, False]
     register: absent_start_two
-    failed_when: absent_start_two.changed
-  - name: ensure absent cert which doesn't exist, in check mode
-    aws_acm:
-      name_tag: '{{ item.name }}'
-      state: absent
-    with_items: '{{ local_certs }}'
-    check_mode: yes # read-only task, should work the same as with no
-    register: absent_check
-    failed_when: absent_check.changed
+  - name: check no change when ensuring absent cert is absent
+    assert:
+      that:
+        - not item.changed
+    with_items: "{{ absent_start_two.results }}"
   - name: list cert which shouldn't exist
     aws_acm_info:
       tags:
@@ -44,7 +49,11 @@
     with_nested:
       - '{{ local_certs }}'
       - [ False, True ] # read-only task, should work the same with check mode or not
-    failed_when: (list_tag.certificates | length > 0) or list_tag.changed
+  - name: check listing of missing cert returns no result
+    assert:
+      that:
+        - (list_tag.certificates | length) == 0
+        -  not list_tag.changed
   - name: check directory was made
     assert:
       that:
@@ -79,14 +88,17 @@
     check_mode: yes
     register: upload_check
     with_items: '{{ local_certs }}'
-    failed_when: not upload_check.changed
-  - name: check cert was not really uploaded in check mode
+  - name: check whether cert was uploaded in check mode
     aws_acm_info:
       tags:
         Name: '{{ item.name }}'
     register: list_after_check_mode_upload
     with_items: '{{ local_certs }}'
-    failed_when: list_after_check_mode_upload | length > 0
+  - name: check cert was not really uploaded in check mode
+    assert:
+      that:
+        - upload_check.changed
+        - (list_after_check_mode_upload | length) == 0
   - name: upload certificates first time
     aws_acm:
       name_tag: '{{ item.name }}'
@@ -135,7 +147,11 @@
     check_mode: yes
     register: fetch_after_up_check
     with_items: '{{ upload.results }}'
-    failed_when: fetch_after_up_check.changed or (fetch_after_up_check.certificates != fetch_after_up.certificates)
+  - name: check values in uploaded cert
+    assert:
+      that:
+        - not fetch_after_up_check.changed
+        - fetch_after_up_check.certificates == fetch_after_up.certificates
   - name: fetch data about cert just uploaded, by name
     aws_acm_info:
       tags:
@@ -197,7 +213,10 @@
       private_key: '{{ lookup(''file'', local_certs[1].priv_key ) }}'
     check_mode: yes
     register: overwrite_check
-    failed_when: (not overwrite_check.changed)
+  - name: check update in check mode detected required update
+    assert:
+      that:
+        - overwrite_check.changed
   - name: check previous tasks did not change real cert
     aws_acm_info:
       tags:
@@ -276,7 +295,6 @@
       domain_name: '{{ local_certs[1].domain }}'
     check_mode: yes
     register: delete_both_check
-    failed_when: not delete_both_check.changed
   - name: fetch info for certs 1 and 2
     aws_acm_info:
       tags:
@@ -285,7 +303,11 @@
     with_items:
     - 0
     - 1
-    failed_when: (check_del_one.certificates | length) == 0
+  - name: test deletion with check mode detected change
+      assert:
+        that:
+          - delete_both_check.changed
+          - (check_del_one.certificates | length) == 2
   - name: delete certs 1 and 2 real
     aws_acm:
       state: absent
@@ -314,13 +336,16 @@
   - name: check certs 1 and 2 were already deleted
     with_items: '{{ check_del_one.results }}'
     assert:
-      that: item.certificates | length == 0
-  - name: check cert 3 not deleted
+      that: (item.certificates | length) == 0
+  - name: check cert 3
     aws_acm_info:
       tags:
         Name: '{{ local_certs[2].name }}'
     register: check_del_one_remain
-    failed_when: check_del_one_remain.certificates | length != 1
+  - name: check cert 3 not deleted
+    assert:
+      that:
+        - (check_del_one_remain.certificates | length) == 1
   - name: delete cert 3
     aws_acm:
       state: absent
@@ -356,7 +381,10 @@
       domain_name: '{{ local_certs[2].domain }}'
     check_mode: yes
     register: delete_third_check
-    failed_when: delete_third_check.changed
+  - name: test deletion in check mode detected required change
+    assert:
+      that:
+        - not delete_third_check.changed
   - name: check directory was made
     assert:
       that:

--- a/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
+++ b/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
@@ -48,9 +48,10 @@
       - '{{ local_certs }}'
       - [ False, True ] # read-only task, should work the same with check mode or not
   - name: check listing of missing cert returns no result
+    with_items: "{{ list_tag.results }}"
     assert:
       that:
-        - (list_tag.certificates | length) == 0
+        - (item.certificates | length) == 0
         - not list_tag.changed
   - name: check directory was made
     assert:
@@ -93,10 +94,11 @@
     register: list_after_check_mode_upload
     with_items: '{{ local_certs }}'
   - name: check cert was not really uploaded in check mode
+    with_items: "{{ list_after_check_mode_upload.results }}"
     assert:
       that:
         - upload_check.changed
-        - (list_after_check_mode_upload | length) == 0
+        - (item.certificates | length) == 0
   - name: upload certificates first time
     aws_acm:
       name_tag: '{{ item.name }}'
@@ -139,17 +141,6 @@
       fetch_after_up_result: '{{ item }}'
       upload_result: '{{ item.item }}'
       original_cert: '{{ item.item.item }}'
-  - name: fetch data about cert just uploaded, by ARN, check mode
-    aws_acm_info:
-      certificate_arn: '{{ item.certificate.arn }}'
-    check_mode: yes
-    register: fetch_after_up_check
-    with_items: '{{ upload.results }}'
-  - name: check values in uploaded cert
-    assert:
-      that:
-        - not fetch_after_up_check.changed
-        - fetch_after_up_check.certificates == fetch_after_up.certificates
   - name: fetch data about cert just uploaded, by name
     aws_acm_info:
       tags:
@@ -293,6 +284,10 @@
       domain_name: '{{ local_certs[1].domain }}'
     check_mode: yes
     register: delete_both_check
+  - name: test deletion with check mode detected change
+    assert:
+      that:
+        - delete_both_check.changed
   - name: fetch info for certs 1 and 2
     aws_acm_info:
       tags:
@@ -302,10 +297,10 @@
     - 0
     - 1
   - name: test deletion with check mode detected change
+    with_items: '{{ check_del_one_check.results }}'
     assert:
       that:
-        - delete_both_check.changed
-        - (check_del_one.certificates | length) == 2
+        - (item.certificates | length) == 1
   - name: delete certs 1 and 2 real
     aws_acm:
       state: absent


### PR DESCRIPTION
##### SUMMARY

Fixes #451 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_acm

##### ADDITIONAL INFORMATION

I've hard-coded the domain and ARN to return for some check_mode tasks.
I don't know if I need to bother dynamically extracting the domain from the local cert file.
I also don't know if ARNs are predictable for ACM certs.

I have not tried running these integration tests locally because the tests won't run. `ansible-test` tells me I need to configure stuff. I did, but `ansible-test` still won't run.

```
╭╴matthew:~/Documents/Projects/software/ansible/collections/ansible_collections/community/aws
╰╴ $ ansible-test integration --docker centos8 -v aws_acm
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
WARNING: Excluding tests marked "unstable" which require --allow-unstable or prefixing with "unstable/": aws_acm
WARNING: Excluding tests marked "cloud/aws" which require config (see "/home/matthew/.local/lib/python3.8/site-packages/ansible_test/config/cloud-config-aws.ini.template"): aws_acm
WARNING: All targets skipped.
```

So I'm just hoping that the CI bots can run the tests for me.