### PR TITLE
Add Python and Glue version parameters, add check mode

### DIFF
--- a/changelogs/fragments/480-aws_glue_job-python-glue-version.yml
+++ b/changelogs/fragments/480-aws_glue_job-python-glue-version.yml
@@ -2,3 +2,4 @@ minor_changes:
   - aws_glue_job - Added ``glue_version`` parameter (https://github.com/ansible-collections/community.aws/pull/480).
   - aws_glue_job - Added ``command_python_version`` parameter (https://github.com/ansible-collections/community.aws/pull/480).
   - aws_glue_job - Added support for check mode (https://github.com/ansible-collections/community.aws/pull/480).
+  - aws_glue_job - Added support for tags (https://github.com/ansible-collections/community.aws/pull/480).

--- a/changelogs/fragments/480-aws_glue_job-python-glue-version.yml
+++ b/changelogs/fragments/480-aws_glue_job-python-glue-version.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - aws_glue_job - Added ``glue_version`` parameter (https://github.com/ansible-collections/community.aws/pull/480).
+  - aws_glue_job - Added ``command_python_version`` parameter (https://github.com/ansible-collections/community.aws/pull/480).
+  - aws_glue_job - Added support for check mode (https://github.com/ansible-collections/community.aws/pull/480).

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -33,7 +33,7 @@ options:
       - Python version being used to execute a Python shell job.
       - AWS currently supports C('2') or C('3').
     type: str
-    version_added: 2.1.0
+    version_added: 2.2.0
   command_script_location:
     description:
       - The S3 path to a script that executes a job.
@@ -83,7 +83,7 @@ options:
       - If the I(tags) parameter is not set then tags will not be modified.
     default: true
     type: bool
-    version_added: 2.1.0
+    version_added: 2.2.0
   role:
     description:
       - The name or ARN of the IAM role associated with this job.
@@ -100,7 +100,7 @@ options:
       - A hash/dictionary of tags to be applied to the job.
       - Remove completely or specify an empty dictionary to remove all tags.
     type: dict
-    version_added: 2.1.0
+    version_added: 2.2.0
   timeout:
     description:
       - The job timeout in minutes.

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -56,6 +56,7 @@ options:
     description:
       - AWS Glue version. This determines the available version of Apache Scala and Python as described here
         U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
+    default: 0.9
     type: str
   max_concurrent_runs:
     description:
@@ -467,7 +468,7 @@ def main():
             connections=dict(type='list', elements='str'),
             default_arguments=dict(type='dict'),
             description=dict(type='str'),
-            glue_version=dict(type='str'),
+            glue_version=dict(type='str', default='0.9'),
             max_concurrent_runs=dict(type='int'),
             max_retries=dict(type='int'),
             name=dict(required=True, type='str'),

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -399,7 +399,7 @@ def main():
         dict(
             allocated_capacity=dict(type='int'),
             command_name=dict(type='str', default='glueetl'),
-            command_python_version=dict(type='str', default='2'),
+            command_python_version=dict(type='str'),
             command_script_location=dict(type='str'),
             connections=dict(type='list', elements='str'),
             default_arguments=dict(type='dict'),

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -52,6 +52,12 @@ options:
     description:
       - Description of the job being defined.
     type: str
+  glue_version:
+    description:
+      - AWS Glue version. This determines the available version of Apache Scala and Python as described here
+        U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
+    default: 0.9
+    type: str
   max_concurrent_runs:
     description:
       - The maximum number of concurrent runs allowed for the job. The default is 1. An error is returned when
@@ -462,6 +468,7 @@ def main():
             connections=dict(type='list', elements='str'),
             default_arguments=dict(type='dict'),
             description=dict(type='str'),
+            glue_version=dict(type='str', default='0.9'),
             max_concurrent_runs=dict(type='int'),
             max_retries=dict(type='int'),
             name=dict(required=True, type='str'),

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -465,7 +465,7 @@ def main():
             purge_tags=dict(type='bool', default=True),
             role=dict(type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
-            tags=dict(type='dict', default={}),
+            tags=dict(type='dict'),
             timeout=dict(type='int'),
             worker_type=dict(choices=['Standard', 'G.1X', 'G.2X'], type='str'),
         )

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -432,7 +432,7 @@ def create_or_update_glue_job(connection, module, glue_job):
 
     changed |= ensure_tags(connection, module, glue_job)
 
-    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_job or {}))
+    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_job or {}, ignore_list=['DefaultArguments']))
 
 
 def delete_glue_job(connection, module, glue_job):

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -52,13 +52,6 @@ options:
     description:
       - Description of the job being defined.
     type: str
-  glue_version:
-    description:
-      - AWS Glue version. This determines the available version of Apache Scala and Python as described here
-        U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
-    default: 0.9
-    type: str
-    version_added: 1.5.0
   max_concurrent_runs:
     description:
       - The maximum number of concurrent runs allowed for the job. The default is 1. An error is returned when

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -305,9 +305,9 @@ def _compare_glue_job_params(user_params, current_params):
             return True
         if user_params['Command']['PythonVersion'] != current_params['Command']['PythonVersion']:
             return True
-    if 'Connections' in user_params and set(user_params['Connections']) != set(current_params['Connections']):
+    if 'Connections' in user_params and user_params['Connections'] != current_params['Connections']:
         return True
-    if 'DefaultArguments' in user_params and set(user_params['DefaultArguments']) != set(current_params['DefaultArguments']):
+    if 'DefaultArguments' in user_params and user_params['DefaultArguments'] != current_params['DefaultArguments']:
         return True
     if 'Description' in user_params and user_params['Description'] != current_params['Description']:
         return True

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -31,7 +31,6 @@ options:
   command_python_version:
     description:
       - Python version being used to execute a Python shell job. Allowed values are '2' or '3'.
-    default: 2
     type: str
   command_script_location:
     description:
@@ -56,7 +55,6 @@ options:
     description:
       - AWS Glue version. This determines the available version of Apache Scala and Python as described here
         U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
-    default: 0.9
     type: str
   max_concurrent_runs:
     description:
@@ -404,7 +402,7 @@ def main():
             connections=dict(type='list', elements='str'),
             default_arguments=dict(type='dict'),
             description=dict(type='str'),
-            glue_version=dict(type='str', default='0.9'),
+            glue_version=dict(type='str'),
             max_concurrent_runs=dict(type='int'),
             max_retries=dict(type='int'),
             name=dict(required=True, type='str'),

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -33,7 +33,7 @@ options:
       - Python version being used to execute a Python shell job.
       - AWS currently supports C('2') or C('3').
     type: str
-    version_added: 1.5.0
+    version_added: 2.1.0
   command_script_location:
     description:
       - The S3 path to a script that executes a job.
@@ -83,7 +83,7 @@ options:
       - If the I(tags) parameter is not set then tags will not be modified.
     default: true
     type: bool
-    version_added: 1.5.0
+    version_added: 2.1.0
   role:
     description:
       - The name or ARN of the IAM role associated with this job.
@@ -100,7 +100,7 @@ options:
       - A hash/dictionary of tags to be applied to the job.
       - Remove completely or specify an empty dictionary to remove all tags.
     type: dict
-    version_added: 1.5.0
+    version_added: 2.1.0
   timeout:
     description:
       - The job timeout in minutes.

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -52,12 +52,6 @@ options:
     description:
       - Description of the job being defined.
     type: str
-  glue_version:
-    description:
-      - AWS Glue version. This determines the available version of Apache Scala and Python as described here
-        U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
-    type: str
-    version_added: 1.5.0
   max_concurrent_runs:
     description:
       - The maximum number of concurrent runs allowed for the job. The default is 1. An error is returned when

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -56,7 +56,6 @@ options:
     description:
       - AWS Glue version. This determines the available version of Apache Scala and Python as described here
         U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
-    default: 0.9
     type: str
   max_concurrent_runs:
     description:
@@ -468,7 +467,7 @@ def main():
             connections=dict(type='list', elements='str'),
             default_arguments=dict(type='dict'),
             description=dict(type='str'),
-            glue_version=dict(type='str', default='0.9'),
+            glue_version=dict(type='str'),
             max_concurrent_runs=dict(type='int'),
             max_retries=dict(type='int'),
             name=dict(required=True, type='str'),

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -58,6 +58,7 @@ options:
         U(https://docs.aws.amazon.com/glue/latest/dg/add-job.html).
     default: 0.9
     type: str
+    version_added: 1.5.0
   max_concurrent_runs:
     description:
       - The maximum number of concurrent runs allowed for the job. The default is 1. An error is returned when

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -469,7 +469,6 @@ def main():
             connections=dict(type='list', elements='str'),
             default_arguments=dict(type='dict'),
             description=dict(type='str'),
-            glue_version=dict(type='str', default='0.9'),
             max_concurrent_runs=dict(type='int'),
             max_retries=dict(type='int'),
             name=dict(required=True, type='str'),

--- a/tests/integration/targets/aws_glue_job/aliases
+++ b/tests/integration/targets/aws_glue_job/aliases
@@ -1,0 +1,1 @@
+cloud/aws

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,8 +1,12 @@
 ---
 glue_job_name: "{{ resource_prefix }}"
 glue_job_description: Test job
+<<<<<<< HEAD
 glue_job_command_script_location: "s3://test-s3-bucket-glue/job.py"
 glue_job_temp_dir: "s3://test-s3-bucket-glue/temp/"
+=======
+glue_job_command_script_location: test-s3-bucket-glue/job.py
+>>>>>>> Update IAM role name for Glue job to make sure it's shorter than 64 characters
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+glue_job_name: '{{ resource_prefix }}'
+glue_job_role_name: 'ansible-test-{{ resource_prefix }}-glue-job'
+glue_job_description: Test job
+glue_job_command_script_location: test-s3-bucket-glue/job.py

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 glue_job_name: "{{ resource_prefix }}"
 glue_job_description: Test job
-glue_job_command_script_location: test-s3-bucket-glue/job.py
+glue_job_command_script_location: "s3://test-s3-bucket-glue/job.py"
+glue_job_temp_dir: "s3://test-s3-bucket-glue/temp/"
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,12 +1,8 @@
 ---
 glue_job_name: "{{ resource_prefix }}"
 glue_job_description: Test job
-<<<<<<< HEAD
 glue_job_command_script_location: "s3://test-s3-bucket-glue/job.py"
 glue_job_temp_dir: "s3://test-s3-bucket-glue/temp/"
-=======
-glue_job_command_script_location: test-s3-bucket-glue/job.py
->>>>>>> Update IAM role name for Glue job to make sure it's shorter than 64 characters
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel

--- a/tests/integration/targets/aws_glue_job/defaults/main.yml
+++ b/tests/integration/targets/aws_glue_job/defaults/main.yml
@@ -1,5 +1,11 @@
 ---
-glue_job_name: '{{ resource_prefix }}'
-glue_job_role_name: 'ansible-test-{{ resource_prefix }}-glue-job'
+glue_job_name: "{{ resource_prefix }}"
 glue_job_description: Test job
 glue_job_command_script_location: test-s3-bucket-glue/job.py
+# IAM role names have to be less than 64 characters
+# The 8 digit identifier at the end of resource_prefix helps determine during
+# which test something was created and allows tests to be run in parallel
+# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
+# we need both sets of digits to keep the resource name unique
+unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+glue_job_role_name: "ansible-test-{{ unique_id }}-glue-job"

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -84,7 +84,7 @@
     - name: Verity that Glue job was created
       assert:
         that:
-          - glue_job.changed"
+          - glue_job.changed
           - glue_job.command.python_version == job_info["Job"]["Command"]["PythonVersion"]
           - glue_job.command.script_location == job_info["Job"]["Command"]["ScriptLocation"]
           - glue_job.default_arguments == job_info["Job"]["DefaultArguments"]
@@ -127,8 +127,8 @@
         that:
           - not glue_job_idempotent_check.changed
           - job_info["Job"]["Name"] == job_info_idempotent_check["Job"]["Name"]
-          - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent_check["Job"]["Command"]["PythonVersion"]
-          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent_check["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["Command"]["PythonVersion"] == job_info_idempotent_check["Job"]["Command"]["PythonVersion"]
+          - job_info["Job"]["Command"]["ScriptLocation"] == job_info_idempotent_check["Job"]["Command"]["ScriptLocation"]
           - job_info["Job"]["DefaultArguments"] == job_info_idempotent_check["Job"]["DefaultArguments"]
           - job_info["Job"]["Description"] == job_info_idempotent_check["Job"]["Description"]
           - job_info["Job"]["GlueVersion"] == job_info_idempotent_check["Job"]["GlueVersion"]

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -50,7 +50,7 @@
       assert:
         that:
           - glue_job_check.changed
-          - not glue_job_check.description
+          - "description" not in glue_job_check
 
     - name: Create Glue job
       aws_glue_job:

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -32,11 +32,14 @@
     - name: Create Glue job (check mode)
       aws_glue_job:
         name: "{{ glue_job_name }}"
-        description: "{{ glue_job_description }}"
-        command_script_location: "{{ glue_job_command_script_location }}"
         command_python_version: 3
+        command_script_location: "{{ glue_job_command_script_location }}"
+        description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
+        tags:
+          Environment: Test
+          Product: Glue
         state: present
       check_mode: true
       register: glue_job_check
@@ -50,11 +53,14 @@
     - name: Create Glue job
       aws_glue_job:
         name: "{{ glue_job_name }}"
-        description: "{{ glue_job_description }}"
-        command_script_location: "{{ glue_job_command_script_location }}"
         command_python_version: 3
+        command_script_location: "{{ glue_job_command_script_location }}"
+        description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
+        tags:
+          Environment: Test
+          Product: Glue
         state: present
       register: glue_job
 
@@ -75,20 +81,23 @@
       assert:
         that:
           - glue_job.changed"
-          - glue_job.description == job_info["Job"]["Description"]
-          - glue_job.role == job_info["Job"]["Role"]
-          - glue_job.command.script_location == job_info["Job"]["Command"]["ScriptLocation"]
           - glue_job.command.python_version == job_info["Job"]["Command"]["PythonVersion"]
+          - glue_job.command.script_location == job_info["Job"]["Command"]["ScriptLocation"]
+          - glue_job.description == job_info["Job"]["Description"]
           - glue_job.glue_version == job_info["Job"]["GlueVersion"]
+          - glue_job.role == job_info["Job"]["Role"]
 
     - name: Create Glue job (idempotent) (check mode)
       aws_glue_job:
         name: "{{ glue_job_name }}"
-        description: "{{ glue_job_description }}"
-        command_script_location: "{{ glue_job_command_script_location }}"
         command_python_version: 3
+        command_script_location: "{{ glue_job_command_script_location }}"
+        description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
+        tags:
+          Environment: Test
+          Product: Glue
         state: present
       check_mode: true
       register: glue_job_idempotent_check
@@ -111,20 +120,23 @@
         that:
           - not glue_job_idempotent_check.changed
           - job_info["Job"]["Name"] == job_info_idempotent_check["Job"]["Name"]
-          - job_info["Job"]["Description"] == job_info_idempotent_check["Job"]["Description"]
-          - job_info["Job"]["Role"] == job_info_idempotent_check["Job"]["Role"]
-          - job_info["Job"]["GlueVersion"] == job_info_idempotent_check["Job"]["GlueVersion"]
-          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent_check["Job"]["Command"]["ScriptLocation"]
           - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent_check["Job"]["Command"]["PythonVersion"]
+          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent_check["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["Description"] == job_info_idempotent_check["Job"]["Description"]
+          - job_info["Job"]["GlueVersion"] == job_info_idempotent_check["Job"]["GlueVersion"]
+          - job_info["Job"]["Role"] == job_info_idempotent_check["Job"]["Role"]
 
     - name: Create Glue job (idempotent)
       aws_glue_job:
         name: "{{ glue_job_name }}"
-        description: "{{ glue_job_description }}"
-        command_script_location: "{{ glue_job_command_script_location }}"
         command_python_version: 3
+        command_script_location: "{{ glue_job_command_script_location }}"
+        description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
+        tags:
+          Environment: Test
+          Product: Glue
         state: present
       register: glue_job_idempotent
 
@@ -146,20 +158,22 @@
         that:
           - not glue_job_idempotent.changed
           - job_info["Job"]["Name"] == job_info_idempotent["Job"]["Name"]
-          - job_info["Job"]["Description"] == job_info_idempotent["Job"]["Description"]
-          - job_info["Job"]["Role"] == job_info_idempotent["Job"]["Role"]
-          - job_info["Job"]["GlueVersion"] == job_info_idempotent["Job"]["GlueVersion"]
-          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent["Job"]["Command"]["ScriptLocation"]
           - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent["Job"]["Command"]["PythonVersion"]
+          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["Description"] == job_info_idempotent["Job"]["Description"]
+          - job_info["Job"]["GlueVersion"] == job_info_idempotent["Job"]["GlueVersion"]
+          - job_info["Job"]["Role"] == job_info_idempotent["Job"]["Role"]
 
     - name: Update Glue job (check mode)
       aws_glue_job:
         name: "{{ glue_job_name }}"
-        description: "{{ glue_job_description }}"
-        command_script_location: "{{ glue_job_command_script_location }}"
         command_python_version: 2
+        command_script_location: "{{ glue_job_command_script_location }}"
+        description: "{{ glue_job_description }}"
         glue_version: "0.9"
         role: "{{ glue_job_role_name }}"
+        tags:
+          Environment: Test
         state: present
       check_mode: true
       register: glue_job_update_check
@@ -181,20 +195,22 @@
       assert:
         that:
           - glue_job_update_check.changed
-          - glue_job_update_check.description == job_info_update_check["Job"]["Description"]
-          - glue_job_update_check.role == job_info_update_check["Job"]["Role"]
-          - glue_job_update_check.command.script_location == job_info_update_check["Job"]["Command"]["ScriptLocation"]
           - glue_job_update_check.command.python_version == "3"
+          - glue_job_update_check.command.script_location == job_info_update_check["Job"]["Command"]["ScriptLocation"]
+          - glue_job_update_check.description == job_info_update_check["Job"]["Description"]
           - glue_job_update_check.glue_version == "2.0"
+          - glue_job_update_check.role == job_info_update_check["Job"]["Role"]
 
     - name: Update Glue job
       aws_glue_job:
         name: "{{ glue_job_name }}"
-        description: "{{ glue_job_description }}"
-        command_script_location: "{{ glue_job_command_script_location }}"
         command_python_version: 2
+        command_script_location: "{{ glue_job_command_script_location }}"
+        description: "{{ glue_job_description }}"
         glue_version: "0.9"
         role: "{{ glue_job_role_name }}"
+        tags:
+          Environment: Test
         state: present
       register: glue_job_update
 
@@ -215,11 +231,11 @@
       assert:
         that:
           - glue_job_update.changed
-          - glue_job_update.description == job_info_update["Job"]["Description"]
-          - glue_job_update.role == job_info_update["Job"]["Role"]
-          - glue_job_update.command.script_location == job_info_update["Job"]["Command"]["ScriptLocation"]
           - glue_job_update.command.python_version == job_info_update["Job"]["Command"]["PythonVersion"]
+          - glue_job_update.command.script_location == job_info_update["Job"]["Command"]["ScriptLocation"]
+          - glue_job_update.description == job_info_update["Job"]["Description"]
           - glue_job_update.glue_version == job_info_update["Job"]["Command"]["GlueVersion"]
+          - glue_job_update.role == job_info_update["Job"]["Role"]
 
     - name: Delete Glue job (check mode)
       aws_glue_job:

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -27,7 +27,7 @@
                 Service: glue.amazonaws.com
         create_instance_profile: false
         managed_policies:
-          - "arn:aws:iam::aws:policy/AWSGlueServiceRole"
+          - "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
 
     - name: Create Glue job (check mode)
       aws_glue_job:

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -293,7 +293,7 @@
 
   always:
     - name: Delete Glue job
-      aws_glue_connection:
+      aws_glue_job:
         name: "{{ glue_job_name }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -18,7 +18,7 @@
     - name: Create minimal Glue job role
       iam_role:
         name: "{{ glue_job_role_name }}"
-        trust_policy:
+        assume_role_policy_document:
           Version: "2008-10-17"
           Statement:
             - Action: "sts:AssumeRole"

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -34,6 +34,8 @@
         name: "{{ glue_job_name }}"
         command_python_version: 3
         command_script_location: "{{ glue_job_command_script_location }}"
+        default_arguments:
+          "--TempDir": "{{ glue_job_temp_dir }}"
         description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
@@ -55,6 +57,8 @@
         name: "{{ glue_job_name }}"
         command_python_version: 3
         command_script_location: "{{ glue_job_command_script_location }}"
+        default_arguments:
+          "--TempDir": "{{ glue_job_temp_dir }}"
         description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
@@ -83,6 +87,7 @@
           - glue_job.changed"
           - glue_job.command.python_version == job_info["Job"]["Command"]["PythonVersion"]
           - glue_job.command.script_location == job_info["Job"]["Command"]["ScriptLocation"]
+          - glue_job.default_arguments == job_info["Job"]["DefaultArguments"]
           - glue_job.description == job_info["Job"]["Description"]
           - glue_job.glue_version == job_info["Job"]["GlueVersion"]
           - glue_job.role == job_info["Job"]["Role"]
@@ -92,6 +97,8 @@
         name: "{{ glue_job_name }}"
         command_python_version: 3
         command_script_location: "{{ glue_job_command_script_location }}"
+        default_arguments:
+          "--TempDir": "{{ glue_job_temp_dir }}"
         description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
@@ -122,6 +129,7 @@
           - job_info["Job"]["Name"] == job_info_idempotent_check["Job"]["Name"]
           - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent_check["Job"]["Command"]["PythonVersion"]
           - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent_check["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["DefaultArguments"] == job_info_idempotent_check["Job"]["DefaultArguments"]
           - job_info["Job"]["Description"] == job_info_idempotent_check["Job"]["Description"]
           - job_info["Job"]["GlueVersion"] == job_info_idempotent_check["Job"]["GlueVersion"]
           - job_info["Job"]["Role"] == job_info_idempotent_check["Job"]["Role"]
@@ -131,6 +139,8 @@
         name: "{{ glue_job_name }}"
         command_python_version: 3
         command_script_location: "{{ glue_job_command_script_location }}"
+        default_arguments:
+          "--TempDir": "{{ glue_job_temp_dir }}"
         description: "{{ glue_job_description }}"
         glue_version: "2.0"
         role: "{{ glue_job_role_name }}"
@@ -158,8 +168,9 @@
         that:
           - not glue_job_idempotent.changed
           - job_info["Job"]["Name"] == job_info_idempotent["Job"]["Name"]
-          - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent["Job"]["Command"]["PythonVersion"]
-          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["Command"]["PythonVersion"] == job_info_idempotent["Job"]["Command"]["PythonVersion"]
+          - job_info["Job"]["Command"]["ScriptLocation"] == job_info_idempotent["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["DefaultArguments"] == job_info_idempotent["Job"]["DefaultArguments"]
           - job_info["Job"]["Description"] == job_info_idempotent["Job"]["Description"]
           - job_info["Job"]["GlueVersion"] == job_info_idempotent["Job"]["GlueVersion"]
           - job_info["Job"]["Role"] == job_info_idempotent["Job"]["Role"]
@@ -169,6 +180,8 @@
         name: "{{ glue_job_name }}"
         command_python_version: 2
         command_script_location: "{{ glue_job_command_script_location }}"
+        default_arguments:
+          "--TempDir": "{{ glue_job_temp_dir }}subfolder/"
         description: "{{ glue_job_description }}"
         glue_version: "0.9"
         role: "{{ glue_job_role_name }}"
@@ -195,10 +208,11 @@
       assert:
         that:
           - glue_job_update_check.changed
-          - glue_job_update_check.command.python_version == "3"
+          - glue_job_update_check.command.python_version == job_info_update_check["Job"]["Command"]["PythonVersion"]
           - glue_job_update_check.command.script_location == job_info_update_check["Job"]["Command"]["ScriptLocation"]
+          - glue_job_update_check.default_arguments == job_info_update_check["Job"]["DefaultArguments"]
           - glue_job_update_check.description == job_info_update_check["Job"]["Description"]
-          - glue_job_update_check.glue_version == "2.0"
+          - glue_job_update_check.glue_version == job_info_update_check["Job"]["Command"]["GlueVersion"]
           - glue_job_update_check.role == job_info_update_check["Job"]["Role"]
 
     - name: Update Glue job
@@ -206,6 +220,8 @@
         name: "{{ glue_job_name }}"
         command_python_version: 2
         command_script_location: "{{ glue_job_command_script_location }}"
+        default_arguments:
+          "--TempDir": "{{ glue_job_temp_dir }}subfolder/"
         description: "{{ glue_job_description }}"
         glue_version: "0.9"
         role: "{{ glue_job_role_name }}"
@@ -233,6 +249,7 @@
           - glue_job_update.changed
           - glue_job_update.command.python_version == job_info_update["Job"]["Command"]["PythonVersion"]
           - glue_job_update.command.script_location == job_info_update["Job"]["Command"]["ScriptLocation"]
+          - glue_job_update.default_arguments == job_info_update["Job"]["DefaultArguments"]
           - glue_job_update.description == job_info_update["Job"]["Description"]
           - glue_job_update.glue_version == job_info_update["Job"]["Command"]["GlueVersion"]
           - glue_job_update.role == job_info_update["Job"]["Role"]

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -212,7 +212,7 @@
           - glue_job_update_check.command.script_location == job_info_update_check["Job"]["Command"]["ScriptLocation"]
           - glue_job_update_check.default_arguments == job_info_update_check["Job"]["DefaultArguments"]
           - glue_job_update_check.description == job_info_update_check["Job"]["Description"]
-          - glue_job_update_check.glue_version == job_info_update_check["Job"]["Command"]["GlueVersion"]
+          - glue_job_update_check.glue_version == job_info_update_check["Job"]["GlueVersion"]
           - glue_job_update_check.role == job_info_update_check["Job"]["Role"]
 
     - name: Update Glue job
@@ -251,7 +251,7 @@
           - glue_job_update.command.script_location == job_info_update["Job"]["Command"]["ScriptLocation"]
           - glue_job_update.default_arguments == job_info_update["Job"]["DefaultArguments"]
           - glue_job_update.description == job_info_update["Job"]["Description"]
-          - glue_job_update.glue_version == job_info_update["Job"]["Command"]["GlueVersion"]
+          - glue_job_update.glue_version == job_info_update["Job"]["GlueVersion"]
           - glue_job_update.role == job_info_update["Job"]["Role"]
 
     - name: Delete Glue job (check mode)

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -50,7 +50,7 @@
       assert:
         that:
           - glue_job_check.changed
-          - "description" not in glue_job_check
+          - glue_job_check.description is not defined
 
     - name: Create Glue job
       aws_glue_job:

--- a/tests/integration/targets/aws_glue_job/tasks/main.yml
+++ b/tests/integration/targets/aws_glue_job/tasks/main.yml
@@ -1,0 +1,271 @@
+---
+- name: aws_glue_job integration tests
+  collections:
+    - amazon.aws
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    # AWS CLI is needed until there's a module to get info about Glue jobs
+    - name: Install AWS CLI
+      pip:
+        name: awscli
+        state: present
+
+    - name: Create minimal Glue job role
+      iam_role:
+        name: "{{ glue_job_role_name }}"
+        trust_policy:
+          Version: "2008-10-17"
+          Statement:
+            - Action: "sts:AssumeRole"
+              Effect: Allow
+              Principal:
+                Service: glue.amazonaws.com
+        create_instance_profile: false
+        managed_policies:
+          - "arn:aws:iam::aws:policy/AWSGlueServiceRole"
+
+    - name: Create Glue job (check mode)
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        description: "{{ glue_job_description }}"
+        command_script_location: "{{ glue_job_command_script_location }}"
+        command_python_version: 3
+        glue_version: "2.0"
+        role: "{{ glue_job_role_name }}"
+        state: present
+      check_mode: true
+      register: glue_job_check
+
+    - name: Verity that Glue job was not created in check mode
+      assert:
+        that:
+          - glue_job_check.changed
+          - not glue_job_check.description
+
+    - name: Create Glue job
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        description: "{{ glue_job_description }}"
+        command_script_location: "{{ glue_job_command_script_location }}"
+        command_python_version: 3
+        glue_version: "2.0"
+        role: "{{ glue_job_role_name }}"
+        state: present
+      register: glue_job
+
+    - name: Get info on Glue job
+      command: "aws glue get-job --job-name {{ glue_job_name }}"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: job_info_query
+
+    - name: Convert it to an object
+      set_fact:
+        job_info: "{{ job_info_query.stdout | from_json }}"
+
+    - name: Verity that Glue job was created
+      assert:
+        that:
+          - glue_job.changed"
+          - glue_job.description == job_info["Job"]["Description"]
+          - glue_job.role == job_info["Job"]["Role"]
+          - glue_job.command.script_location == job_info["Job"]["Command"]["ScriptLocation"]
+          - glue_job.command.python_version == job_info["Job"]["Command"]["PythonVersion"]
+          - glue_job.glue_version == job_info["Job"]["GlueVersion"]
+
+    - name: Create Glue job (idempotent) (check mode)
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        description: "{{ glue_job_description }}"
+        command_script_location: "{{ glue_job_command_script_location }}"
+        command_python_version: 3
+        glue_version: "2.0"
+        role: "{{ glue_job_role_name }}"
+        state: present
+      check_mode: true
+      register: glue_job_idempotent_check
+
+    - name: Get info on Glue job
+      command: "aws glue get-job --job-name {{ glue_job_name }}"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: job_info_query_idempotent_check
+
+    - name: Convert it to an object
+      set_fact:
+        job_info_idempotent_check: "{{ job_info_query_idempotent_check.stdout | from_json }}"
+
+    - name: Verity that Glue job was not modified in check mode
+      assert:
+        that:
+          - not glue_job_idempotent_check.changed
+          - job_info["Job"]["Name"] == job_info_idempotent_check["Job"]["Name"]
+          - job_info["Job"]["Description"] == job_info_idempotent_check["Job"]["Description"]
+          - job_info["Job"]["Role"] == job_info_idempotent_check["Job"]["Role"]
+          - job_info["Job"]["GlueVersion"] == job_info_idempotent_check["Job"]["GlueVersion"]
+          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent_check["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent_check["Job"]["Command"]["PythonVersion"]
+
+    - name: Create Glue job (idempotent)
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        description: "{{ glue_job_description }}"
+        command_script_location: "{{ glue_job_command_script_location }}"
+        command_python_version: 3
+        glue_version: "2.0"
+        role: "{{ glue_job_role_name }}"
+        state: present
+      register: glue_job_idempotent
+
+    - name: Get info on Glue job
+      command: "aws glue get-job --job-name {{ glue_job_name }}"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: job_info_query_idempotent
+
+    - name: Convert it to an object
+      set_fact:
+        job_info_idempotent: "{{ job_info_query_idempotent.stdout | from_json }}"
+
+    - name: Verity that Glue job was not modified
+      assert:
+        that:
+          - not glue_job_idempotent.changed
+          - job_info["Job"]["Name"] == job_info_idempotent["Job"]["Name"]
+          - job_info["Job"]["Description"] == job_info_idempotent["Job"]["Description"]
+          - job_info["Job"]["Role"] == job_info_idempotent["Job"]["Role"]
+          - job_info["Job"]["GlueVersion"] == job_info_idempotent["Job"]["GlueVersion"]
+          - job_info["Job"]["Command"]['ScriptLocation'] == job_info_idempotent["Job"]["Command"]["ScriptLocation"]
+          - job_info["Job"]["Command"]['PythonVersion'] == job_info_idempotent["Job"]["Command"]["PythonVersion"]
+
+    - name: Update Glue job (check mode)
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        description: "{{ glue_job_description }}"
+        command_script_location: "{{ glue_job_command_script_location }}"
+        command_python_version: 2
+        glue_version: "0.9"
+        role: "{{ glue_job_role_name }}"
+        state: present
+      check_mode: true
+      register: glue_job_update_check
+
+    - name: Get info on Glue job
+      command: "aws glue get-job --job-name {{ glue_job_name }}"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: job_info_query_update_check
+
+    - name: Convert it to an object
+      set_fact:
+        job_info_update_check: "{{ job_info_query_update_check.stdout | from_json }}"
+
+    - name: Verity that Glue job was not modified in check mode
+      assert:
+        that:
+          - glue_job_update_check.changed
+          - glue_job_update_check.description == job_info_update_check["Job"]["Description"]
+          - glue_job_update_check.role == job_info_update_check["Job"]["Role"]
+          - glue_job_update_check.command.script_location == job_info_update_check["Job"]["Command"]["ScriptLocation"]
+          - glue_job_update_check.command.python_version == "3"
+          - glue_job_update_check.glue_version == "2.0"
+
+    - name: Update Glue job
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        description: "{{ glue_job_description }}"
+        command_script_location: "{{ glue_job_command_script_location }}"
+        command_python_version: 2
+        glue_version: "0.9"
+        role: "{{ glue_job_role_name }}"
+        state: present
+      register: glue_job_update
+
+    - name: Get info on Glue job
+      command: "aws glue get-job --job-name {{ glue_job_name }}"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: job_info_query_update
+
+    - name: Convert it to an object
+      set_fact:
+        job_info_update: "{{ job_info_query_update.stdout | from_json }}"
+
+    - name: Verity that Glue job was modified
+      assert:
+        that:
+          - glue_job_update.changed
+          - glue_job_update.description == job_info_update["Job"]["Description"]
+          - glue_job_update.role == job_info_update["Job"]["Role"]
+          - glue_job_update.command.script_location == job_info_update["Job"]["Command"]["ScriptLocation"]
+          - glue_job_update.command.python_version == job_info_update["Job"]["Command"]["PythonVersion"]
+          - glue_job_update.glue_version == job_info_update["Job"]["Command"]["GlueVersion"]
+
+    - name: Delete Glue job (check mode)
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        state: absent
+      check_mode: true
+      register: glue_job_delete_check
+
+    - name: Get info on Glue job
+      command: "aws glue get-job --job-name {{ glue_job_name }}"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: job_info_query_delete_check
+
+    - name: Convert it to an object
+      set_fact:
+        job_info_delete_check: "{{ job_info_query_delete_check.stdout | from_json }}"
+
+    - name: Verity that Glue job was not deleted in check mode
+      assert:
+        that:
+          - glue_job_delete_check.changed
+          - job_info["Job"]["Name"] == job_info_delete_check["Job"]["Name"]
+
+    - name: Delete Glue job
+      aws_glue_job:
+        name: "{{ glue_job_name }}"
+        state: absent
+      register: glue_job_delete
+
+    - name: Verity that Glue job was deleted
+      assert:
+        that:
+          - glue_job_delete.changed
+
+  always:
+    - name: Delete Glue job
+      aws_glue_connection:
+        name: "{{ glue_job_name }}"
+        state: absent
+      ignore_errors: true
+    - name: Delete Glue job role
+      iam_role:
+        name: "{{ glue_job_role_name }}"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add parameters for Python version and Glue version.

Available Python and Glue version can be found here:
https://docs.aws.amazon.com/glue/latest/dg/add-job.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_glue_job

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example:

```
community.aws.aws_glue_job:
  - name: my-job
    description: My test job
    command_script_location: my-s3-bucket/script.py
    command_python_version: 3
    glue_version: "2.0"
    role: MyGlueJobRole
    state: present
```