### PR TITLE
Fix cloudfront_distribution disabling ipv6 when updating resource

### DIFF
--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1975,7 +1975,7 @@ class CloudFrontValidationManager(object):
     def validate_distribution_config_parameters(self, config, default_root_object, ipv6_enabled, http_version, web_acl_id):
         try:
             config['default_root_object'] = default_root_object or config.get('default_root_object', '')
-            config['is_i_p_v_6_enabled'] = ipv6_enabled or config.get('i_p_v_6_enabled', self.__default_ipv6_enabled)
+            config['is_i_p_v6_enabled'] = ipv6_enabled if ipv6_enabled is not None else config.get('is_i_p_v6_enabled', self.__default_ipv6_enabled)
             if http_version is not None or config.get('http_version'):
                 self.validate_attribute_with_allowed_values(http_version, 'http_version', self.__valid_http_versions)
                 config['http_version'] = http_version or config.get('http_version')
@@ -2056,7 +2056,7 @@ class CloudFrontValidationManager(object):
             if caller_reference is not None:
                 return self.validate_distribution_from_caller_reference(caller_reference)
             else:
-                if aliases:
+                if aliases and distribution_id is None:
                     distribution_id = self.validate_distribution_id_from_alias(aliases)
                 if distribution_id:
                     return self.__cloudfront_facts_mgr.get_distribution(distribution_id)

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -25,6 +25,67 @@
   - set_fact:
       distribution_id: '{{ cf_distribution.id }}'
 
+  - name: ensure that default value of ipv6_enabled
+    assert:
+      that:
+        - cf_distribution.changed
+        - not cf_distribution.is_ipv6_enabled
+
+  - name: Update the distribution with tags
+    cloudfront_distribution:
+      state: present
+      distribution_id: "{{ distribution_id }}"
+      tags:
+        property: ansible
+    register: cf_update_tags
+
+  - name: ensure the 'ipv6_enabled' value has not changed
+    assert:
+      that:
+        - cf_update_tags.changed
+        - not cf_update_tags.is_ipv6_enabled
+
+  - name: Update the distribution ipv6_enabled set to true
+    cloudfront_distribution:
+      state: present
+      distribution_id: "{{ distribution_id }}"
+      ipv6_enabled: True
+    register: cf_update_ipv6
+
+  - name: ensure the 'ipv6_enabled' value has changed (new value is true)
+    assert:
+      that:
+        - cf_update_ipv6.changed
+        - cf_update_ipv6.is_ipv6_enabled
+
+  - name: Update the distribution with tags
+    cloudfront_distribution:
+      state: present
+      distribution_id: "{{ distribution_id }}"
+      tags:
+        test: integration
+    register: cf_update_tags
+
+  - name: ensure the 'ipv6_enabled' value has not changed (value remains true)
+    assert:
+      that:
+        - cf_update_tags.changed
+        - cf_update_tags.is_ipv6_enabled
+
+  - name: Test idempotency updating cloudfront_distribution with same value of ipv6_enabled
+    cloudfront_distribution:
+      state: present
+      distribution_id: "{{ distribution_id }}"
+      ipv6_enabled: True
+    register: cf_update_ipv6
+
+  - name: ensure the 'ipv6_enabled' value has changed (new value is true)
+    assert:
+      that:
+        # FixMe : idempotency issues
+        # - not cf_update_ipv6.changed
+        - cf_update_ipv6.is_ipv6_enabled
+  
   - name: re-run cloudfront distribution with same defaults
     cloudfront_distribution:
       distribution_id: "{{ distribution_id }}"

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -25,7 +25,7 @@
   - set_fact:
       distribution_id: '{{ cf_distribution.id }}'
 
-  - name: ensure that default value of ipv6_enabled
+  - name: ensure that default value of 'ipv6_enabled' is 'false'
     assert:
       that:
         - cf_distribution.changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
IpV6Enabled value is changed when updating a cloud distribution
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#336 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
When option ipv6_enabled is not explicitly specified as parameters, the current value is kept when updating the cloudfront distribution
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
