### PR TITLE
rds_instance: Add purge_security_groups

### DIFF
--- a/changelogs/fragments/500-rds_instance-purge-sg-option.yml
+++ b/changelogs/fragments/500-rds_instance-purge-sg-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- rds_instance - new ``purge_security_groups`` parameter (https://github.com/ansible-collections/community.aws/issues/385).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -416,6 +416,13 @@ options:
           - A list of EC2 VPC security groups to associate with the DB cluster.
         type: list
         elements: str
+    purge_security_groups:
+        description:
+          - Set to False to retain any enabled security groups that aren't specified in the task and are associated with the instance.
+          - Can be applied to I(vpc_security_group_ids) and I(db_security_groups)
+        type: bool
+        default: True
+        version_added: 1.5.0
 '''
 
 EXAMPLES = r'''
@@ -451,6 +458,15 @@ EXAMPLES = r'''
     id: "{{ instance_id }}"
     state: absent
     final_snapshot_identifier: "{{ snapshot_id }}"
+
+- name: Add a new security group without purge
+  community.aws.rds_instance:
+    id: "{{ instance_id }}"
+    state: present
+    vpc_security_group_ids:
+      - sg-0be17ba10c9286b0b
+    purge_security_groups: false
+    register: result
 '''
 
 RETURN = r'''
@@ -752,6 +768,7 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.six import string_types
@@ -861,6 +878,7 @@ def get_options_with_changing_values(client, module, parameters):
     port = module.params['port']
     apply_immediately = parameters.pop('ApplyImmediately', None)
     cloudwatch_logs_enabled = module.params['enable_cloudwatch_logs_exports']
+    purge_security_groups = module.params['purge_security_groups']
 
     if port:
         parameters['DBPortNumber'] = port
@@ -872,7 +890,7 @@ def get_options_with_changing_values(client, module, parameters):
         parameters.pop('Iops', None)
 
     instance = get_instance(client, module, instance_id)
-    updated_parameters = get_changing_options_with_inconsistent_keys(parameters, instance, purge_cloudwatch_logs)
+    updated_parameters = get_changing_options_with_inconsistent_keys(parameters, instance, purge_cloudwatch_logs, purge_security_groups)
     updated_parameters.update(get_changing_options_with_consistent_keys(parameters, instance))
     parameters = updated_parameters
 
@@ -884,7 +902,7 @@ def get_options_with_changing_values(client, module, parameters):
         parameters['DBInstanceIdentifier'] = instance_id
         if apply_immediately is not None:
             parameters['ApplyImmediately'] = apply_immediately
-
+    
     return parameters
 
 
@@ -909,8 +927,8 @@ def get_current_attributes_with_inconsistent_keys(instance):
     else:
         options['ProcessorFeatures'] = instance.get('ProcessorFeatures', {})
     options['OptionGroupName'] = [g['OptionGroupName'] for g in instance['OptionGroupMemberships']]
-    options['DBSecurityGroups'] = [sg['DBSecurityGroupName'] for sg in instance['DBSecurityGroups'] if sg['Status'] in ['adding', 'active']]
-    options['VpcSecurityGroupIds'] = [sg['VpcSecurityGroupId'] for sg in instance['VpcSecurityGroups'] if sg['Status'] in ['adding', 'active']]
+    options['DBSecurityGroups'] = [sg['DBSecurityGroupName'] for sg in instance['DBSecurityGroups']] if sg['Status'] in ['adding', 'active']]
+    options['VpcSecurityGroupIds'] = [sg['VpcSecurityGroupId'] for sg in instance['VpcSecurityGroups']] if sg['Status'] in ['adding', 'active']]
     options['DBParameterGroupName'] = [parameter_group['DBParameterGroupName'] for parameter_group in instance['DBParameterGroups']]
     options['AllowMajorVersionUpgrade'] = None
     options['EnableIAMDatabaseAuthentication'] = instance['IAMDatabaseAuthenticationEnabled']
@@ -922,7 +940,7 @@ def get_current_attributes_with_inconsistent_keys(instance):
     return options
 
 
-def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_cloudwatch_logs):
+def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_cloudwatch_logs, purge_security_groups):
     changing_params = {}
     current_options = get_current_attributes_with_inconsistent_keys(instance)
 
@@ -938,7 +956,9 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
         # TODO: allow other purge_option module parameters rather than just checking for things to add
         if isinstance(current_option, list):
             if isinstance(desired_option, list):
-                if set(desired_option) <= set(current_option):
+                if set(desired_option) < set(current_option):
+                    if (option == 'DBSecurityGroups' or option == 'VpcSecurityGroupIds') and purge_security_groups:
+                        changing_params[option] = desired_option
                     continue
             elif isinstance(desired_option, string_types):
                 if desired_option in current_option:
@@ -958,6 +978,11 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
                 format_option['DisableLogTypes'] = list(current_option.difference(desired_option))
             if format_option['EnableLogTypes'] or format_option['DisableLogTypes']:
                 changing_params[option] = format_option
+        elif option == 'DBSecurityGroups' or option == 'VpcSecurityGroupIds':
+            if purge_security_groups:
+                changing_params[option] = desired_option
+            else:
+                changing_params[option] = list(set(current_option) | set(desired_option))
         else:
             changing_params[option] = desired_option
 
@@ -1082,6 +1107,7 @@ def main():
         purge_tags=dict(type='bool', default=True),
         read_replica=dict(type='bool'),
         wait=dict(type='bool', default=True),
+        purge_security_groups=dict(type='bool', default=True),
     )
 
     parameter_options = dict(

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -956,9 +956,12 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
         # TODO: allow other purge_option module parameters rather than just checking for things to add
         if isinstance(current_option, list):
             if isinstance(desired_option, list):
-                if set(desired_option) < set(current_option):
-                    if (option == 'DBSecurityGroups' or option == 'VpcSecurityGroupIds') and purge_security_groups:
-                        changing_params[option] = desired_option
+                if (
+                    set(desired_option) < set(current_option) and
+                    option in ('DBSecurityGroups', 'VpcSecurityGroupIds',) and purge_security_groups
+                ):
+                    changing_params[option] = desired_option
+                elif set(desired_option) <= set(current_option):
                     continue
             elif isinstance(desired_option, string_types):
                 if desired_option in current_option:
@@ -978,7 +981,7 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
                 format_option['DisableLogTypes'] = list(current_option.difference(desired_option))
             if format_option['EnableLogTypes'] or format_option['DisableLogTypes']:
                 changing_params[option] = format_option
-        elif option == 'DBSecurityGroups' or option == 'VpcSecurityGroupIds':
+        elif option in ('DBSecurityGroups', 'VpcSecurityGroupIds',):
             if purge_security_groups:
                 changing_params[option] = desired_option
             else:

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -902,7 +902,7 @@ def get_options_with_changing_values(client, module, parameters):
         parameters['DBInstanceIdentifier'] = instance_id
         if apply_immediately is not None:
             parameters['ApplyImmediately'] = apply_immediately
-    
+
     return parameters
 
 
@@ -927,8 +927,8 @@ def get_current_attributes_with_inconsistent_keys(instance):
     else:
         options['ProcessorFeatures'] = instance.get('ProcessorFeatures', {})
     options['OptionGroupName'] = [g['OptionGroupName'] for g in instance['OptionGroupMemberships']]
-    options['DBSecurityGroups'] = [sg['DBSecurityGroupName'] for sg in instance['DBSecurityGroups']] if sg['Status'] in ['adding', 'active']]
-    options['VpcSecurityGroupIds'] = [sg['VpcSecurityGroupId'] for sg in instance['VpcSecurityGroups']] if sg['Status'] in ['adding', 'active']]
+    options['DBSecurityGroups'] = [sg['DBSecurityGroupName'] for sg in instance['DBSecurityGroups'] if sg['Status'] in ['adding', 'active']]
+    options['VpcSecurityGroupIds'] = [sg['VpcSecurityGroupId'] for sg in instance['VpcSecurityGroups'] if sg['Status'] in ['adding', 'active']]
     options['DBParameterGroupName'] = [parameter_group['DBParameterGroupName'] for parameter_group in instance['DBParameterGroups']]
     options['AllowMajorVersionUpgrade'] = None
     options['EnableIAMDatabaseAuthentication'] = instance['IAMDatabaseAuthenticationEnabled']

--- a/tests/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml
@@ -73,18 +73,70 @@
           that:
             - result.changed
             - "result.db_instance_identifier == '{{ instance_id }}'"
+            - "result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 2"
 
-      - name: Add a new security group
+      - name: Add a new security group without purge (check_mode)
         rds_instance:
           id: "{{ instance_id }}"
           state: present
           vpc_security_group_ids:
             - "{{ sgs_result.results.2.group_id }}"
+          apply_immediately: true
+          purge_security_groups: false
+        check_mode: true
         register: result
 
       - assert:
           that:
             - result.changed
+            - "result.db_instance_identifier == '{{ instance_id }}'"
+      
+      - name: Add a new security group without purge
+        rds_instance:
+          id: "{{ instance_id }}"
+          state: present
+          vpc_security_group_ids:
+            - "{{ sgs_result.results.2.group_id }}"
+          apply_immediately: true
+          purge_security_groups: false
+        register: result
+
+      - assert:
+          that:
+            - result.changed
+            - "result.db_instance_identifier == '{{ instance_id }}'"
+            - "result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 3"
+      
+      - name: Add a new security group without purge (test idempotence)
+        rds_instance:
+          id: "{{ instance_id }}"
+          state: present
+          vpc_security_group_ids:
+            - "{{ sgs_result.results.2.group_id }}"
+          apply_immediately: true
+          purge_security_groups: false
+        register: result
+
+      - assert:
+          that:
+            - not result.changed
+            - "result.db_instance_identifier == '{{ instance_id }}'"
+      
+      - name: Add a security group with purge
+        rds_instance:
+          id: "{{ instance_id }}"
+          state: present
+          vpc_security_group_ids:
+            - "{{ sgs_result.results.2.group_id }}"
+          apply_immediately: true
+        register: result
+
+      - assert:
+          that:
+            - result.changed
+            - "result.db_instance_identifier == '{{ instance_id }}'"
+            - "result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 1"
+            - "result.vpc_security_groups | selectattr('status', 'equalto', 'removing') | list | length == 2"
 
     always:
 
@@ -127,7 +179,7 @@
           - {"cidr": "10.122.122.160/28", "zone": "{{ aws_region }}c"}
           - {"cidr": "10.122.122.176/28", "zone": "{{ aws_region }}d"}
 
-      - name: create a VPC
+      - name: Delete VPC
         ec2_vpc_net:
           name: "{{ resource_prefix }}-vpc"
           state: absent

--- a/tests/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml
@@ -90,6 +90,7 @@
           that:
             - result.changed
             - "result.db_instance_identifier == '{{ instance_id }}'"
+
       - name: Add a new security group without purge
         rds_instance:
           id: "{{ instance_id }}"
@@ -105,6 +106,7 @@
             - result.changed
             - "result.db_instance_identifier == '{{ instance_id }}'"
             - "result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 3"
+
       - name: Add a new security group without purge (test idempotence)
         rds_instance:
           id: "{{ instance_id }}"
@@ -119,7 +121,7 @@
           that:
             - not result.changed
             - "result.db_instance_identifier == '{{ instance_id }}'"
-      
+
       - name: Add a security group with purge
         rds_instance:
           id: "{{ instance_id }}"

--- a/tests/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml
@@ -90,7 +90,6 @@
           that:
             - result.changed
             - "result.db_instance_identifier == '{{ instance_id }}'"
-      
       - name: Add a new security group without purge
         rds_instance:
           id: "{{ instance_id }}"
@@ -106,7 +105,6 @@
             - result.changed
             - "result.db_instance_identifier == '{{ instance_id }}'"
             - "result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 3"
-      
       - name: Add a new security group without purge (test idempotence)
         rds_instance:
           id: "{{ instance_id }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

rds_instance: Add `purge_security_groups` parameter for both `db_security_groups` and `vpc_security_groups_ids`.
Should fix: https://github.com/ansible-collections/community.aws/issues/385

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

According to the boto3 documentation https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.describe_db_instances,  `describe_db_instances()` provides  this information for the associated security groups
```
'DBSecurityGroups': [
                {
                    'DBSecurityGroupName': 'string',
                    'Status': 'string'
                },
            ],
 'VpcSecurityGroups': [
                {
                    'VpcSecurityGroupId': 'string',
                    'Status': 'string'
                },
            ],
```
With this patch the status is reflected accordingly as showed in the following example.
```
- name: Create a DB instance in the VPC with two security groups
   rds_instance:
     id: "{{ instance_id }}"
     state: present
     engine: mariadb
     username: "{{ username }}"
     password: "{{ password }}"
     db_instance_class: "{{ db_instance_class }}"
     allocated_storage: "{{ allocated_storage }}"
     vpc_security_group_ids:
            - "sg-1"
            - "sg-2"

```
This gives:
```
....
"vpc_security_groups": [
        {
            "status": "active",
            "vpc_security_group_id": "sg-1"
        },
        {
            "status": "active",
            "vpc_security_group_id": "sg-2"
        }
    ]
```
And then if we want to set the a new security group `sg-3` (purge_security_groups=True by default).
```
- name: Add a new security group (purge_security_groups=True by default)
   rds_instance:
     id: "{{ instance_id }}"
     state: present
     vpc_security_group_ids:
            - "sg-3"
```

The log produced:
```
"vpc_security_groups": [
        {
            "status": "removing",
            "vpc_security_group_id": "sg-1"
        },
        {
            "status": "removing",
            "vpc_security_group_id": "sg-2"
        },
        {
            "status": "adding",
            "vpc_security_group_id": "sg-3"
        }
    ]
```

Since some vpc security groups are reported "removing" status, do we want to show them? Others are also with "adding" state. I was wondering if there is a way to only show security groups with an active status or however wait until a security group passes from "adding" to "active". 
