### PR TITLE
route53: fix getting private zones by name when a vpc_id is provided

### DIFF
--- a/changelogs/fragments/510-fix-route53-private-zone-vpc.yaml
+++ b/changelogs/fragments/510-fix-route53-private-zone-vpc.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - route53 - fix ``AttributeError`` in ``get_zone_id_by_name`` when a vpc_id
+    on a private zone is provided (https://github.com/ansible-collections/community.aws/issues/509).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -411,13 +411,8 @@ def get_zone_id_by_name(route53, module, zone_name, want_private, want_vpc_id):
                 # NOTE: These details aren't available in other boto methods, hence the necessary
                 # extra API call
                 hosted_zone = route53.get_hosted_zone(aws_retry=True, Id=zone_id)
-                # this is to deal with this boto bug: https://github.com/boto/boto/pull/2882
-                if isinstance(hosted_zone['VPCs'], dict):
-                    if hosted_zone['VPCs']['VPC']['VPCId'] == want_vpc_id:
-                        return zone_id
-                else:  # Forward compatibility for when boto fixes that bug
-                    if want_vpc_id in [v['VPCId'] for v in hosted_zone['VPCs']]:
-                        return zone_id
+                if want_vpc_id in [v['VPCId'] for v in hosted_zone['VPCs']]:
+                    return zone_id
             else:
                 return zone_id
     return None

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -410,14 +410,13 @@ def get_zone_id_by_name(route53, module, zone_name, want_private, want_vpc_id):
             if want_vpc_id:
                 # NOTE: These details aren't available in other boto methods, hence the necessary
                 # extra API call
-                hosted_zone = route53.get_hosted_zone(aws_retry=True, Id=zone.id)
-                zone_details = hosted_zone['HostedZone']
+                hosted_zone = route53.get_hosted_zone(aws_retry=True, Id=zone_id)
                 # this is to deal with this boto bug: https://github.com/boto/boto/pull/2882
-                if isinstance(zone_details['VPCs'], dict):
-                    if zone_details['VPCs']['VPC']['VPCId'] == want_vpc_id:
+                if isinstance(hosted_zone['VPCs'], dict):
+                    if hosted_zone['VPCs']['VPC']['VPCId'] == want_vpc_id:
                         return zone_id
                 else:  # Forward compatibility for when boto fixes that bug
-                    if want_vpc_id in [v['VPCId'] for v in zone_details['VPCs']]:
+                    if want_vpc_id in [v['VPCId'] for v in hosted_zone['VPCs']]:
                         return zone_id
             else:
                 return zone_id

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -67,14 +67,11 @@
       hosted_zone_method: details
     register: hosted_zones
 
-  - name: debug (to remove)
-    debug:
-      var: hosted_zones
-
   - name: Assert newly created hosted zone only has NS and SOA records
     assert:
       that:
         - hosted_zones.HostedZone.ResourceRecordSetCount == 2
+        - hosted_zones.HostedZone.Config.PrivateZone
 
   - name: Create A record using zone fqdn
     route53:
@@ -353,6 +350,7 @@
       record: '{{ item.Name }}'
       type: '{{ item.Type }}'
       value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
+      private_zone: true
     loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
   - name: Delete test zone one '{{ zone_one }}'
     route53_zone:

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -19,7 +19,7 @@
 
   - name: create VPC
     ec2_vpc_net:
-      cidr_block: 10.228.228.0/22
+      cidr_block: 192.0.2.0/24
       name: '{{ resource_prefix }}_vpc'
       state: present
     register: vpc
@@ -79,7 +79,7 @@
       zone: '{{ zone_one }}'
       record: 'qdn_test.{{ zone_one }}'
       type: A
-      value: 1.2.3.4
+      value: 192.0.2.1
     register: qdn
   - assert:
       that:
@@ -97,7 +97,7 @@
       that:
         - get_result.nameservers|length > 0
         - get_result.set.Name == "qdn_test.{{ zone_one }}"
-        - get_result.set.ResourceRecords[0].Value == "1.2.3.4"
+        - get_result.set.ResourceRecords[0].Value == "192.0.2.1"
         - get_result.set.Type == "A"
 
   - name: Create same A record using zone non-qualified domain
@@ -106,7 +106,7 @@
       zone: '{{ zone_one[:-1] }}'
       record: 'qdn_test.{{ zone_one[:-1] }}'
       type: A
-      value: 1.2.3.4
+      value: 192.0.2.1
     register: non_qdn
   - assert:
       that:
@@ -119,7 +119,7 @@
       hosted_zone_id: '{{ z1.zone_id }}'
       record: 'zid_test.{{ zone_one }}'
       type: A
-      value: 1.2.3.4
+      value: 192.0.2.1
     register: zid
   - assert:
       that:
@@ -133,8 +133,8 @@
       record: 'order_test.{{ zone_one }}'
       type: A
       value:
-        - 4.5.6.7
-        - 1.2.3.4
+        - 192.0.2.2
+        - 192.0.2.1
     register: mv_a_record
   - assert:
       that:
@@ -148,8 +148,8 @@
       record: 'order_test.{{ zone_one }}'
       type: A
       value:
-        - 4.5.6.7
-        - 1.2.3.4
+        - 192.0.2.2
+        - 192.0.2.1
     register: mv_a_record
   - assert:
       that:
@@ -168,8 +168,8 @@
       that:
         - records.ResourceRecordSets|length == 3
         - records.ResourceRecordSets[0].ResourceRecords|length == 2
-        - records.ResourceRecordSets[0].ResourceRecords[0].Value == "4.5.6.7"
-        - records.ResourceRecordSets[0].ResourceRecords[1].Value == "1.2.3.4"
+        - records.ResourceRecordSets[0].ResourceRecords[0].Value == "192.0.2.2"
+        - records.ResourceRecordSets[0].ResourceRecords[1].Value == "192.0.2.1"
 
   - name: Remove a member from multi-value A record with values in different order
     route53:
@@ -178,7 +178,7 @@
       record: 'order_test.{{ zone_one }}'
       type: A
       value:
-        - 4.5.6.7
+        - 192.0.2.2
     register: del_a_record
     ignore_errors: true
   - name: This should fail, because `overwrite` is false
@@ -194,7 +194,7 @@
       overwrite: true
       type: A
       value:
-        - 4.5.6.7
+        - 192.0.2.2
     register: del_a_record
     ignore_errors: true
   - name: This should not fail, because `overwrite` is true
@@ -215,7 +215,7 @@
       that:
         - records.ResourceRecordSets|length == 3
         - records.ResourceRecordSets[0].ResourceRecords|length == 1
-        - records.ResourceRecordSets[0].ResourceRecords[0].Value == "4.5.6.7"
+        - records.ResourceRecordSets[0].ResourceRecords[0].Value == "192.0.2.2"
 
   - name: Create a LetsEncrypt CAA record
     route53:
@@ -273,7 +273,7 @@
       zone: '{{ zone_two }}'
       record: 'qdn_test.{{ zone_two }}'
       type: A
-      value: 2.3.4.5
+      value: 192.0.2.1
       private_zone: true
     register: qdn
   - assert:
@@ -293,7 +293,7 @@
       that:
         - get_result.nameservers|length > 0
         - get_result.set.Name == "qdn_test.{{ zone_two }}"
-        - get_result.set.ResourceRecords[0].Value == "2.3.4.5"
+        - get_result.set.ResourceRecords[0].Value == "192.0.2.1"
         - get_result.set.Type == "A"
 
   - name: Create same A record using zone non-qualified domain
@@ -302,7 +302,7 @@
       zone: '{{ zone_two[:-1] }}'
       record: 'qdn_test.{{ zone_two[:-1] }}'
       type: A
-      value: 2.3.4.5
+      value: 192.0.2.1
       private_zone: true
     register: non_qdn
   - assert:
@@ -316,7 +316,7 @@
       hosted_zone_id: '{{ z2.zone_id }}'
       record: 'zid_test.{{ zone_two }}'
       type: A
-      value: 3.4.5.6
+      value: 192.0.2.2
       private_zone: true
     register: zid
   - assert:
@@ -330,7 +330,7 @@
       zone: '{{ zone_two }}'
       record: 'qdn_test_vpc.{{ zone_two }}'
       type: A
-      value: 4.5.6.7
+      value: 192.0.2.3
       private_zone: true
       vpc_id: '{{ vpc.vpc.id }}'
     register: qdn
@@ -345,7 +345,7 @@
       hosted_zone_id: '{{ z2.zone_id }}'
       record: 'zid_test_vpc.{{ zone_two }}'
       type: A
-      value: 5.6.7.8
+      value: 192.0.2.4
       private_zone: true
       vpc_id: '{{ vpc.vpc.id }}'
     register: zid
@@ -401,7 +401,7 @@
     when: false
   - name: destroy VPC
     ec2_vpc_net:
-      cidr_block: 10.228.228.0/22
+      cidr_block: 192.0.2.0/24
       name: '{{ resource_prefix }}_vpc'
       state: absent
     register: remove_vpc

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -328,7 +328,7 @@
     route53:
       state: present
       zone: '{{ zone_two }}'
-      record: 'qdn_test.{{ zone_two }}'
+      record: 'qdn_test_vpc.{{ zone_two }}'
       type: A
       value: 4.5.6.7
       private_zone: true
@@ -343,7 +343,7 @@
     route53:
       state: present
       hosted_zone_id: '{{ z2.zone_id }}'
-      record: 'zid_test.{{ zone_two }}'
+      record: 'zid_test_vpc.{{ zone_two }}'
       type: A
       value: 5.6.7.8
       private_zone: true

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -316,8 +316,38 @@
       hosted_zone_id: '{{ z2.zone_id }}'
       record: 'zid_test.{{ zone_two }}'
       type: A
-      value: 2.3.4.5
+      value: 3.4.5.6
       private_zone: true
+    register: zid
+  - assert:
+      that:
+        - zid is not failed
+        - zid is changed
+
+  - name: Create A record using zone fqdn and vpc_id
+    route53:
+      state: present
+      zone: '{{ zone_two }}'
+      record: 'qdn_test.{{ zone_two }}'
+      type: A
+      value: 4.5.6.7
+      private_zone: true
+      vpc_id: '{{ vpc.vpc.id }}'
+    register: qdn
+  - assert:
+      that:
+        - qdn is not failed
+        - qdn is changed
+
+  - name: Create A record using zone ID and vpc_id
+    route53:
+      state: present
+      hosted_zone_id: '{{ z2.zone_id }}'
+      record: 'zid_test.{{ zone_two }}'
+      type: A
+      value: 5.6.7.8
+      private_zone: true
+      vpc_id: '{{ vpc.vpc.id }}'
     register: zid
   - assert:
       that:

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -16,6 +16,14 @@
     route53:
       region: null
   block:
+
+  - name: create VPC
+    ec2_vpc_net:
+      cidr_block: 10.228.228.0/22
+      name: '{{ resource_prefix }}_vpc'
+      state: present
+    register: vpc
+
   - route53_zone:
       zone: '{{ zone_one }}'
       comment: Created in Ansible test {{ resource_prefix }}
@@ -33,6 +41,35 @@
       hosted_zone_id: '{{ z1.zone_id }}'
       hosted_zone_method: details
     register: hosted_zones
+
+  - name: Assert newly created hosted zone only has NS and SOA records
+    assert:
+      that:
+        - hosted_zones.HostedZone.ResourceRecordSetCount == 2
+
+  - route53_zone:
+      zone: '{{ zone_two }}'
+      vpc_id: '{{ vpc.vpc.id }}'
+      vpc_region: '{{ aws_region }}'
+      comment: Created in Ansible test {{ resource_prefix }}
+    register: z2
+
+  - assert:
+      that:
+        - z2 is success
+        - z2 is changed
+        - "z2.comment == 'Created in Ansible test {{ resource_prefix }}'"
+
+  - name: Get zone details
+    route53_info:
+      query: hosted_zone
+      hosted_zone_id: '{{ z2.zone_id }}'
+      hosted_zone_method: details
+    register: hosted_zones
+
+  - name: debug (to remove)
+    debug:
+      var: hosted_zones
 
   - name: Assert newly created hosted zone only has NS and SOA records
     assert:
@@ -232,6 +269,63 @@
         - caa is not failed
         - caa is not changed
 
+  # Tests on zone two (private zone)
+  - name: Create A record using zone fqdn
+    route53:
+      state: present
+      zone: '{{ zone_two }}'
+      record: 'qdn_test.{{ zone_two }}'
+      type: A
+      value: 2.3.4.5
+      private_zone: true
+    register: qdn
+  - assert:
+      that:
+        - qdn is not failed
+        - qdn is changed
+
+  - name: Get A record using 'get' method of route53 module
+    route53:
+      state: get
+      zone: "{{ zone_two }}"
+      record: "qdn_test.{{ zone_two }}"
+      type: A
+      private_zone: true
+    register: get_result
+  - assert:
+      that:
+        - get_result.nameservers|length > 0
+        - get_result.set.Name == "qdn_test.{{ zone_two }}"
+        - get_result.set.ResourceRecords[0].Value == "2.3.4.5"
+        - get_result.set.Type == "A"
+
+  - name: Create same A record using zone non-qualified domain
+    route53:
+      state: present
+      zone: '{{ zone_two[:-1] }}'
+      record: 'qdn_test.{{ zone_two[:-1] }}'
+      type: A
+      value: 2.3.4.5
+      private_zone: true
+    register: non_qdn
+  - assert:
+      that:
+        - non_qdn is not failed
+        - non_qdn is not changed
+
+  - name: Create A record using zone ID
+    route53:
+      state: present
+      hosted_zone_id: '{{ z2.zone_id }}'
+      record: 'zid_test.{{ zone_two }}'
+      type: A
+      value: 2.3.4.5
+      private_zone: true
+    register: zid
+  - assert:
+      that:
+        - zid is not failed
+        - zid is changed
 
   always:
   - route53_info:
@@ -247,6 +341,19 @@
       type: '{{ item.Type }}'
       value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
     loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+  - route53_info:
+      query: record_sets
+      hosted_zone_id: '{{ z2.zone_id }}'
+    register: z2_records
+  - debug: var=z2_records
+  - name: Loop over A/AAAA/CNAME records and delete them
+    route53:
+      state: absent
+      zone: '{{ zone_two }}'
+      record: '{{ item.Name }}'
+      type: '{{ item.Type }}'
+      value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
+    loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
   - name: Delete test zone one '{{ zone_one }}'
     route53_zone:
       state: absent
@@ -264,3 +371,13 @@
     retries: 10
     until: delete_two is not failed
     when: false
+  - name: destroy VPC
+    ec2_vpc_net:
+      cidr_block: 10.228.228.0/22
+      name: '{{ resource_prefix }}_vpc'
+      state: absent
+    register: remove_vpc
+    retries: 10
+    delay: 5
+    until: remove_vpc is success
+    ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #509 and add tests.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`route53`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is an attempt to fix #509 and add tests for the specific use case described in the issue.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
