### PR TITLE
rds_instance - test fixups

### DIFF
--- a/changelogs/fragments/515-rds_snapshot-aws-group.yml
+++ b/changelogs/fragments/515-rds_snapshot-aws-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- rds_snapshot - added to the aws module_defaults group (https://github.com/ansible-collections/community.aws/pull/515).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -197,6 +197,7 @@ action_groups:
   - rds_instance
   - rds_instance_info
   - rds_param_group
+  - rds_snapshot
   - rds_snapshot_info
   - rds_subnet_group
   - redshift

--- a/tests/integration/targets/rds_instance/aliases
+++ b/tests/integration/targets/rds_instance/aliases
@@ -1,4 +1,5 @@
 # reason: missing-policy
+# reason: slow
 unsupported
 
 cloud/aws

--- a/tests/integration/targets/rds_instance/tasks/test_read_replica.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_read_replica.yml
@@ -58,12 +58,12 @@
         register: result
 
       - assert:
-        that:
-          - result.changed
-          - "result.db_instance_identifier == '{{ instance_id }}-replica'"
-          - "result.tags | length == 2"
-          - "result.tags.Name == '{{ instance_id }}'"
-          - "result.tags.Created_by == 'Ansible rds_instance tests'"
+          that:
+            - result.changed
+            - "result.db_instance_identifier == '{{ instance_id }}-replica'"
+            - "result.tags | length == 2"
+            - "result.tags.Name == '{{ instance_id }}'"
+            - "result.tags.Created_by == 'Ansible rds_instance tests'"
 
       - name: Test idempotence with a read replica
         rds_instance:


### PR DESCRIPTION
##### SUMMARY

The rds_instance tests are currenlty broken

- rds_snapshot is missing from meta/runtime.yml
- test_read_replica.yml syntax mistake

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rds_instance
rds_snapshot

##### ADDITIONAL INFORMATION
