### PR TITLE
rds_instance - fix idempotency when using non-lowercase for preferred_maintenance_window

### DIFF
--- a/changelogs/516-rds_instance-preferred_maintenance_window.yml
+++ b/changelogs/516-rds_instance-preferred_maintenance_window.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- rds_instance - convert ``preferred_maintenance_window`` days into lowercase so changed returns properly (https://github.com/ansible-collections/community.aws/pull/515).
+- rds_instance - convert ``preferred_maintenance_window`` days into lowercase so changed returns properly (https://github.com/ansible-collections/community.aws/pull/516).

--- a/changelogs/516-rds_instance-preferred_maintenance_window.yml
+++ b/changelogs/516-rds_instance-preferred_maintenance_window.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- rds_instance - convert ``preferred_maintenance_window`` days into lowercase so changed returns properly (https://github.com/ansible-collections/community.aws/pull/515).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1214,6 +1214,10 @@ def main():
     if module.params['processor_features'] is not None:
         module.params['processor_features'] = dict((k, to_text(v)) for k, v in module.params['processor_features'].items())
 
+    # Ensure dates are in lowercase
+    if module.params['preferred_maintenance_window']:
+        module.params['preferred_maintenance_window'] = module.params['preferred_maintenance_window'].lower()
+
     client = module.client('rds')
     changed = False
     state = module.params['state']

--- a/tests/integration/targets/rds_instance/tasks/test_modification.yml
+++ b/tests/integration/targets/rds_instance/tasks/test_modification.yml
@@ -153,6 +153,34 @@
             - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == "db.t2.medium"'
             - '"engine_version" in result.pending_modified_values or result.engine_version == "10.2.21"'
 
+      - name: Idempotence modifying several pending attributes - preferred_maintenance_window not lowercase
+        rds_instance:
+          id: '{{ instance_id }}'
+          state: present
+          allocated_storage: 30
+          db_instance_class: "{{ modified_db_instance_class }}"
+          backup_retention_period: 2
+          preferred_backup_window: "05:00-06:00"
+          preferred_maintenance_window: "Mon:06:20-Mon:06:50"
+          engine_version: "10.2.21"
+          allow_major_version_upgrade: true
+          auto_minor_version_upgrade: false
+          port: 1150
+          max_allocated_storage: 100
+        register: result
+        retries: 30
+        delay: 10
+        until: result is not failed
+
+      - assert:
+          that:
+            - not result.changed
+            - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == 30'
+            - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage == 100'
+            - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
+            - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == "db.t2.medium"'
+            - '"engine_version" in result.pending_modified_values or result.engine_version == "10.2.21"'
+
       - name: Delete the instance
         rds_instance:
           id: '{{ instance_id }}'


### PR DESCRIPTION
##### SUMMARY

Rather than relying on changing the docs (#310) force the day of the week into lowercase so that it matches what AWS returns.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rds_instance

##### ADDITIONAL INFORMATION