### PR TITLE
glue_connection - Avoid converting connection_parameter keys to lowercase

### DIFF
--- a/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
+++ b/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - aws_glue_connection - Avoid converting connection_parameters to lowercase (https://github.com/ansible-collections/community.aws/pull/518).
+  - aws_glue_connection - Avoid converting connection_parameters to lowercase (https://github.com/ansible-collections/community.aws/pull/518)

--- a/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
+++ b/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - aws_glue_connection - Avoid converting connection_parameters to lowercase (https://github.com/ansible-collections/community.aws/pull/518)
+- aws_glue_connection - avoid converting connection_parameters to lowercase (https://github.com/ansible-collections/community.aws/pull/518).

--- a/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
+++ b/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_glue_connection - Avoid converting connection_parameters to lowercase (https://github.com/ansible-collections/community.aws/pull/518).

--- a/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
+++ b/changelogs/fragments/518-aws_glue_connection-do-not-lowercase-connection-parameters.yml
@@ -1,2 +1,4 @@
 minor_changes:
-- aws_glue_connection - avoid converting connection_parameters to lowercase (https://github.com/ansible-collections/community.aws/pull/518).
+- aws_glue_connection - added new ``raw_connection_parameters`` return key which doesn't snake case the connection parameters (https://github.com/ansible-collections/community.aws/pull/518).
+deprecated_features:
+- aws_glue_connection - the ``connection_parameters`` return key has been deprecated and will be removed in a release after 2024-06-01, it is being replaced by the ``raw_connection_parameters`` key (https://github.com/ansible-collections/community.aws/pull/518).

--- a/plugins/modules/glue_connection.py
+++ b/plugins/modules/glue_connection.py
@@ -316,7 +316,7 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
 
     glue_connection['RawConnectionProperties'] = glue_connection['ConnectionProperties']
 
-    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_connection or {}, ignore_list=['ConnectionProperties']))
+    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_connection or {}, ignore_list=['RawConnectionProperties']))
 
 
 def delete_glue_connection(connection, module, glue_connection):

--- a/plugins/modules/glue_connection.py
+++ b/plugins/modules/glue_connection.py
@@ -314,7 +314,11 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
     if changed and not module.check_mode:
         glue_connection = _await_glue_connection(connection, module)
 
-    glue_connection['RawConnectionProperties'] = glue_connection['ConnectionProperties']
+
+    if glue_connection:
+        module.deprecate("The 'connection_properties' return key is deprecated and will be replaced by 'raw_connection_properties'. Both values are returned for now.",
+                         date='2024-06-01', collection_name='community.aws')
+        glue_connection['RawConnectionProperties'] = glue_connection['ConnectionProperties']
 
     module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_connection or {}, ignore_list=['RawConnectionProperties']))
 
@@ -369,9 +373,6 @@ def main():
                               ],
                               supports_check_mode=True
                               )
-
-    module.deprecate("The 'connection_properties' return key is deprecated and will be replaced by 'raw_connection_properties'. Both values are returned for now.",
-                     date='2024-06-01', collection_name='community.aws')
 
     retry_decorator = AWSRetry.jittered_backoff(retries=10)
     connection_glue = module.client('glue', retry_decorator=retry_decorator)

--- a/plugins/modules/glue_connection.py
+++ b/plugins/modules/glue_connection.py
@@ -309,7 +309,7 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
     if changed and not module.check_mode:
         glue_connection = _await_glue_connection(connection, module)
 
-    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_connection or {}))
+    module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_connection or {}, ignore_list=['ConnectionProperties']))
 
 
 def delete_glue_connection(connection, module, glue_connection):

--- a/plugins/modules/glue_connection.py
+++ b/plugins/modules/glue_connection.py
@@ -109,7 +109,9 @@ EXAMPLES = r'''
 
 RETURN = r'''
 connection_properties:
-    description: (deprecated) A dict of key-value pairs (converted to lowercase) used as parameters for this connection. This return key has been deprecated, and will be removed in a release after 2024-06-01.
+    description:
+        - (deprecated) A dict of key-value pairs (converted to lowercase) used as parameters for this connection.
+        - This return key has been deprecated, and will be removed in a release after 2024-06-01.
     returned: when state is present
     type: dict
     sample: {'jdbc_connection_url':'jdbc:mysql://mydb:3306/databasename','username':'x','password':'y'}
@@ -314,9 +316,9 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
     if changed and not module.check_mode:
         glue_connection = _await_glue_connection(connection, module)
 
-
     if glue_connection:
-        module.deprecate("The 'connection_properties' return key is deprecated and will be replaced by 'raw_connection_properties'. Both values are returned for now.",
+        module.deprecate("The 'connection_properties' return key is deprecated and will be replaced"
+                         " by 'raw_connection_properties'. Both values are returned for now.",
                          date='2024-06-01', collection_name='community.aws')
         glue_connection['RawConnectionProperties'] = glue_connection['ConnectionProperties']
 

--- a/plugins/modules/glue_connection.py
+++ b/plugins/modules/glue_connection.py
@@ -109,10 +109,10 @@ EXAMPLES = r'''
 
 RETURN = r'''
 connection_properties:
-    description: A dict of key-value pairs used as parameters for this connection.
+    description: (deprecated) A dict of key-value pairs (converted to lowercase) used as parameters for this connection. This return key has been deprecated, and will be removed in a release after 2024-06-01.
     returned: when state is present
     type: dict
-    sample: {'JDBC_CONNECTION_URL':'jdbc:mysql://mydb:3306/databasename','USERNAME':'x','PASSWORD':'y'}
+    sample: {'jdbc_connection_url':'jdbc:mysql://mydb:3306/databasename','username':'x','password':'y'}
 connection_type:
     description: The type of the connection.
     returned: when state is present
@@ -149,6 +149,11 @@ physical_connection_requirements:
     returned: when state is present
     type: dict
     sample: {'subnet-id':'subnet-aabbccddee'}
+raw_connection_properties:
+    description: A dict of key-value pairs used as parameters for this connection.
+    returned: when state is present
+    type: dict
+    sample: {'JDBC_CONNECTION_URL':'jdbc:mysql://mydb:3306/databasename','USERNAME':'x','PASSWORD':'y'}
 '''
 
 # Non-ansible imports
@@ -309,6 +314,8 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
     if changed and not module.check_mode:
         glue_connection = _await_glue_connection(connection, module)
 
+    glue_connection['RawConnectionProperties'] = glue_connection['ConnectionProperties']
+
     module.exit_json(changed=changed, **camel_dict_to_snake_dict(glue_connection or {}, ignore_list=['ConnectionProperties']))
 
 
@@ -362,6 +369,9 @@ def main():
                               ],
                               supports_check_mode=True
                               )
+
+    module.deprecate("The 'connection_properties' return key is deprecated and will be replaced by 'raw_connection_properties'. Both values are returned for now.",
+                     date='2024-06-01', collection_name='community.aws')
 
     retry_decorator = AWSRetry.jittered_backoff(retries=10)
     connection_glue = module.client('glue', retry_decorator=retry_decorator)

--- a/tests/integration/targets/glue_connection/tasks/test_connection_network.yml
+++ b/tests/integration/targets/glue_connection/tasks/test_connection_network.yml
@@ -101,7 +101,7 @@
           - glue_connection.changed
           - glue_connection.name == connection_info["Connection"]["Name"]
           - glue_connection.description == connection_info["Connection"]["Description"]
-          - glue_connection.connection_properties == connection_info["Connection"]["ConnectionProperties"]
+          - glue_connection.raw_connection_properties == connection_info["Connection"]["ConnectionProperties"]
           - glue_connection.connection_type == connection_info["Connection"]["ConnectionType"]
           - glue_connection.physical_connection_requirements.subnet_id == connection_info["Connection"]["PhysicalConnectionRequirements"]["SubnetId"]
           - glue_connection.physical_connection_requirements.security_group_id_list == connection_info["Connection"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"]
@@ -221,7 +221,7 @@
           - glue_connection_update_check.changed
           - glue_connection_update_check.name == connection_info_update_check["Connection"]["Name"]
           - glue_connection_update_check.description == connection_info_update_check["Connection"]["Description"]
-          - glue_connection_update_check.connection_properties == connection_info_update_check["Connection"]["ConnectionProperties"]
+          - glue_connection_update_check.raw_connection_properties == connection_info_update_check["Connection"]["ConnectionProperties"]
           - glue_connection_update_check.connection_type == connection_info_update_check["Connection"]["ConnectionType"]
           - glue_connection_update_check.physical_connection_requirements.subnet_id == connection_info_update_check["Connection"]["PhysicalConnectionRequirements"]["SubnetId"]
           - glue_connection_update_check.physical_connection_requirements.security_group_id_list == connection_info_update_check["Connection"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"]
@@ -261,7 +261,7 @@
           - glue_connection_update.changed
           - glue_connection_update.name == connection_info_update["Connection"]["Name"]
           - glue_connection_update.description == connection_info_update["Connection"]["Description"]
-          - glue_connection_update.connection_properties == connection_info_update["Connection"]["ConnectionProperties"]
+          - glue_connection_update.raw_connection_properties == connection_info_update["Connection"]["ConnectionProperties"]
           - glue_connection_update.connection_type == connection_info_update["Connection"]["ConnectionType"]
           - glue_connection_update.physical_connection_requirements.subnet_id == connection_info_update["Connection"]["PhysicalConnectionRequirements"]["SubnetId"]
           - glue_connection_update.physical_connection_requirements.security_group_id_list == connection_info_update["Connection"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"]

--- a/tests/integration/targets/glue_connection/tasks/test_connection_network.yml
+++ b/tests/integration/targets/glue_connection/tasks/test_connection_network.yml
@@ -106,6 +106,7 @@
           - glue_connection.physical_connection_requirements.subnet_id == connection_info["Connection"]["PhysicalConnectionRequirements"]["SubnetId"]
           - glue_connection.physical_connection_requirements.security_group_id_list == connection_info["Connection"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"]
           - glue_connection.physical_connection_requirements.availability_zone == connection_info["Connection"]["PhysicalConnectionRequirements"]["AvailabilityZone"]
+          - glue_connection.raw_connection_properties == connection_info["Connection"]["ConnectionProperties"]
 
     - name: Create Glue connection (idempotent) (check mode)
       aws_glue_connection:
@@ -225,6 +226,7 @@
           - glue_connection_update_check.physical_connection_requirements.subnet_id == connection_info_update_check["Connection"]["PhysicalConnectionRequirements"]["SubnetId"]
           - glue_connection_update_check.physical_connection_requirements.security_group_id_list == connection_info_update_check["Connection"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"]
           - glue_connection_update_check.physical_connection_requirements.availability_zone == connection_info_update_check["Connection"]["PhysicalConnectionRequirements"]["AvailabilityZone"]
+          - glue_connection_update_check.raw_connection_properties == connection_info_update_check["Connection"]["ConnectionProperties"]
 
     - name: Update Glue connection
       aws_glue_connection:
@@ -264,6 +266,7 @@
           - glue_connection_update.physical_connection_requirements.subnet_id == connection_info_update["Connection"]["PhysicalConnectionRequirements"]["SubnetId"]
           - glue_connection_update.physical_connection_requirements.security_group_id_list == connection_info_update["Connection"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"]
           - glue_connection_update.physical_connection_requirements.availability_zone == connection_info_update["Connection"]["PhysicalConnectionRequirements"]["AvailabilityZone"]
+          - glue_connection_update.raw_connection_properties == connection_info_update["Connection"]["ConnectionProperties"]
 
     - name: Delete Glue connection (check mode)
       aws_glue_connection:

--- a/tests/integration/targets/glue_connection/tasks/test_connection_network.yml
+++ b/tests/integration/targets/glue_connection/tasks/test_connection_network.yml
@@ -52,7 +52,7 @@
         name: "{{ resource_prefix }}"
         availability_zone: "{{ aws_region }}a"
         connection_properties:
-          jdbc_enforce_ssl: "false"
+          JDBC_ENFORCE_SSL: "false"
         connection_type: NETWORK
         description: Test connection
         security_groups:
@@ -73,7 +73,7 @@
         name: "{{ resource_prefix }}"
         availability_zone: "{{ aws_region }}a"
         connection_properties:
-          jdbc_enforce_ssl: "false"
+          JDBC_ENFORCE_SSL: "false"
         connection_type: NETWORK
         description: Test connection
         security_groups:
@@ -112,7 +112,7 @@
         name: "{{ resource_prefix }}"
         availability_zone: "{{ aws_region }}a"
         connection_properties:
-          jdbc_enforce_ssl: "false"
+          JDBC_ENFORCE_SSL: "false"
         connection_type: NETWORK
         description: Test connection
         security_groups:
@@ -152,7 +152,7 @@
         name: "{{ resource_prefix }}"
         availability_zone: "{{ aws_region }}a"
         connection_properties:
-          jdbc_enforce_ssl: "false"
+          JDBC_ENFORCE_SSL: "false"
         connection_type: NETWORK
         description: Test connection
         security_groups:
@@ -191,7 +191,7 @@
         name: "{{ resource_prefix }}"
         availability_zone: "{{ aws_region }}a"
         connection_properties:
-          jdbc_enforce_ssl: "false"
+          JDBC_ENFORCE_SSL: "false"
         connection_type: NETWORK
         description: Test connection modified
         security_groups:
@@ -231,7 +231,7 @@
         name: "{{ resource_prefix }}"
         availability_zone: "{{ aws_region }}a"
         connection_properties:
-          jdbc_enforce_ssl: "false"
+          JDBC_ENFORCE_SSL: "false"
         connection_type: NETWORK
         description: Test connection modified
         security_groups:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a follow to my own PR [#503](https://github.com/ansible-collections/community.aws/pull/503).

This is a cosmetic change that prevents converting keys in connection_parameters dict to lowercase.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_glue_connection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
As an example, this:

```
- community.aws.glue_connection:
    name: test-connection
    connection_parameters:
      JDBC_ENFORCE_SSL: "false"
    ...
```

is a valid value, while this:

```
- community.aws.glue_connection:
    name: test-connection
    connection_parameters:
      jdbc_enforce_ssl: "false"
    ...
```

is not.

This PR simply aligns the module output to the expected input.
