### PR TITLE
ec2_instance_info - Add AWS Retries

### DIFF
--- a/changelogs/fragments/521-ec2_instance_info-retries.yml
+++ b/changelogs/fragments/521-ec2_instance_info-retries.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_instance_info - add retries on common AWS failures (https://github.com/ansible-collections/community.aws/pull/521).


### PR DESCRIPTION
##### SUMMARY

Add AWSRetry decorator to ec2_instance_info

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_instance_info

##### ADDITIONAL INFORMATION

Fixes:
https://app.shippable.com/github/ansible-collections/community.aws/runs/2158/30/console