### PR TITLE
ec2_instance - fetch status of instance before attempting to set additional parameters

### DIFF
--- a/changelogs/fragments/532-ec2_instance-wait-status.yml
+++ b/changelogs/fragments/532-ec2_instance-wait-status.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_instance - wait for new instances to return a status before attempting to set additional parameters (https://github.com/ansible-collections/community.aws/pull/533).


### PR DESCRIPTION
##### SUMMARY

Approximately 50% of ec2_instance test runs are currently failing because describe_instance_attribute is being called before the initial creation of the instance has completed.  Add a describe_instance_status call (with retries) to wait for the initial creation to complete before setting the attributes.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_instance

##### ADDITIONAL INFORMATION

https://app.shippable.com/github/ansible-collections/community.aws/runs/2224/31/tests
```
Traceback (most recent call last):
  File "/tmp/ansible_ec2_instance_payload_idd_9g5u/ansible_ec2_instance_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_instance.py", line 1316, in diff_instance_and_params
  File "/tmp/ansible_ec2_instance_payload_idd_9g5u/ansible_ec2_instance_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/core.py", line 288, in deciding_wrapper
    return retrying_wrapper(*args, **kwargs)
  File "/tmp/ansible_ec2_instance_payload_idd_9g5u/ansible_ec2_instance_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py", line 154, in retry_func
    raise e
  File "/tmp/ansible_ec2_instance_payload_idd_9g5u/ansible_ec2_instance_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py", line 144, in retry_func
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/dist-packages/botocore/client.py", line 676, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidInstanceID.NotFound) when calling the DescribeInstanceAttribute operation: The instance ID 'i-03e5c4198b9b9823a' does not exist
```