### PR TITLE
ec2_vpc_peering_info - Add AWSRetry decorator

### DIFF
--- a/changelogs/fragments/536-ec2_vpc_peering_info-retry.yml
+++ b/changelogs/fragments/536-ec2_vpc_peering_info-retry.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vpc_peering_info - add retries on common AWS failures (https://github.com/ansible-collections/community.aws/pull/536).


### PR DESCRIPTION
##### SUMMARY

- Add AWSRetry decorator
- Use common normalize_boto3_result code instead of C&P

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_peering_info

##### ADDITIONAL INFORMATION
