### PR TITLE
Update ec2_vpc_endpoint_info AWS retries

### DIFF
--- a/changelogs/fragments/537-ec2_vpc_endpoint_info-retries.yml
+++ b/changelogs/fragments/537-ec2_vpc_endpoint_info-retries.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_vpc_endpoint_info - use boto3 paginator when fetching services (https://github.com/ansible-collections/community.aws/pull/537).
+- ec2_vpc_endpoint_info - ensure paginated endpoint description is retried on common AWS failures (https://github.com/ansible-collections/community.aws/pull/537).

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -536,6 +536,7 @@
       route_table_ids:
         - '{{ rtb_igw_id }}'
       tags:
+        testPrefix: '{{ resource_prefix }}'
         camelCase: "helloWorld"
         PascalCase: "HelloWorld"
         snake_case: "hello_world"
@@ -547,7 +548,8 @@
     assert:
       that:
         - tag_vpc_endpoint.changed
-        - tag_vpc_endpoint.result.tags | length == 5
+        - tag_vpc_endpoint.result.tags | length == 6
+        - endpoint_tags["testPrefix"] == resource_prefix
         - endpoint_tags["camelCase"] == "helloWorld"
         - endpoint_tags["PascalCase"] == "HelloWorld"
         - endpoint_tags["snake_case"] == "hello_world"
@@ -560,8 +562,8 @@
     ec2_vpc_endpoint_info:
       query: endpoints
       filters:
-        "tag:camelCase":
-        - "helloWorld"
+        "tag:testPrefix":
+        - "{{ resource_prefix }}"
     register: tag_result
 
   - name: Assert tag lookup found endpoint
@@ -582,6 +584,7 @@
       route_table_ids:
         - '{{ rtb_igw_id }}'
       tags:
+        testPrefix: '{{ resource_prefix }}'
         camelCase: "helloWorld"
         PascalCase: "HelloWorld"
         snake_case: "hello_world"
@@ -603,6 +606,7 @@
       route_table_ids:
         - '{{ rtb_igw_id }}'
       tags:
+        testPrefix: '{{ resource_prefix }}'
         camelCase: "helloWorld"
         PascalCase: "HelloWorld"
         snake_case: "hello_world"
@@ -649,7 +653,8 @@
     assert:
       that:
         - add_tag_vpc_endpoint.changed
-        - add_tag_vpc_endpoint.result.tags | length == 6
+        - add_tag_vpc_endpoint.result.tags | length == 7
+        - endpoint_tags["testPrefix"] == resource_prefix
         - endpoint_tags["camelCase"] == "helloWorld"
         - endpoint_tags["PascalCase"] == "HelloWorld"
         - endpoint_tags["snake_case"] == "hello_world"


### PR DESCRIPTION
##### SUMMARY

We're still seeing some failures during Integration tests because we caught ClientError before the decorator could retry it.

https://app.shippable.com/github/ansible-collections/community.aws/runs/2267/24/tests

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_endpoint_info

##### ADDITIONAL INFORMATION
```
  File "/tmp/ansible_ec2_vpc_endpoint_info_payload_fXIuP1/ansible_ec2_vpc_endpoint_info_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_vpc_endpoint_info.py", line 152, in get_endpoints
  File "/usr/local/lib/python2.7/dist-packages/botocore/paginate.py", line 449, in build_full_result
    for response in self:
  File "/usr/local/lib/python2.7/dist-packages/botocore/paginate.py", line 255, in __iter__
    response = self._make_request(current_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/paginate.py", line 332, in _make_request
    return self._method(**current_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 676, in _make_api_call
    raise error_class(parsed_response, operation_name)
ClientError: An error occurred (RequestLimitExceeded) when calling the DescribeVpcEndpoints operation (reached max retries: 4): Request limit exceeded.

                        
```
