### PR TITLE
[WIP] cloudfront_distribution - fix Type error when validating distribution origins

### DIFF
--- a/changelogs/fragments/504-cloudfront_distribution-origins.yml
+++ b/changelogs/fragments/504-cloudfront_distribution-origins.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- cloudfront_distribution - fix type error when validating distribution origins (https://github.com/ansible-collections/community.aws/issues/504).
+- cloudfront_distrubution - fix idempotency issues when running with botocore 1.17.24 or later (https://github.com/ansible-collections/community.aws/pull/540).

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1726,8 +1726,6 @@ class CloudFrontValidationManager(object):
                 custom_origin_config = self.add_missing_key(custom_origin_config, 'origin_keepalive_timeout', self.__default_custom_origin_keepalive_timeout)
                 custom_origin_config = self.add_key_else_change_dict_key(custom_origin_config, 'http_port', 'h_t_t_p_port', self.__default_http_port)
                 custom_origin_config = self.add_key_else_change_dict_key(custom_origin_config, 'https_port', 'h_t_t_p_s_port', self.__default_https_port)
-                if custom_origin_config.get('origin_ssl_protocols', {}).get('items'):
-                    custom_origin_config['origin_ssl_protocols'] = custom_origin_config['origin_ssl_protocols']['items']
                 if custom_origin_config.get('origin_ssl_protocols'):
                     self.validate_attribute_list_with_allowed_list(custom_origin_config['origin_ssl_protocols'], 'origins[].origin_ssl_protocols',
                                                                    self.__valid_origin_ssl_protocols)
@@ -2102,7 +2100,35 @@ def main():
         aliases=dict(type='list', default=[], elements='str'),
         purge_aliases=dict(type='bool', default=False),
         default_root_object=dict(),
-        origins=dict(type='list', elements='dict'),
+        origins=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                id=dict(),
+                domain_name=dict(),
+                origin_path=dict(),
+                custom_headers=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        header_name=dict(required=True),
+                        header_value=dict(required=True),
+                    ),
+                ),
+                s3_origin_access_identity_enabled=dict(type='bool', default=False),
+                custom_origin_config=dict(
+                    type='dict',
+                    options=dict(
+                        http_port=dict(type='int'),
+                        https_port=dict(type='int'),
+                        origin_protocol_policy=dict(),
+                        origin_ssl_protocols=dict(type='list', elements='str'),
+                        origin_read_timeout=dict(type='int'),
+                        origin_keepalive_timeout=dict(type='int'),
+                    ),
+                ),
+            ),
+        ),
         purge_origins=dict(type='bool', default=False),
         default_cache_behavior=dict(type='dict'),
         cache_behaviors=dict(type='list', elements='dict'),

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -2121,7 +2121,7 @@ def main():
                         header_value=dict(required=True),
                     ),
                 ),
-                s3_origin_access_identity_enabled=dict(type='bool', default=False),
+                s3_origin_access_identity_enabled=dict(type='bool'),
                 custom_origin_config=dict(
                     type='dict',
                     options=dict(

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1718,6 +1718,9 @@ class CloudFrontValidationManager(object):
                     if 'custom_origin_config' in origin:
                         self.module.fail_json(msg="s3_origin_access_identity_enabled and custom_origin_config are mutually exclusive")
             else:
+                existing_origin_config = existing_config.get('custom_origin_config', {})
+                if existing_origin_config.get('origin_ssl_protocols'):
+                    existing_origin_config['origin_ssl_protocols'] = existing_origin_config['origin_ssl_protocols']['items']
                 origin = self.add_missing_key(origin, 'custom_origin_config', existing_config.get('custom_origin_config', {}))
                 custom_origin_config = origin.get('custom_origin_config')
                 custom_origin_config = self.add_key_else_validate(custom_origin_config, 'origin_protocol_policy',

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1699,6 +1699,8 @@ class CloudFrontValidationManager(object):
             origin = self.add_missing_key(origin, 'origin_path', existing_config.get('origin_path', default_origin_path or ''))
             self.validate_required_key('origin_path', 'origins[].origin_path', origin)
             origin = self.add_missing_key(origin, 'id', existing_config.get('id', self.__default_datetime_string))
+            origin = self.add_missing_key(origin, 'connection_attempts', existing_config.get('connection_attempts', None))
+            origin = self.add_missing_key(origin, 'connection_timeout', existing_config.get('connection_timeout', None))
             if 'custom_headers' in origin and len(origin.get('custom_headers')) > 0:
                 for custom_header in origin.get('custom_headers'):
                     if 'header_name' not in custom_header or 'header_value' not in custom_header:

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1365,6 +1365,7 @@ web_acl_id:
 
 from ansible.module_utils._text import to_text, to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import scrub_none_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.cloudfront_facts import CloudFrontFactsServiceManager
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags, ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict
@@ -2200,6 +2201,9 @@ def main():
 
     if alias and alias not in aliases:
         aliases.append(alias)
+
+    if origins:
+        origins = [scrub_none_parameters(origin, descend_into_lists=True) for origin in origins]
 
     distribution = validation_mgr.validate_distribution_from_aliases_caller_reference(distribution_id, aliases, caller_reference)
 

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -63,15 +63,17 @@
           origin_read_timeout: 5
           origin_ssl_protocols: TLSv1.2
       state: present
-    loop: [0, 1, 2]
-    check_mode: "{{ item == 0 }}"
+    loop: [0, 1, 2, 3]
+    check_mode: "{{ item % 2 == 0 }}"
     register: update_origin_custom_config
 
   - assert:
       that:
-        - update_origin_custom_config.results.0 is changed
+        # check_mode not supported
+        #- update_origin_custom_config.results.0 is changed
         - update_origin_custom_config.results.1 is changed
-        - update_origin_custom_config.results.2 is not changed
+        #- update_origin_custom_config.results.2 is not changed
+        - update_origin_custom_config.results.3 is not changed
 
   - name: update restrictions
     cloudfront_distribution:

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -50,20 +50,28 @@
       that:
         - not cf_dist_with_id.changed
 
-  - name: update origin http port
+  - name: set custom origin config
     cloudfront_distribution:
       distribution_id: "{{ distribution_id }}"
       origins:
       - domain_name: "{{ cloudfront_hostname }}-origin.example.com"
         custom_origin_config:
           http_port: 8080
+          https_port: 8443
+          origin_keepalive_timeout: 15
+          origin_protocol_policy: https-only
+          origin_read_timeout: 5
+          origin_ssl_protocols: TLSv1.2
       state: present
-    register: update_origin_http_port
+    loop: [0, 1, 2]
+    check_mode: "{{ item == 0 }}"
+    register: update_origin_custom_config
 
-  - name: ensure http port was updated
-    assert:
+  - assert:
       that:
-        - update_origin_http_port.changed
+        - update_origin_custom_config.results.0 is changed
+        - update_origin_custom_config.results.1 is changed
+        - update_origin_custom_config.results.2 is not changed
 
   - name: update restrictions
     cloudfront_distribution:


### PR DESCRIPTION
##### SUMMARY

fixes: #504 
When updating the origin on an existing distribution cloudfront returns a "cloudfront list" rather than the list that the code expected.  Resulting in a Type error.

See #504 for more details

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

cloudfront_distribution

##### ADDITIONAL INFORMATION

Initial work by @flowerysong 