### PR TITLE
Fix KeyError in aws_config_aggregator module

### DIFF
--- a/changelogs/fragments/553-aws_config_aggregator-fix-organization-source.yml
+++ b/changelogs/fragments/553-aws_config_aggregator-fix-organization-source.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_config_aggregator - Fix typos in attribute names (https://github.com/ansible-collections/community.aws/pull/553).

--- a/plugins/modules/aws_config_aggregator.py
+++ b/plugins/modules/aws_config_aggregator.py
@@ -103,7 +103,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, ca
 def resource_exists(client, module, params):
     try:
         aggregator = client.describe_configuration_aggregators(
-            ConfigurationAggregatorNames=[params['name']]
+            ConfigurationAggregatorNames=[params['ConfigurationAggregatorName']]
         )
         return aggregator['ConfigurationAggregators'][0]
     except is_boto3_error_code('NoSuchConfigurationAggregatorException'):
@@ -128,7 +128,7 @@ def create_resource(client, module, params, result):
 
 def update_resource(client, module, params, result):
     current_params = client.describe_configuration_aggregators(
-        ConfigurationAggregatorNames=[params['name']]
+        ConfigurationAggregatorNames=[params['ConfigurationAggregatorName']]
     )
 
     del current_params['ConfigurationAggregatorArn']
@@ -181,8 +181,8 @@ def main():
     params = {}
     if name:
         params['ConfigurationAggregatorName'] = name
+    params['AccountAggregationSources'] = []
     if module.params.get('account_sources'):
-        params['AccountAggregationSources'] = []
         for i in module.params.get('account_sources'):
             tmp_dict = {}
             if i.get('account_ids'):
@@ -203,7 +203,7 @@ def main():
                 'AwsRegions': module.params.get('organization_source').get('aws_regions')
             })
         if module.params.get('organization_source').get('all_aws_regions') is not None:
-            params['OrganizationAggregationSourcep'].update({
+            params['OrganizationAggregationSource'].update({
                 'AllAwsRegions': module.params.get('organization_source').get('all_aws_regions')
             })
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If `organization_source` attribute is specified, module fails with the
following error on line 206:

```
KeyError: 'OrganizationAggregationSourcep'
```

If `organization_source` attribute is specified and `account_sources`
attribute is empty, module fails with the following error on line 119:

```
KeyError: 'AccountAggregationSources'
```

This PR fixes both issues.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_config_aggregator

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example of an execution that triggers both errors:

```paste below
- community.aws.aws_config_aggregator:
    name: test
    account_sources: []
    organization_source:
      all_aws_regions: true
      role_arn: "arn:aws:iam::123412341234:role/my-role"
    state: present
```