### PR TITLE
fix ssm connection plugin fails at gathering facts

### DIFF
--- a/changelogs/fragments/558-ssm_connection-invalid-literal.yml
+++ b/changelogs/fragments/558-ssm_connection-invalid-literal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_ssm - fix ``invalid literal for int`` error on some operating systems (https://github.com/ansible-collections/community.aws/issues/113).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -447,11 +447,94 @@ class Connection(ConnectionBase):
 
     def _prepare_terminal(self):
         ''' perform any one-time terminal settings '''
+        # No windows setup for now
+        if self.is_windows:
+            return
 
-        if not self.is_windows:
-            cmd = "stty -echo\n" + "PS1=''\n"
-            cmd = to_bytes(cmd, errors='surrogate_or_strict')
-            self._session.stdin.write(cmd)
+        # *_complete variables are 3 valued:
+        #   - None: not started
+        #   - False: started
+        #   - True: complete
+
+        startup_complete = False
+        disable_echo_complete = None
+        disable_echo_cmd = to_bytes("stty -echo\n", errors="surrogate_or_strict")
+
+        disable_prompt_complete = None
+        end_mark = "".join(
+            [random.choice(string.ascii_letters) for i in xrange(self.MARK_LENGTH)]
+        )
+        disable_prompt_cmd = to_bytes(
+            "PS1='' ; printf '\\n%s\\n' '" + end_mark + "'\n",
+            errors="surrogate_or_strict",
+        )
+        disable_prompt_reply = re.compile(
+            r"\r\r\n" + re.escape(end_mark) + r"\r\r\n", re.MULTILINE
+        )
+
+        stdout = ""
+        # Custom command execution for when we're waiting for startup
+        stop_time = int(round(time.time())) + self.get_option("ssm_timeout")
+        while (not disable_prompt_complete) and (self._session.poll() is None):
+            remaining = stop_time - int(round(time.time()))
+            if remaining < 1:
+                self._timeout = True
+                display.vvvv(
+                    "PRE timeout stdout: {0}".format(to_bytes(stdout)), host=self.host
+                )
+                raise AnsibleConnectionFailure(
+                    "SSM start_session timeout on host: %s" % self.instance_id
+                )
+            if self._poll_stdout.poll(1000):
+                stdout += to_text(self._stdout.read(1024))
+                display.vvvv(
+                    "PRE stdout line: {0}".format(to_bytes(stdout)), host=self.host
+                )
+            else:
+                display.vvvv("PRE remaining: {0}".format(remaining), host=self.host)
+
+            # wait til prompt is ready
+            if startup_complete is False:
+                match = str(stdout).find("Starting session with SessionId")
+                if match != -1:
+                    display.vvvv("PRE startup output received", host=self.host)
+                    startup_complete = True
+
+            # disable echo
+            if startup_complete and (disable_echo_complete is None):
+                display.vvvv(
+                    "PRE Disabling Echo: {0}".format(disable_echo_cmd), host=self.host
+                )
+                self._session.stdin.write(disable_echo_cmd)
+                disable_echo_complete = False
+
+            if disable_echo_complete is False:
+                match = str(stdout).find("stty -echo")
+                if match != -1:
+                    disable_echo_complete = True
+
+            # disable prompt
+            if disable_echo_complete and disable_prompt_complete is None:
+                display.vvvv(
+                    "PRE Disabling Prompt: {0}".format(disable_prompt_cmd),
+                    host=self.host,
+                )
+                self._session.stdin.write(disable_prompt_cmd)
+                disable_prompt_complete = False
+
+            if disable_prompt_complete is False:
+                match = disable_prompt_reply.search(stdout)
+                if match:
+                    stdout = stdout[match.end() :]
+                    disable_prompt_complete = True
+
+        if not disable_prompt_complete:
+            raise AnsibleConnectionFailure(
+                "SSM process closed during _prepare_terminal on host: %s"
+                % self.instance_id
+            )
+        else:
+            display.vvv("PRE Terminal configured", host=self.host)
 
     def _wrap_command(self, cmd, sudoable, mark_start, mark_end):
         ''' wrap command so stdout and status can be extracted '''
@@ -463,7 +546,11 @@ class Connection(ConnectionBase):
         else:
             if sudoable:
                 cmd = "sudo " + cmd
-            cmd = "echo " + mark_start + "\n" + cmd + "\necho $'\\n'$?\n" + "echo " + mark_end + "\n"
+            cmd = (
+                f"printf '%s\\n' '{mark_start}';\n"
+                f"echo | {cmd};\n"
+                f"printf '\\n%s\\n%s\\n' \"$?\" '{mark_end}';\n"
+            )
 
         display.vvvv(u"_wrap_command: '{0}'".format(to_text(cmd)), host=self.host)
         return cmd

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -525,7 +525,7 @@ class Connection(ConnectionBase):
             if disable_prompt_complete is False:
                 match = disable_prompt_reply.search(stdout)
                 if match:
-                    stdout = stdout[match.end() :]
+                    stdout = stdout[match.end():]
                     disable_prompt_complete = True
 
         if not disable_prompt_complete:


### PR DESCRIPTION
##### SUMMARY

Apply diff proposed by @thomas-anderson-bsl https://github.com/ansible-collections/community.aws/issues/113#issuecomment-785652169

Fix #113
Fix #1163

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ssm

##### ADDITIONAL INFORMATION

Currently the example is failing on my Linux laptop

```bash
[vagrant@centos8 test]$ env |grep AWS
AWS_PROFILE=TKM_NOPROD
AWS_DEFAULT_REGION=eu-west-3
AWS_SDK_LOAD_CONFIG=1
[vagrant@centos8 test]$ aws sts get-caller-identity
{
    "UserId": "AROAQIIBQ3JCUSOU4JWCK:A512753",
    "Account": "017719941701",
    "Arn": "arn:aws:sts::017719941701:assumed-role/SysAdmin/A512753"
}
[vagrant@centos8 test]$ cat linux.yaml
- name: install aws-cli
  hosts: all
  gather_facts: false
  vars:
    ansible_connection: aws_ssm
    ansible_aws_ssm_bucket_name: tkm-exported-logs
    ansible_aws_ssm_region: eu-west-3
  tasks:
  - name: aws-cli
    raw: yum install -y awscli
    tags: aws-cli
[vagrant@centos8 test]$ cat aws_ec2.yml
plugin: aws_ec2
regions:
    - eu-west-3
hostnames:
    - instance-id
filters:
    tag:SSMTag: ssmlinux
[vagrant@centos8 test]$ ansible-playbook linux.yaml -i aws_ec2.yml -vvvv
ansible-playbook 2.10.5
  config file = /home/vagrant/.ansible.cfg
  configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/.local/lib/python3.6/site-packages/ansible
  executable location = /home/vagrant/.local/bin/ansible-playbook
  python version = 3.6.8 (default, Aug 24 2020, 17:57:11) [GCC 8.3.1 20191121 (Red Hat 8.3.1-5)]
Using /home/vagrant/.ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml as it did not pass its verify_file() method
script declined parsing /tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml as it did not pass its verify_file() method
redirecting (type: inventory) ansible.builtin.aws_ec2 to amazon.aws.aws_ec2
Loading collection amazon.aws from /home/vagrant/.ansible/collections/ansible_collections/amazon/aws
Parsed /tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml inventory source with auto plugin
Loading callback plugin default of type stdout, v2.0 from /home/vagrant/.local/lib/python3.6/site-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: linux.yaml ***************************************************************************************************************************************************
Positional arguments: linux.yaml
verbosity: 4
connection: smart
timeout: 10
become_method: sudo
tags: ('all',)
inventory: ('/tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml',)
forks: 5
1 plays in linux.yaml

PLAY [install aws-cli] *************************************************************************************************************************************************
META: ran handlers

TASK [aws-cli] *********************************************************************************************************************************************************
task path: /tmp/ansible-ami/base_aws_configuration/test/linux.yaml:9
redirecting (type: connection) ansible.builtin.aws_ssm to community.aws.aws_ssm
Loading collection community.aws from /home/vagrant/.local/lib/python3.6/site-packages/ansible_collections/community/aws
<i-01a919b33286168b1> ESTABLISH SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> SSM COMMAND: ['/usr/local/bin/session-manager-plugin', '{"SessionId": "A512753-0c292c1774b397c6f", "TokenValue": "AAEAAf79ujbqpQGYfHpLaJiTOlhUExBJDOkiLd/Fbq/alKF7AAAAAGCJEg4Fl3ljDMM9XwWJvAyTVsF3XwDlkJzbk4+c2802jl7gIIIODbDpCdsh9YRRLe5zIb1eXcZCTAquivDmzKpNp46ZxxRg/8UK/y5zeq8SvB58Fv8ir91F9LfxQD/hjVYOXKbU6MTjBeL7/JLCrWio5jV55NjXV1PMFWVVbfYvR+lesRhPKVhFf6bO4quyCTL+bmEDVAmCJnQX52KwBSqJhKArWUjAsmCfVj/YqaPLt1xmcR+CMlwO/x1VZPm6n2BBpFRr856bxsmVdEBOl/ckwsOK9k3JrTGQQuGxAVplO5rKlynBD15h2J4/CX1f2RiPOQghLyLSOUaSMA/o0MJMFkD7vMztgswj91lTqJKEu5O5fV1/3s1FnqRrXfFV6/+tcECoaDPxqbPvBiouN+5HHw4S", "StreamUrl": "wss://ssmmessages.eu-west-3.amazonaws.com/v1/data-channel/A512753-0c292c1774b397c6f?role=publish_subscribe", "ResponseMetadata": {"RequestId": "cd5a7d6a-406c-4a7b-9840-d74ce2a7db09", "HTTPStatusCode": 200, "HTTPHeaders": {"server": "Server", "date": "Wed, 28 Apr 2021 07:43:10 GMT", "content-type": "application/x-amz-json-1.1", "content-length": "642", "connection": "keep-alive", "x-amzn-requestid": "cd5a7d6a-406c-4a7b-9840-d74ce2a7db09"}, "RetryAttempts": 0}}', 'eu-west-3', 'StartSession', '', '{"Target": "i-01a919b33286168b1"}', 'https://ssm.eu-west-3.amazonaws.com']
<i-01a919b33286168b1> SSM CONNECTION ID: A512753-0c292c1774b397c6f
<i-01a919b33286168b1> EXEC yum install -y awscli
<i-01a919b33286168b1> _wrap_command: 'echo MjGohIiJUEeYoYWfZIfzrUfbLg
sudo yum install -y awscli
echo $'\n'$?
echo YoJSNqxmpcVfcJGJRJVfIteacP
'
<i-01a919b33286168b1> EXEC stdout line:
<i-01a919b33286168b1> EXEC stdout line: Starting session with SessionId: A512753-0c292c1774b397c6f
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ stty -echo
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ MjGohIiJUEeYoYWfZIfzrUfbLg
<i-01a919b33286168b1> EXEC stdout line: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
amzn2-core                                               | 3.7 kB     00:00
<i-01a919b33286168b1> EXEC remaining: 59
<i-01a919b33286168b1> EXEC stdout line: 332 packages excluded due to repository priority protections
<i-01a919b33286168b1> EXEC stdout line: Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
<i-01a919b33286168b1> EXEC stdout line: Nothing to do
<i-01a919b33286168b1> EXEC remaining: 57
<i-01a919b33286168b1> EXEC remaining: 56
<i-01a919b33286168b1> EXEC remaining: 55
<i-01a919b33286168b1> EXEC remaining: 54
<i-01a919b33286168b1> EXEC remaining: 53
<i-01a919b33286168b1> EXEC remaining: 52
<i-01a919b33286168b1> EXEC remaining: 51
<i-01a919b33286168b1> EXEC remaining: 50
<i-01a919b33286168b1> EXEC remaining: 49
<i-01a919b33286168b1> EXEC remaining: 48
<i-01a919b33286168b1> EXEC remaining: 47
<i-01a919b33286168b1> EXEC remaining: 46
<i-01a919b33286168b1> EXEC remaining: 45
<i-01a919b33286168b1> EXEC remaining: 44
<i-01a919b33286168b1> EXEC remaining: 43
<i-01a919b33286168b1> EXEC remaining: 42
<i-01a919b33286168b1> EXEC remaining: 41
<i-01a919b33286168b1> EXEC remaining: 40
<i-01a919b33286168b1> EXEC remaining: 39
<i-01a919b33286168b1> EXEC remaining: 38
<i-01a919b33286168b1> EXEC remaining: 37
<i-01a919b33286168b1> EXEC remaining: 36
<i-01a919b33286168b1> EXEC remaining: 35
<i-01a919b33286168b1> EXEC remaining: 34
<i-01a919b33286168b1> EXEC remaining: 32
<i-01a919b33286168b1> EXEC remaining: 31
<i-01a919b33286168b1> EXEC remaining: 30
<i-01a919b33286168b1> EXEC remaining: 29
<i-01a919b33286168b1> EXEC remaining: 28
<i-01a919b33286168b1> EXEC remaining: 27
<i-01a919b33286168b1> EXEC remaining: 26
<i-01a919b33286168b1> EXEC remaining: 25
<i-01a919b33286168b1> EXEC remaining: 24
<i-01a919b33286168b1> EXEC remaining: 23
<i-01a919b33286168b1> EXEC remaining: 22
<i-01a919b33286168b1> EXEC remaining: 21
<i-01a919b33286168b1> EXEC remaining: 20
<i-01a919b33286168b1> EXEC remaining: 19
<i-01a919b33286168b1> EXEC remaining: 18
<i-01a919b33286168b1> EXEC remaining: 17
<i-01a919b33286168b1> EXEC remaining: 16
<i-01a919b33286168b1> EXEC remaining: 15
<i-01a919b33286168b1> EXEC remaining: 14
<i-01a919b33286168b1> EXEC remaining: 13
<i-01a919b33286168b1> EXEC remaining: 12
<i-01a919b33286168b1> EXEC remaining: 11
<i-01a919b33286168b1> EXEC remaining: 10
<i-01a919b33286168b1> EXEC remaining: 9
<i-01a919b33286168b1> EXEC remaining: 8
<i-01a919b33286168b1> EXEC remaining: 7
<i-01a919b33286168b1> EXEC remaining: 6
<i-01a919b33286168b1> EXEC remaining: 5
<i-01a919b33286168b1> EXEC remaining: 4
<i-01a919b33286168b1> EXEC remaining: 3
<i-01a919b33286168b1> EXEC remaining: 2
<i-01a919b33286168b1> EXEC remaining: 1
<i-01a919b33286168b1> EXEC timeout stdout: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
amzn2-core                                               | 3.7 kB     00:00
332 packages excluded due to repository priority protections
Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
Nothing to do
<i-01a919b33286168b1> ssm_retry: attempt: 0, cmd (yum install -y awscli...), pausing for 0 seconds
<i-01a919b33286168b1> CLOSING SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> TERMINATE SSM SESSION: A512753-0c292c1774b397c6f
<i-01a919b33286168b1> ESTABLISH SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> SSM COMMAND: ['/usr/local/bin/session-manager-plugin', '{"SessionId": "A512753-0d6533239e4db8272", "TokenValue": "AAEAAcua+Crf0t+FmSNgvZSpxTvDQksaWVQiDjJ96ZmNStp0AAAAAGCJEkzdO6ZTkt7WRjUVePEQ7dys7SUGc/Ys8sPyn9r/gKqfi9g84j8uc6HaLKbB/jmrdVSdGMBVNvDEZtgeSpJMSRqZ/jPjB9jW0RHXCia8161lzpG6mnACyoL/bt6l1zpXA98sa4NFbaBRATXP+Rwd+gNONSn40kLYWegp/hvnsCgRsE70FfSrH+9NNsCpNvMli1TexqTuoQB1xz7MUnsMEwc/kkHM8NDcpEH+AGbNbVlSy3pLVe2EPS0ps2ElPp9WKpMrkywhN2LZT510TgRK6UoS23QBp2ZxqNPZLgK/qZh91M++pXYX/kBX5ACpOdBSccyMyHMN+aO//690zfC7Glk6t+i68R9odMFesPrDGPeWvhfZvtEuxW6TIOYLVqNOG7xR6/ilcGir7wrHNLvAmw4M", "StreamUrl": "wss://ssmmessages.eu-west-3.amazonaws.com/v1/data-channel/A512753-0d6533239e4db8272?role=publish_subscribe", "ResponseMetadata": {"RequestId": "48b9d452-99da-4b4d-9e30-148c4648760e", "HTTPStatusCode": 200, "HTTPHeaders": {"server": "Server", "date": "Wed, 28 Apr 2021 07:44:12 GMT", "content-type": "application/x-amz-json-1.1", "content-length": "642", "connection": "keep-alive", "x-amzn-requestid": "48b9d452-99da-4b4d-9e30-148c4648760e"}, "RetryAttempts": 0}}', 'eu-west-3', 'StartSession', '', '{"Target": "i-01a919b33286168b1"}', 'https://ssm.eu-west-3.amazonaws.com']
<i-01a919b33286168b1> SSM CONNECTION ID: A512753-0d6533239e4db8272
<i-01a919b33286168b1> EXEC yum install -y awscli
<i-01a919b33286168b1> _wrap_command: 'echo AhNjLyNqKvKkPpDrBmFRWXQhYa
sudo yum install -y awscli
echo $'\n'$?
echo JuLdCBzespYaUSOaucFXezVwIt
'
<i-01a919b33286168b1> EXEC stdout line:
<i-01a919b33286168b1> EXEC stdout line: Starting session with SessionId: A512753-0d6533239e4db8272
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ stty -echo
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ AhNjLyNqKvKkPpDrBmFRWXQhYa
<i-01a919b33286168b1> EXEC stdout line: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
<i-01a919b33286168b1> EXEC remaining: 58
<i-01a919b33286168b1> EXEC stdout line: 332 packages excluded due to repository priority protections
<i-01a919b33286168b1> EXEC stdout line: Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
<i-01a919b33286168b1> EXEC stdout line: Nothing to do
<i-01a919b33286168b1> EXEC remaining: 56
<i-01a919b33286168b1> EXEC remaining: 55
<i-01a919b33286168b1> EXEC remaining: 54
<i-01a919b33286168b1> EXEC remaining: 53
<i-01a919b33286168b1> EXEC remaining: 52
<i-01a919b33286168b1> EXEC remaining: 51
<i-01a919b33286168b1> EXEC remaining: 50
<i-01a919b33286168b1> EXEC remaining: 49
<i-01a919b33286168b1> EXEC remaining: 48
<i-01a919b33286168b1> EXEC remaining: 47
<i-01a919b33286168b1> EXEC remaining: 46
<i-01a919b33286168b1> EXEC remaining: 45
<i-01a919b33286168b1> EXEC remaining: 44
<i-01a919b33286168b1> EXEC remaining: 43
<i-01a919b33286168b1> EXEC remaining: 42
<i-01a919b33286168b1> EXEC remaining: 41
<i-01a919b33286168b1> EXEC remaining: 40
<i-01a919b33286168b1> EXEC remaining: 39
<i-01a919b33286168b1> EXEC remaining: 38
<i-01a919b33286168b1> EXEC remaining: 37
<i-01a919b33286168b1> EXEC remaining: 36
<i-01a919b33286168b1> EXEC remaining: 35
<i-01a919b33286168b1> EXEC remaining: 34
<i-01a919b33286168b1> EXEC remaining: 33
<i-01a919b33286168b1> EXEC remaining: 32
<i-01a919b33286168b1> EXEC remaining: 31
<i-01a919b33286168b1> EXEC remaining: 30
<i-01a919b33286168b1> EXEC remaining: 29
<i-01a919b33286168b1> EXEC remaining: 28
<i-01a919b33286168b1> EXEC remaining: 27
<i-01a919b33286168b1> EXEC remaining: 26
<i-01a919b33286168b1> EXEC remaining: 25
<i-01a919b33286168b1> EXEC remaining: 24
<i-01a919b33286168b1> EXEC remaining: 23
<i-01a919b33286168b1> EXEC remaining: 22
<i-01a919b33286168b1> EXEC remaining: 21
<i-01a919b33286168b1> EXEC remaining: 20
<i-01a919b33286168b1> EXEC remaining: 19
<i-01a919b33286168b1> EXEC remaining: 18
<i-01a919b33286168b1> EXEC remaining: 17
<i-01a919b33286168b1> EXEC remaining: 16
<i-01a919b33286168b1> EXEC remaining: 15
<i-01a919b33286168b1> EXEC remaining: 14
<i-01a919b33286168b1> EXEC remaining: 13
<i-01a919b33286168b1> EXEC remaining: 12
<i-01a919b33286168b1> EXEC remaining: 11
<i-01a919b33286168b1> EXEC remaining: 10
<i-01a919b33286168b1> EXEC remaining: 9
<i-01a919b33286168b1> EXEC remaining: 8
<i-01a919b33286168b1> EXEC remaining: 7
<i-01a919b33286168b1> EXEC remaining: 6
<i-01a919b33286168b1> EXEC remaining: 5
<i-01a919b33286168b1> EXEC remaining: 4
<i-01a919b33286168b1> EXEC remaining: 3
<i-01a919b33286168b1> EXEC remaining: 2
<i-01a919b33286168b1> EXEC remaining: 1
<i-01a919b33286168b1> EXEC timeout stdout: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
332 packages excluded due to repository priority protections
Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
Nothing to do
<i-01a919b33286168b1> ssm_retry: attempt: 1, cmd (yum install -y awscli...), pausing for 1 seconds
<i-01a919b33286168b1> CLOSING SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> TERMINATE SSM SESSION: A512753-0d6533239e4db8272
<i-01a919b33286168b1> ESTABLISH SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> SSM COMMAND: ['/usr/local/bin/session-manager-plugin', '{"SessionId": "A512753-09a773809c4290ba8", "TokenValue": "AAEAAY8euMXFMJqb6NktLar2duBd+N19wyEaDkoCkanNHU2RAAAAAGCJEoofW/XfRQ9bW2MlXFDd2V+3X2Dg9t1qHGvHkz8Ms1kHMZVNHAq4vk6YnulLLJmDf8GuBAbm1UpguJLbtdI1/dmWMXCSAHmAKwdCchds+eP4a0kBNWNCWRpa4g5igD6t+gwJNqtYFgfofbUJ1tPYenBUHtP/iYaWloP9NKXMDlcxB80mIc0jhWdK7IM+ohztD4HHWz9YLjw/yTrnUjTVMoLgoVAYp+42knhG5DYxXW6l5R6j2KUdGCgCsPmiQog9rZnpG1FR9Tr3+EpuEQhxZ4jRQA7Oez12KE1TMCcp5y22pg1i2tZ5bSu+NreIBmorVTay0RSoGtVCIGvcFs0T3UIQZQtlGwNhwpbOFqyT50d6N99zw7chzv5ORi3ilmweSIEqbUFTaCfCGxy7bOX+br5z", "StreamUrl": "wss://ssmmessages.eu-west-3.amazonaws.com/v1/data-channel/A512753-09a773809c4290ba8?role=publish_subscribe", "ResponseMetadata": {"RequestId": "6f105bd2-61c4-49b3-92b5-64b71149161d", "HTTPStatusCode": 200, "HTTPHeaders": {"server": "Server", "date": "Wed, 28 Apr 2021 07:45:14 GMT", "content-type": "application/x-amz-json-1.1", "content-length": "642", "connection": "keep-alive", "x-amzn-requestid": "6f105bd2-61c4-49b3-92b5-64b71149161d"}, "RetryAttempts": 0}}', 'eu-west-3', 'StartSession', '', '{"Target": "i-01a919b33286168b1"}', 'https://ssm.eu-west-3.amazonaws.com']
<i-01a919b33286168b1> SSM CONNECTION ID: A512753-09a773809c4290ba8
<i-01a919b33286168b1> EXEC yum install -y awscli
<i-01a919b33286168b1> _wrap_command: 'echo fxUMwVtRygloIfujoykKZqsRYQ
sudo yum install -y awscli
echo $'\n'$?
echo meoFrFEeqnsFelOUcbgYMqWcqf
'
<i-01a919b33286168b1> EXEC stdout line:
<i-01a919b33286168b1> EXEC stdout line: Starting session with SessionId: A512753-09a773809c4290ba8
<i-01a919b33286168b1> EXEC remaining: 60
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ stty -echo
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ fxUMwVtRygloIfujoykKZqsRYQ
<i-01a919b33286168b1> EXEC stdout line: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
<i-01a919b33286168b1> EXEC remaining: 58
<i-01a919b33286168b1> EXEC stdout line: 332 packages excluded due to repository priority protections
<i-01a919b33286168b1> EXEC stdout line: Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
<i-01a919b33286168b1> EXEC stdout line: Nothing to do
<i-01a919b33286168b1> EXEC remaining: 55
<i-01a919b33286168b1> EXEC remaining: 54
<i-01a919b33286168b1> EXEC remaining: 53
<i-01a919b33286168b1> EXEC remaining: 52
<i-01a919b33286168b1> EXEC remaining: 51
<i-01a919b33286168b1> EXEC remaining: 50
<i-01a919b33286168b1> EXEC remaining: 49
<i-01a919b33286168b1> EXEC remaining: 48
<i-01a919b33286168b1> EXEC remaining: 47
<i-01a919b33286168b1> EXEC remaining: 46
<i-01a919b33286168b1> EXEC remaining: 45
<i-01a919b33286168b1> EXEC remaining: 44
<i-01a919b33286168b1> EXEC remaining: 43
<i-01a919b33286168b1> EXEC remaining: 42
<i-01a919b33286168b1> EXEC remaining: 41
<i-01a919b33286168b1> EXEC remaining: 40
<i-01a919b33286168b1> EXEC remaining: 39
<i-01a919b33286168b1> EXEC remaining: 38
<i-01a919b33286168b1> EXEC remaining: 37
<i-01a919b33286168b1> EXEC remaining: 36
<i-01a919b33286168b1> EXEC remaining: 35
<i-01a919b33286168b1> EXEC remaining: 34
<i-01a919b33286168b1> EXEC remaining: 33
<i-01a919b33286168b1> EXEC remaining: 32
<i-01a919b33286168b1> EXEC remaining: 31
<i-01a919b33286168b1> EXEC remaining: 30
<i-01a919b33286168b1> EXEC remaining: 29
<i-01a919b33286168b1> EXEC remaining: 28
<i-01a919b33286168b1> EXEC remaining: 27
<i-01a919b33286168b1> EXEC remaining: 26
<i-01a919b33286168b1> EXEC remaining: 25
<i-01a919b33286168b1> EXEC remaining: 24
<i-01a919b33286168b1> EXEC remaining: 23
<i-01a919b33286168b1> EXEC remaining: 22
<i-01a919b33286168b1> EXEC remaining: 21
<i-01a919b33286168b1> EXEC remaining: 20
<i-01a919b33286168b1> EXEC remaining: 19
<i-01a919b33286168b1> EXEC remaining: 18
<i-01a919b33286168b1> EXEC remaining: 17
<i-01a919b33286168b1> EXEC remaining: 16
<i-01a919b33286168b1> EXEC remaining: 15
<i-01a919b33286168b1> EXEC remaining: 14
<i-01a919b33286168b1> EXEC remaining: 13
<i-01a919b33286168b1> EXEC remaining: 12
<i-01a919b33286168b1> EXEC remaining: 11
<i-01a919b33286168b1> EXEC remaining: 10
<i-01a919b33286168b1> EXEC remaining: 9
<i-01a919b33286168b1> EXEC remaining: 8
<i-01a919b33286168b1> EXEC remaining: 7
<i-01a919b33286168b1> EXEC remaining: 6
<i-01a919b33286168b1> EXEC remaining: 5
<i-01a919b33286168b1> EXEC remaining: 4
<i-01a919b33286168b1> EXEC remaining: 3
<i-01a919b33286168b1> EXEC remaining: 2
<i-01a919b33286168b1> EXEC remaining: 1
<i-01a919b33286168b1> EXEC timeout stdout: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
332 packages excluded due to repository priority protections
Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
Nothing to do
<i-01a919b33286168b1> ssm_retry: attempt: 2, cmd (yum install -y awscli...), pausing for 3 seconds
<i-01a919b33286168b1> CLOSING SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> TERMINATE SSM SESSION: A512753-09a773809c4290ba8
<i-01a919b33286168b1> ESTABLISH SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> SSM COMMAND: ['/usr/local/bin/session-manager-plugin', '{"SessionId": "A512753-04ce28f1ed0a9b2cc", "TokenValue": "AAEAAWShVQvs4lr+jZzebJuPI/kjqeHN9aRbG8Ga+dDyG92JAAAAAGCJEsu8ji1RBCTYUF6gZuRvoNRCynBSdcj5DEXOx/aGcIvd9dhQ35CL3yqd6vc2SG3CfGuVDrzaPjXdqbSpK8vYeC8T6o1iqCQQZTWRjx3hv1JPNcIvqKToXnVNYEehyuqL9AiEwjsp4BKsj+1GyZaONSEhu3hGv7CaU0lLwsZSeLNx/gUo48QKJJdfUFhAfElnlyt/bLgAFNokPWfhJo9C8eJaGUbPjGx5q5fFajpbCt56XE6bMqdvDkQq0rL0CCVOa8OwcXrq1cixwj8zyVJRk4r1xFaxVJUrNSiZjBef8XnuIJSwJGS4rqW3xj7MAcN+fP37cwsvRDXzaJiaNIQixd4BMUJT9DKBTnt5k8CKlkig/1CkLiqRfpTt/1dDrk3ijIn+WmijmUIGzXGTASXf4NL4", "StreamUrl": "wss://ssmmessages.eu-west-3.amazonaws.com/v1/data-channel/A512753-04ce28f1ed0a9b2cc?role=publish_subscribe", "ResponseMetadata": {"RequestId": "079764cf-ef62-4378-a6a7-c1aa982b2175", "HTTPStatusCode": 200, "HTTPHeaders": {"server": "Server", "date": "Wed, 28 Apr 2021 07:46:19 GMT", "content-type": "application/x-amz-json-1.1", "content-length": "642", "connection": "keep-alive", "x-amzn-requestid": "079764cf-ef62-4378-a6a7-c1aa982b2175"}, "RetryAttempts": 0}}', 'eu-west-3', 'StartSession', '', '{"Target": "i-01a919b33286168b1"}', 'https://ssm.eu-west-3.amazonaws.com']
<i-01a919b33286168b1> SSM CONNECTION ID: A512753-04ce28f1ed0a9b2cc
<i-01a919b33286168b1> EXEC yum install -y awscli
<i-01a919b33286168b1> _wrap_command: 'echo mYEabajpUREmWopOVdtXWVjhjA
sudo yum install -y awscli
echo $'\n'$?
echo HUOIrDSkTqNbXtGnpsfqUWmKse
'
<i-01a919b33286168b1> EXEC stdout line:
<i-01a919b33286168b1> EXEC stdout line: Starting session with SessionId: A512753-04ce28f1ed0a9b2cc
<i-01a919b33286168b1> EXEC remaining: 60
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ stty -echo
<i-01a919b33286168b1> EXEC stdout line: sh-4.2$ mYEabajpUREmWopOVdtXWVjhjA
<i-01a919b33286168b1> EXEC stdout line: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
<i-01a919b33286168b1> EXEC remaining: 59
<i-01a919b33286168b1> EXEC stdout line: 332 packages excluded due to repository priority protections
<i-01a919b33286168b1> EXEC stdout line: Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
<i-01a919b33286168b1> EXEC stdout line: Nothing to do
<i-01a919b33286168b1> EXEC remaining: 56
<i-01a919b33286168b1> EXEC remaining: 55
<i-01a919b33286168b1> EXEC remaining: 54
<i-01a919b33286168b1> EXEC remaining: 53
<i-01a919b33286168b1> EXEC remaining: 52
<i-01a919b33286168b1> EXEC remaining: 51
<i-01a919b33286168b1> EXEC remaining: 50
<i-01a919b33286168b1> EXEC remaining: 49
<i-01a919b33286168b1> EXEC remaining: 48
<i-01a919b33286168b1> EXEC remaining: 47
<i-01a919b33286168b1> EXEC remaining: 46
<i-01a919b33286168b1> EXEC remaining: 45
<i-01a919b33286168b1> EXEC remaining: 44
<i-01a919b33286168b1> EXEC remaining: 43
<i-01a919b33286168b1> EXEC remaining: 42
<i-01a919b33286168b1> EXEC remaining: 41
<i-01a919b33286168b1> EXEC remaining: 40
<i-01a919b33286168b1> EXEC remaining: 39
<i-01a919b33286168b1> EXEC remaining: 38
<i-01a919b33286168b1> EXEC remaining: 37
<i-01a919b33286168b1> EXEC remaining: 36
<i-01a919b33286168b1> EXEC remaining: 35
<i-01a919b33286168b1> EXEC remaining: 34
<i-01a919b33286168b1> EXEC remaining: 33
<i-01a919b33286168b1> EXEC remaining: 32
<i-01a919b33286168b1> EXEC remaining: 31
<i-01a919b33286168b1> EXEC remaining: 30
<i-01a919b33286168b1> EXEC remaining: 29
<i-01a919b33286168b1> EXEC remaining: 28
<i-01a919b33286168b1> EXEC remaining: 27
<i-01a919b33286168b1> EXEC remaining: 26
<i-01a919b33286168b1> EXEC remaining: 25
<i-01a919b33286168b1> EXEC remaining: 24
<i-01a919b33286168b1> EXEC remaining: 23
<i-01a919b33286168b1> EXEC remaining: 22
<i-01a919b33286168b1> EXEC remaining: 21
<i-01a919b33286168b1> EXEC remaining: 20
<i-01a919b33286168b1> EXEC remaining: 19
<i-01a919b33286168b1> EXEC remaining: 18
<i-01a919b33286168b1> EXEC remaining: 17
<i-01a919b33286168b1> EXEC remaining: 16
<i-01a919b33286168b1> EXEC remaining: 15
<i-01a919b33286168b1> EXEC remaining: 14
<i-01a919b33286168b1> EXEC remaining: 13
<i-01a919b33286168b1> EXEC remaining: 12
<i-01a919b33286168b1> EXEC remaining: 11
<i-01a919b33286168b1> EXEC remaining: 10
<i-01a919b33286168b1> EXEC remaining: 9
<i-01a919b33286168b1> EXEC remaining: 8
<i-01a919b33286168b1> EXEC remaining: 7
<i-01a919b33286168b1> EXEC remaining: 6
<i-01a919b33286168b1> EXEC remaining: 5
<i-01a919b33286168b1> EXEC remaining: 4
<i-01a919b33286168b1> EXEC remaining: 3
<i-01a919b33286168b1> EXEC remaining: 2
<i-01a919b33286168b1> EXEC remaining: 1
<i-01a919b33286168b1> EXEC timeout stdout: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
332 packages excluded due to repository priority protections
Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
Nothing to do
<i-01a919b33286168b1> CLOSING SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> TERMINATE SSM SESSION: A512753-04ce28f1ed0a9b2cc
fatal: [i-01a919b33286168b1]: UNREACHABLE! => {
    "changed": false,
    "msg": "SSM exec_command timeout on host: i-01a919b33286168b1",
    "unreachable": true
}

PLAY RECAP *************************************************************************************************************************************************************
i-01a919b33286168b1        : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0
```

When I apply the patch, it works well

```bash
[vagrant@centos8 test]$ ansible-playbook linux.yaml -i aws_ec2.yml -vvvv
ansible-playbook 2.10.5
  config file = /home/vagrant/.ansible.cfg
  configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/.local/lib/python3.6/site-packages/ansible
  executable location = /home/vagrant/.local/bin/ansible-playbook
  python version = 3.6.8 (default, Aug 24 2020, 17:57:11) [GCC 8.3.1 20191121 (Red Hat 8.3.1-5)]
Using /home/vagrant/.ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml as it did not pass its verify_file() method
script declined parsing /tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml as it did not pass its verify_file() method
redirecting (type: inventory) ansible.builtin.aws_ec2 to amazon.aws.aws_ec2
Loading collection amazon.aws from /home/vagrant/.ansible/collections/ansible_collections/amazon/aws
Parsed /tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml inventory source with auto plugin
Loading callback plugin default of type stdout, v2.0 from /home/vagrant/.local/lib/python3.6/site-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: linux.yaml ***************************************************************************************************************************************************
Positional arguments: linux.yaml
verbosity: 4
connection: smart
timeout: 10
become_method: sudo
tags: ('all',)
inventory: ('/tmp/ansible-ami/base_aws_configuration/test/aws_ec2.yml',)
forks: 5
1 plays in linux.yaml

PLAY [install aws-cli] *************************************************************************************************************************************************
META: ran handlers

TASK [aws-cli] *********************************************************************************************************************************************************
task path: /tmp/ansible-ami/base_aws_configuration/test/linux.yaml:9
<i-01a919b33286168b1> ESTABLISH SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> SSM COMMAND: ['/usr/local/bin/session-manager-plugin', '{"SessionId": "A512753-03fc91cde78438694", "TokenValue": "AAEAAW/9pxZQ5rD36JpYalo7sawVweoKITNNtI4392BVkuEDAAAAAGCJE4m7i9Fiy79NAlD8WLAXo1Ybury4avfnW75u3V57mFHcOLF/NHkGHVrg9CgaddaKEdq46EmXmpnqL4BJ/bUzE6sm8YpX/JyLmxnuBaOMMfTEpBdTmTdEjJfq3JeRG3ze4klZwUAO3Bkr6Y4PebzPDSsiC9cYa/vF7JKWS05BR80j0eX3JrI02NQs6Xl4R12D88l80kxvhorMtSwdSuwVrfDJtVSX0AgRpDgc3ZaeoZOl6INJSz1joXdykO6J6sFNUorQwLYVOet8EgHRHSxes2rhWccZxsNWA4WDqLe4yJ53/aVfvEtAXrC5sB/dEdyh0HaT7e3xZJGgTLqkY8tPZ1t96ftCU4WCGyqcmsey6AHjY4pyKzspibjtb+3mQiFmhHVY2qXJdNm/GK8QiM3KvDNV", "StreamUrl": "wss://ssmmessages.eu-west-3.amazonaws.com/v1/data-channel/A512753-03fc91cde78438694?role=publish_subscribe", "ResponseMetadata": {"RequestId": "ae9980f6-68e2-4724-9e9d-cd46030ff8a7", "HTTPStatusCode": 200, "HTTPHeaders": {"server": "Server", "date": "Wed, 28 Apr 2021 07:49:29 GMT", "content-type": "application/x-amz-json-1.1", "content-length": "642", "connection": "keep-alive", "x-amzn-requestid": "ae9980f6-68e2-4724-9e9d-cd46030ff8a7"}, "RetryAttempts": 0}}', 'eu-west-3', 'StartSession', '', '{"Target": "i-01a919b33286168b1"}', 'https://ssm.eu-west-3.amazonaws.com']
<i-01a919b33286168b1> PRE stdout line: b'\r\nStarting session with SessionId: A512753-03fc91cde78438694\r\n'
<i-01a919b33286168b1> PRE startup output received
<i-01a919b33286168b1> PRE Disabling Echo: b'stty -echo\n'
<i-01a919b33286168b1> PRE stdout line: b'\r\nStarting session with SessionId: A512753-03fc91cde78438694\r\n\x1b[?1034hsh-4.2$ '
<i-01a919b33286168b1> PRE stdout line: b'\r\nStarting session with SessionId: A512753-03fc91cde78438694\r\n\x1b[?1034hsh-4.2$ s'
<i-01a919b33286168b1> PRE stdout line: b'\r\nStarting session with SessionId: A512753-03fc91cde78438694\r\n\x1b[?1034hsh-4.2$ stty -echo\r\r\nsh-4.2$ '
<i-01a919b33286168b1> PRE Disabling Prompt: b"PS1='' ; printf '\\n%s\\n' 'tzLzeOyQfgbHdOairfXctIHvCE'\n"
<i-01a919b33286168b1> PRE stdout line: b'\r\nStarting session with SessionId: A512753-03fc91cde78438694\r\n\x1b[?1034hsh-4.2$ stty -echo\r\r\nsh-4.2$ \r\r\ntzLzeOyQfgbHdOairfXctIHvCE\r\r\n'
<i-01a919b33286168b1> PRE Terminal configured
<i-01a919b33286168b1> SSM CONNECTION ID: A512753-03fc91cde78438694
<i-01a919b33286168b1> EXEC yum install -y awscli
<i-01a919b33286168b1> _wrap_command: 'printf '%s\n' 'unVADXWGDhKpmPYyJlyAahHsWK';
echo | sudo yum install -y awscli;
printf '\n%s\n%s\n' "$?" 'swsasimtXIvBgCtvgOQifPBsrV';
'
<i-01a919b33286168b1> EXEC stdout line: unVADXWGDhKpmPYyJlyAahHsWK
<i-01a919b33286168b1> EXEC stdout line: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
amzn2-core                                               | 3.7 kB     00:00
<i-01a919b33286168b1> EXEC remaining: 59
<i-01a919b33286168b1> EXEC stdout line: 332 packages excluded due to repository priority protections
<i-01a919b33286168b1> EXEC stdout line: Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
<i-01a919b33286168b1> EXEC stdout line: Nothing to do
<i-01a919b33286168b1> EXEC stdout line:
<i-01a919b33286168b1> EXEC stdout line: 0
<i-01a919b33286168b1> EXEC stdout line: swsasimtXIvBgCtvgOQifPBsrV
<i-01a919b33286168b1> POST_PROCESS: Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
amzn2-core                                               | 3.7 kB     00:00
332 packages excluded due to repository priority protections
Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version
Nothing to do

0
<i-01a919b33286168b1> (0, 'Loaded plugins: extras_suggestions, langpacks, priorities, update-motd\r\r\r\n\ramzn2-core                                               | 3.7 kB     00:00     \r\r\r\n332 packages excluded due to repository priority protections\r\r\r\nPackage awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version\r\r\r\nNothing to do\r\r\r', '')
<i-01a919b33286168b1> CLOSING SSM CONNECTION TO: i-01a919b33286168b1
<i-01a919b33286168b1> TERMINATE SSM SESSION: A512753-03fc91cde78438694
changed: [i-01a919b33286168b1] => {
    "changed": true,
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Loaded plugins: extras_suggestions, langpacks, priorities, update-motd\r\r\r\n\ramzn2-core                                               | 3.7 kB     00:00     \r\r\r\n332 packages excluded due to repository priority protections\r\r\r\nPackage awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version\r\r\r\nNothing to do\r\r\r",
    "stdout_lines": [
        "Loaded plugins: extras_suggestions, langpacks, priorities, update-motd",
        "",
        "",
        "",
        "amzn2-core                                               | 3.7 kB     00:00     ",
        "",
        "",
        "332 packages excluded due to repository priority protections",
        "",
        "",
        "Package awscli-1.18.147-1.amzn2.0.1.noarch already installed and latest version",
        "",
        "",
        "Nothing to do",
        "",
        ""
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************
i-01a919b33286168b1        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

With the patch, it also works with `gather_facts: true`
