### PR TITLE
Route53 retry/waiter tweaks

### DIFF
--- a/changelogs/564-route53-retries.yml
+++ b/changelogs/564-route53-retries.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- route53 - fix typo in waiter configuration that prevented management of the delays (https://github.com/ansible-collections/community.aws/pull/564).
+minor_changes:
+- route53 - add retries on ``PriorRequestNotComplete`` errors (https://github.com/ansible-collections/community.aws/pull/564).
+- route53 - update retry ``max_delay`` setting so that it can be set above 60 seconds (https://github.com/ansible-collections/community.aws/pull/564).
+- route53 - add rate-limiting retries while waiting for changes to propagate (https://github.com/ansible-collections/community.aws/pull/564).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -369,6 +369,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.core import scrub_none_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 
 MAX_AWS_RETRIES = 10  # How many retries to perform when an API call is failing
 WAIT_RETRY = 5  # how many seconds to wait between propagation status polls
@@ -667,7 +668,7 @@ def main():
             )
 
             if wait_in:
-                waiter = route53.get_waiter('resource_record_sets_changed')
+                waiter = get_waiter(route53, 'resource_record_sets_changed')
                 waiter.wait(
                     Id=change_resource_record_sets['ChangeInfo']['Id'],
                     WaiterConfig=dict(

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -578,6 +578,7 @@ def main():
         retries=MAX_AWS_RETRIES,
         delay=retry_interval_in,
         catch_extra_error_codes=['PriorRequestNotComplete'],
+        max_delay=max(60, retry_interval_in),
     )
 
     # connect to the route53 endpoint

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -668,7 +668,7 @@ def main():
                     Id=change_resource_record_sets['ChangeInfo']['Id'],
                     WaiterConfig=dict(
                         Delay=WAIT_RETRY,
-                        MaxAttemps=wait_timeout_in // WAIT_RETRY,
+                        MaxAttempts=wait_timeout_in // WAIT_RETRY,
                     )
                 )
         except is_boto3_error_message('but it already exists'):


### PR DESCRIPTION
##### SUMMARY

Investigating Issue 466 I noticed that we don't retry on PriorRequestNotComplete any more, the WaiterConfiguration also included a typo

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

route53

##### ADDITIONAL INFORMATION

depends on https://github.com/ansible-collections/amazon.aws/pull/350