### PR TITLE
Update the default module requirements from python 2.6/boto to python 3.6/boto3

### DIFF
--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -145,14 +145,11 @@ options:
     choices: [present, absent]
     default: present
     type: str
-requirements:
-  - boto3
 author:
   - Matthew Davis (@matt-telstra) on behalf of Telstra Corporation Limited
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_acm_info.py
+++ b/plugins/modules/aws_acm_info.py
@@ -39,14 +39,11 @@ options:
     description:
       - Filter results to show only certificates with tags that match all the tags specified here.
     type: dict
-requirements:
-  - boto3
 author:
   - Will Thames (@willthames)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/aws_api_gateway.py
+++ b/plugins/modules/aws_api_gateway.py
@@ -26,7 +26,6 @@ description:
      - swagger_file and swagger_text are passed directly on to AWS
        transparently whilst swagger_dict is an ansible dict which is
        converted to JSON before the API definitions are uploaded.
-requirements: [ boto3 ]
 options:
   api_id:
     description:
@@ -114,7 +113,6 @@ notes:
      ID so that an API can be created only once.
    - As an early work around an intermediate version will probably do
      the same using a tag embedded in the API name.
-
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_application_scaling_policy.py
+++ b/plugins/modules/aws_application_scaling_policy.py
@@ -19,7 +19,6 @@ description:
 author:
     - Gustavo Maia (@gurumaia)
     - Chen Leibovich (@chenl87)
-requirements: [ json, botocore, boto3 ]
 options:
     state:
         description: Whether a policy should be C(present) or C(absent).
@@ -105,7 +104,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_batch_compute_environment.py
+++ b/plugins/modules/aws_batch_compute_environment.py
@@ -118,9 +118,6 @@ options:
     description:
       - The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment.
     type: str
-
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_batch_job_definition.py
+++ b/plugins/modules/aws_batch_job_definition.py
@@ -169,8 +169,6 @@ options:
         attempts. If attempts is greater than one, the job is retried if it fails until it has moved to RUNNABLE that
         many times.
     type: int
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_batch_job_queue.py
+++ b/plugins/modules/aws_batch_job_queue.py
@@ -59,8 +59,6 @@ options:
         compute_environment:
             type: str
             description: The name of the compute environment.
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_codebuild.py
+++ b/plugins/modules/aws_codebuild.py
@@ -18,7 +18,6 @@ description:
     - Create or delete a CodeBuild projects on AWS, used for building code artifacts from source code.
 author:
     - Stefan Horning (@stefanhorning) <horning@mediapeers.com>
-requirements: [ botocore, boto3 ]
 options:
     name:
         description:

--- a/plugins/modules/aws_codecommit.py
+++ b/plugins/modules/aws_codecommit.py
@@ -16,12 +16,6 @@ description:
   - Supports creation and deletion of CodeCommit repositories.
   - See U(https://aws.amazon.com/codecommit/) for more information about CodeCommit.
 author: Shuang Wang (@ptux)
-
-requirements:
-  - botocore
-  - boto3
-  - python >= 2.6
-
 options:
   name:
     description:

--- a/plugins/modules/aws_codepipeline.py
+++ b/plugins/modules/aws_codepipeline.py
@@ -18,7 +18,6 @@ description:
     - Create or delete a CodePipeline on AWS.
 author:
     - Stefan Horning (@stefanhorning) <horning@mediapeers.com>
-requirements: [ botocore, boto3 ]
 options:
     name:
         description:

--- a/plugins/modules/aws_config_aggregation_authorization.py
+++ b/plugins/modules/aws_config_aggregation_authorization.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 short_description: Manage cross-account AWS Config authorizations
 description:
     - Module manages AWS Config resources.
-requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:

--- a/plugins/modules/aws_config_aggregator.py
+++ b/plugins/modules/aws_config_aggregator.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 short_description: Manage AWS Config aggregations across multiple accounts
 description:
     - Module manages AWS Config resources
-requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:

--- a/plugins/modules/aws_config_delivery_channel.py
+++ b/plugins/modules/aws_config_delivery_channel.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 short_description: Manage AWS Config delivery channels
 description:
     - This module manages AWS Config delivery locations for rule checks and configuration info.
-requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:

--- a/plugins/modules/aws_config_recorder.py
+++ b/plugins/modules/aws_config_recorder.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 short_description: Manage AWS Config Recorders
 description:
     - Module manages AWS Config configuration recorder settings.
-requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:

--- a/plugins/modules/aws_config_rule.py
+++ b/plugins/modules/aws_config_rule.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 short_description: Manage AWS Config resources
 description:
     - Module manages AWS Config rules
-requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:

--- a/plugins/modules/aws_direct_connect_confirm_connection.py
+++ b/plugins/modules/aws_direct_connect_confirm_connection.py
@@ -21,10 +21,6 @@ author: "Matt Traynham (@mtraynham)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - boto3
-  - botocore
 options:
   name:
     description:

--- a/plugins/modules/aws_direct_connect_connection.py
+++ b/plugins/modules/aws_direct_connect_connection.py
@@ -19,10 +19,6 @@ author: "Sloane Hertel (@s-hertel)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - boto3
-  - botocore
 options:
   state:
     description:

--- a/plugins/modules/aws_direct_connect_gateway.py
+++ b/plugins/modules/aws_direct_connect_gateway.py
@@ -19,8 +19,6 @@ description:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ boto3 ]
 options:
   state:
     description:

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -17,10 +17,6 @@ author: "Sloane Hertel (@s-hertel)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - boto3
-  - botocore
 options:
   state:
     description:

--- a/plugins/modules/aws_direct_connect_virtual_interface.py
+++ b/plugins/modules/aws_direct_connect_virtual_interface.py
@@ -14,9 +14,6 @@ short_description: Manage Direct Connect virtual interfaces
 description:
   - Create, delete, or modify a Direct Connect public or private virtual interface.
 author: "Sloane Hertel (@s-hertel)"
-requirements:
-  - boto3
-  - botocore
 options:
   state:
     description:

--- a/plugins/modules/aws_eks_cluster.py
+++ b/plugins/modules/aws_eks_cluster.py
@@ -54,8 +54,6 @@ options:
       to 1200 seconds (20 minutes).
     default: 1200
     type: int
-
-requirements: [ 'botocore', 'boto3' ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_glue_connection.py
+++ b/plugins/modules/aws_glue_connection.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Manage an AWS Glue connection
 description:
     - Manage an AWS Glue connection. See U(https://aws.amazon.com/glue/) for details.
-requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
 options:
   availability_zone:

--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Manage an AWS Glue job
 description:
     - Manage an AWS Glue job. See U(https://aws.amazon.com/glue/) for details.
-requirements: [ boto3 ]
 author:
   - "Rob White (@wimnat)"
   - "Vijayanand Sharma (@vijayanandsharma)"

--- a/plugins/modules/aws_inspector_target.py
+++ b/plugins/modules/aws_inspector_target.py
@@ -38,10 +38,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - boto3
-  - botocore
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_region_info.py
+++ b/plugins/modules/aws_region_info.py
@@ -28,8 +28,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [botocore, boto3]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -14,9 +14,6 @@ module: aws_s3_bucket_info
 version_added: 1.0.0
 author: "Gerben Geijteman (@hyperized)"
 short_description: lists S3 buckets in AWS
-requirements:
-  - boto3 >= 1.4.4
-  - python >= 2.6
 description:
     - Lists S3 buckets and details about those buckets.
     - This module was called C(aws_s3_bucket_facts) before Ansible 2.9, returning C(ansible_facts).

--- a/plugins/modules/aws_secret.py
+++ b/plugins/modules/aws_secret.py
@@ -15,7 +15,6 @@ short_description: Manage secrets stored in AWS Secrets Manager.
 description:
     - Create, update, and delete secrets stored in AWS Secrets Manager.
 author: "REY Remi (@rrey)"
-requirements: [ 'botocore>=1.10.0', 'boto3' ]
 options:
   name:
     description:

--- a/plugins/modules/aws_ses_identity.py
+++ b/plugins/modules/aws_ses_identity.py
@@ -85,7 +85,6 @@ options:
             - This can only be false if both I(bounce_notifications) and I(complaint_notifications) specify SNS topics.
         type: 'bool'
         default: True
-requirements: [ 'botocore', 'boto3' ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_ses_identity_policy.py
+++ b/plugins/modules/aws_ses_identity_policy.py
@@ -36,7 +36,6 @@ options:
         default: present
         choices: [ 'present', 'absent' ]
         type: str
-requirements: [ 'botocore', 'boto3' ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_ses_rule_set.py
+++ b/plugins/modules/aws_ses_rule_set.py
@@ -16,7 +16,6 @@ description:
 author:
   - "Ben Tomasik (@tomislacker)"
   - "Ed Costello (@orthanc)"
-requirements: [ boto3, botocore ]
 options:
   name:
     description:

--- a/plugins/modules/aws_sgw_info.py
+++ b/plugins/modules/aws_sgw_info.py
@@ -16,7 +16,6 @@ short_description: Fetch AWS Storage Gateway information
 description:
     - Fetch AWS Storage Gateway information
     - This module was called C(aws_sgw_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 options:
   gather_local_disks:

--- a/plugins/modules/aws_ssm_parameter_store.py
+++ b/plugins/modules/aws_ssm_parameter_store.py
@@ -83,8 +83,6 @@ author:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ botocore, boto3 ]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_waf_info.py
+++ b/plugins/modules/aws_waf_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 description:
   - Retrieve information for WAF ACLs, Rule , Conditions and Filters.
   - This module was called C(aws_waf_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 options:
   name:
     description:

--- a/plugins/modules/cloudformation_exports_info.py
+++ b/plugins/modules/cloudformation_exports_info.py
@@ -12,7 +12,6 @@ short_description: Read a value from CloudFormation Exports
 version_added: 1.0.0
 description:
   - Module retrieves a value from CloudFormation Exports
-requirements: ['boto3 >= 1.11.15']
 author:
   - "Michael Moyle (@mmoyle)"
 extends_documentation_fragment:

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -172,8 +172,6 @@ author: "Ryan Scott Brown (@ryansb)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ boto3>=1.6, botocore>=1.10.26 ]
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -17,11 +17,6 @@ short_description: Create, update and delete AWS CloudFront distributions.
 description:
     - Allows for easy creation, updating and deletion of CloudFront distributions.
 
-requirements:
-  - boto3 >= 1.0.0
-  - python >= 2.6
-
-
 author:
   - Willem van Ketwich (@wilvk)
   - Will Thames (@willthames)

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -15,9 +15,6 @@ description:
   - Gets information about an AWS CloudFront distribution.
   - This module was called C(cloudfront_facts) before Ansible 2.9, returning C(ansible_facts).
     Note that the M(community.aws.cloudfront_info) module no longer returns C(ansible_facts)!
-requirements:
-  - boto3 >= 1.0.0
-  - python >= 2.6
 author: Willem van Ketwich (@wilvk)
 options:
     distribution_id:

--- a/plugins/modules/cloudfront_invalidation.py
+++ b/plugins/modules/cloudfront_invalidation.py
@@ -16,11 +16,6 @@ short_description: create invalidations for AWS CloudFront distributions
 description:
     - Allows for invalidation of a batch of paths for a CloudFront distribution.
 
-requirements:
-  - boto3 >= 1.0.0
-  - python >= 2.6
-
-
 author: Willem van Ketwich (@wilvk)
 
 extends_documentation_fragment:

--- a/plugins/modules/cloudfront_origin_access_identity.py
+++ b/plugins/modules/cloudfront_origin_access_identity.py
@@ -19,11 +19,6 @@ description:
     - Allows for easy creation, updating and deletion of origin access
       identities.
 
-requirements:
-  - boto3 >= 1.0.0
-  - python >= 2.6
-
-
 author: Willem van Ketwich (@wilvk)
 
 extends_documentation_fragment:

--- a/plugins/modules/cloudtrail.py
+++ b/plugins/modules/cloudtrail.py
@@ -17,9 +17,6 @@ author:
     - Ansible Core Team
     - Ted Timmons (@tedder)
     - Daniel Shepherd (@shepdelacreme)
-requirements:
-  - boto3
-  - botocore
 options:
   state:
     description:

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -18,9 +18,6 @@ extends_documentation_fragment:
 - amazon.aws.ec2
 
 author: "Jim Dalton (@jsdalton) <jim.dalton@gmail.com>"
-requirements:
-  - python >= 2.6
-  - boto3
 notes:
   - A rule must contain at least an I(event_pattern) or I(schedule_expression). A
     rule can have both an I(event_pattern) and a I(schedule_expression), in which

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -18,7 +18,6 @@ description:
     - Create or delete log_group in CloudWatchLogs.
 author:
     - Willian Ricardo (@willricardo) <willricardo@gmail.com>
-requirements: [ json, botocore, boto3 ]
 options:
     state:
       description:

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -17,7 +17,6 @@ description:
     - This module was called C(cloudwatchlogs_log_group_facts) before Ansible 2.9. The usage did not change.
 author:
     - Willian Ricardo (@willricardo) <willricardo@gmail.com>
-requirements: [ botocore, boto3 ]
 options:
     log_group_name:
       description:

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -15,9 +15,6 @@ short_description: Manage CloudWatch log group metric filter
 description:
   - Create, modify and delete CloudWatch log group metric filter.
   - CloudWatch log group metric filter can be use with M(community.aws.ec2_metric_alarm).
-requirements:
-  - boto3
-  - botocore
 options:
     state:
       description:

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 author:
   - Raghu Udiyar (@raags) <raghusiddarth@gmail.com>
   - Sloane Hertel (@s-hertel) <shertel@redhat.com>
-requirements: [ "boto3" ]
 short_description: Create and manage AWS Datapipelines
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -17,8 +17,10 @@ description:
   - Returns the status of the specified table.
 author: Alan Loi (@loia)
 requirements:
-  - "boto >= 2.37.0"
-  - "boto3 >= 1.4.4 (for tagging)"
+- python >= 3.6
+- boto >= 2.49.0
+- boto3 >= 1.13.0
+- botocore >= 1.16.0
 options:
   state:
     description:

--- a/plugins/modules/dynamodb_ttl.py
+++ b/plugins/modules/dynamodb_ttl.py
@@ -12,8 +12,7 @@ module: dynamodb_ttl
 version_added: 1.0.0
 short_description: Set TTL for a given DynamoDB table
 description:
-- Uses boto3 to set TTL.
-- Requires botocore version 1.5.24 or higher.
+- Sets the TTL for a given DynamoDB table.
 options:
   state:
     description:
@@ -37,8 +36,6 @@ author: Ted Timmons (@tedder)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ botocore>=1.5.24, boto3 ]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -72,9 +72,6 @@ author:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto3
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -15,7 +15,6 @@ description:
   - Can create or delete AWS AutoScaling Groups.
   - Can be used with the M(community.aws.ec2_lc) module to manage Launch Configurations.
 author: "Gareth Rushgrove (@garethr)"
-requirements: [ "boto3", "botocore" ]
 options:
   state:
     description:

--- a/plugins/modules/ec2_asg_info.py
+++ b/plugins/modules/ec2_asg_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about ec2 Auto Scaling Groups (ASGs) in AW
 description:
   - Gather information about ec2 Auto Scaling Groups (ASGs) in AWS
   - This module was called C(ec2_asg_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
 options:
   name:

--- a/plugins/modules/ec2_asg_lifecycle_hook.py
+++ b/plugins/modules/ec2_asg_lifecycle_hook.py
@@ -74,8 +74,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
-requirements: [ boto3>=1.4.4 ]
-
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -14,7 +14,6 @@ short_description: Manage an AWS customer gateway
 description:
     - Manage an AWS customer gateway.
 author: Michael Baydoun (@MichaelBaydoun)
-requirements: [ botocore, boto3 ]
 notes:
     - You cannot create more than one customer gateway with the same IP address. If you run an identical request more than one time, the
       first request creates the customer gateway, and subsequent requests return information about the existing customer gateway. The subsequent

--- a/plugins/modules/ec2_customer_gateway_info.py
+++ b/plugins/modules/ec2_customer_gateway_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about customer gateways in AWS
 description:
     - Gather information about customer gateways in AWS.
     - This module was called C(ec2_customer_gateway_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: Madhura Naniwadekar (@Madhura-CSI)
 options:
   filters:

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -53,10 +53,12 @@ options:
         If non-zero then any transient errors are ignored until the timeout is reached. Ignored when wait=no.
     default: 0
     type: int
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
 '''
 
 EXAMPLES = r"""

--- a/plugins/modules/ec2_elb.py
+++ b/plugins/modules/ec2_elb.py
@@ -54,7 +54,6 @@ options:
     default: 0
     type: int
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -37,7 +37,9 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -38,7 +38,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -16,9 +16,6 @@ description:
   - The M(amazon.aws.ec2_instance) and M(community.aws.ec2_asg) modules can, instead of specifying all
     parameters on those tasks, be passed a Launch Template which contains
     settings like instance size, disk type, subnet, and more.
-requirements:
-  - botocore
-  - boto3 >= 1.6.0
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -184,10 +184,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
-
-requirements:
-    - boto3 >= 1.4.4
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ec2_lc_find.py
+++ b/plugins/modules/ec2_lc_find.py
@@ -38,9 +38,6 @@ options:
       - How many results to show.
       - Corresponds to Python slice notation like list[:limit].
     type: int
-requirements:
-  - "python >= 2.6"
-  - boto3
 extends_documentation_fragment:
 - amazon.aws.ec2
 - amazon.aws.aws

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -16,7 +16,6 @@ description:
     - Gather information about AWS Autoscaling Launch Configurations.
     - This module was called C(ec2_lc_facts) before Ansible 2.9. The usage did not change.
 author: "Loïc Latreille (@psykotox)"
-requirements: [ boto3 ]
 options:
   name:
     description:

--- a/plugins/modules/ec2_snapshot_copy.py
+++ b/plugins/modules/ec2_snapshot_copy.py
@@ -56,9 +56,6 @@ author: Deepak Kothandan (@Deepakkothandan) <deepak.kdy@gmail.com>
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto3
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_transit_gateway.py
+++ b/plugins/modules/ec2_transit_gateway.py
@@ -14,7 +14,6 @@ description:
   - Creates AWS Transit Gateways.
   - Deletes AWS Transit Gateways.
   - Updates tags on existing transit gateways.
-requirements: [ 'botocore', 'boto3' ]
 options:
   asn:
     description:

--- a/plugins/modules/ec2_transit_gateway_info.py
+++ b/plugins/modules/ec2_transit_gateway_info.py
@@ -14,9 +14,6 @@ version_added: 1.0.0
 description:
     - Gather information about ec2 transit gateways in AWS
 author: "Bob Boldin (@BobBoldin)"
-requirements:
-  - botocore
-  - boto3
 options:
   transit_gateway_ids:
     description:

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -14,7 +14,6 @@ description:
   - Creates AWS VPC endpoints.
   - Deletes AWS VPC endpoints.
   - This module supports check mode.
-requirements: [ boto3 ]
 options:
   vpc_id:
     description:

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -12,7 +12,6 @@ version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC endpoints.
   - This module was called C(ec2_vpc_endpoint_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 options:
   query:
     description:

--- a/plugins/modules/ec2_vpc_endpoint_service_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_service_info.py
@@ -11,7 +11,6 @@ short_description: retrieves AWS VPC endpoint service details
 version_added: 1.5.0
 description:
   - Gets details related to AWS VPC Endpoint Services.
-requirements: [ boto3 ]
 options:
   filters:
     description:

--- a/plugins/modules/ec2_vpc_igw.py
+++ b/plugins/modules/ec2_vpc_igw.py
@@ -41,10 +41,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - botocore
-  - boto3
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about internet gateways in AWS
 description:
     - Gather information about internet gateways in AWS.
     - This module was called C(ec2_vpc_igw_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: "Nick Aslanidis (@naslanidis)"
 options:
   filters:

--- a/plugins/modules/ec2_vpc_nacl.py
+++ b/plugins/modules/ec2_vpc_nacl.py
@@ -81,8 +81,6 @@ author: Mike Mochan (@mmochan)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ botocore, boto3, json ]
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -14,7 +14,6 @@ description:
     - Gather information about Network ACLs in an AWS VPC
     - This module was called C(ec2_vpc_nacl_facts) before Ansible 2.9. The usage did not change.
 author: "Brad Davidson (@brandond)"
-requirements: [ boto3 ]
 options:
   nacl_ids:
     description:

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Manage AWS VPC NAT Gateways.
 description:
   - Ensure the state of AWS VPC NAT Gateways based on their id, allocation and subnet ids.
-requirements: [boto3, botocore]
 options:
   state:
     description:

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC Managed Nat Gateways
   - This module was called C(ec2_vpc_nat_gateway_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 options:
   nat_gateway_ids:
     description:

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -61,8 +61,6 @@ author: Mike Mochan (@mmochan)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ botocore, boto3, json ]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC Peers
   - This module was called C(ec2_vpc_peering_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 options:
   peer_connection_ids:
     description:

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -15,7 +15,6 @@ description:
   - Deletes AWS VPN Virtual Gateways
   - Attaches Virtual Gateways to VPCs
   - Detaches Virtual Gateways from VPCs
-requirements: [ boto3 ]
 options:
   state:
     description:

--- a/plugins/modules/ec2_vpc_vgw_info.py
+++ b/plugins/modules/ec2_vpc_vgw_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about virtual gateways in AWS
 description:
     - Gather information about virtual gateways in AWS.
     - This module was called C(ec2_vpc_vgw_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 options:
   filters:
     description:

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -17,8 +17,6 @@ description:
 extends_documentation_fragment:
 - amazon.aws.ec2
 - amazon.aws.aws
-
-requirements: ['boto3', 'botocore']
 author: "Sloane Hertel (@s-hertel)"
 options:
   state:

--- a/plugins/modules/ec2_vpc_vpn_info.py
+++ b/plugins/modules/ec2_vpc_vpn_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about VPN Connections in AWS.
 description:
     - Gather information about VPN Connections in AWS.
     - This module was called C(ec2_vpc_vpn_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: Madhura Naniwadekar (@Madhura-CSI)
 options:
   filters:

--- a/plugins/modules/ec2_win_password.py
+++ b/plugins/modules/ec2_win_password.py
@@ -53,10 +53,10 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
-
 requirements:
-    - cryptography
-
+- cryptography
+- python >= 2.6
+- boto >= 2.49.0
 notes:
     - As of Ansible 2.4, this module requires the python cryptography module rather than the
       older pycrypto module.

--- a/plugins/modules/ec2_win_password.py
+++ b/plugins/modules/ec2_win_password.py
@@ -55,7 +55,6 @@ extends_documentation_fragment:
 
 requirements:
 - cryptography
-- python >= 2.6
 - boto >= 2.49.0
 notes:
     - As of Ansible 2.4, this module requires the python cryptography module rather than the

--- a/plugins/modules/ecs_attribute.py
+++ b/plugins/modules/ecs_attribute.py
@@ -14,7 +14,6 @@ short_description: manage ecs attributes
 description:
     - Create, update or delete ECS container instance attributes.
 author: Andrej Svenke (@anryko)
-requirements: [ botocore, boto3 ]
 options:
     cluster:
         description:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -17,7 +17,6 @@ notes:
 description:
     - Creates or terminates ecs clusters.
 author: Mark Chance (@Java1Guy)
-requirements: [ boto3 ]
 options:
     state:
         description:

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -16,7 +16,6 @@ version_added: 1.0.0
 short_description: Manage Elastic Container Registry repositories
 description:
     - Manage Elastic Container Registry repositories.
-requirements: [ boto3 ]
 options:
     name:
         description:

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -22,8 +22,6 @@ author:
     - "Darek Kaczynski (@kaczynskid)"
     - "Stephane Maarek (@simplesteph)"
     - "Zac Blazic (@zacblazic)"
-
-requirements: [ json, botocore, boto3 ]
 options:
     state:
         description:

--- a/plugins/modules/ecs_service_info.py
+++ b/plugins/modules/ecs_service_info.py
@@ -18,7 +18,6 @@ description:
 author:
     - "Mark Chance (@Java1Guy)"
     - "Darek Kaczynski (@kaczynskid)"
-requirements: [ json, botocore, boto3 ]
 options:
     details:
         description:

--- a/plugins/modules/ecs_tag.py
+++ b/plugins/modules/ecs_tag.py
@@ -17,7 +17,6 @@ description:
     - Resources are referenced by their cluster name.
 author:
   - Michael Pechner (@mpechner)
-requirements: [ boto3, botocore ]
 options:
   cluster_name:
     description:

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -14,7 +14,6 @@ short_description: Run, start or stop a task in ecs
 description:
     - Creates or deletes instances of task definitions.
 author: Mark Chance (@Java1Guy)
-requirements: [ json, botocore, boto3 ]
 options:
     operation:
         description:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -14,7 +14,6 @@ short_description: register a task definition in ecs
 description:
     - Registers or deregisters task definitions in the Amazon Web Services (AWS) EC2 Container Service (ECS).
 author: Mark Chance (@Java1Guy)
-requirements: [ json, botocore, boto3 ]
 options:
     state:
         description:

--- a/plugins/modules/ecs_taskdefinition_info.py
+++ b/plugins/modules/ecs_taskdefinition_info.py
@@ -21,7 +21,6 @@ author:
     - Gustavo Maia (@gurumaia)
     - Mark Chance (@Java1Guy)
     - Darek Kaczynski (@kaczynskid)
-requirements: [ json, botocore, boto3 ]
 options:
     task_definition:
         description:

--- a/plugins/modules/efs.py
+++ b/plugins/modules/efs.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: create and maintain EFS file systems
 description:
     - Module allows create, search and destroy Amazon EFS file systems.
-requirements: [ boto3 ]
 author:
     - "Ryan Sydnor (@ryansydnor)"
     - "Artem Kazakov (@akazakov)"

--- a/plugins/modules/efs_info.py
+++ b/plugins/modules/efs_info.py
@@ -15,7 +15,6 @@ description:
     - This module can be used to search Amazon EFS file systems.
     - This module was called C(efs_facts) before Ansible 2.9, returning C(ansible_facts).
       Note that the M(community.aws.efs_info) module no longer returns C(ansible_facts)!
-requirements: [ boto3 ]
 author:
     - "Ryan Sydnor (@ryansydnor)"
 options:

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -15,7 +15,6 @@ short_description: Manage cache clusters in Amazon ElastiCache
 description:
   - Manage cache clusters in Amazon ElastiCache.
   - Returns information about the specified cache cluster.
-requirements: [ boto3 ]
 author: "Jim Dalton (@jsdalton)"
 options:
   state:

--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -19,7 +19,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
-requirements: [ boto3, botocore ]
 options:
   group_family:
     description:

--- a/plugins/modules/elasticache_snapshot.py
+++ b/plugins/modules/elasticache_snapshot.py
@@ -18,8 +18,6 @@ author: "Sloane Hertel (@s-hertel)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ boto3, botocore ]
 options:
   name:
     description:

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -38,7 +38,9 @@ author: "Tim Mahoney (@timmahoney)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -39,7 +39,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -25,7 +25,6 @@ version_added: 1.0.0
 short_description: Manage an Application Load Balancer
 description:
     - Manage an AWS Application Elastic Load Balancer. See U(https://aws.amazon.com/blogs/aws/new-aws-application-load-balancer/) for details.
-requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
 options:
   access_logs_enabled:

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about application ELBs in AWS
 description:
     - Gather information about application ELBs in AWS
     - This module was called C(elb_application_lb_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: Rob White (@wimnat)
 options:
   load_balancer_arns:

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -138,6 +138,9 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = r"""

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -139,7 +139,6 @@ extends_documentation_fragment:
 - amazon.aws.ec2
 
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -37,10 +37,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - botocore
-  - boto3
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -60,7 +60,9 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = r"""

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -61,7 +61,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/elb_network_lb.py
+++ b/plugins/modules/elb_network_lb.py
@@ -15,7 +15,6 @@ short_description: Manage a Network Load Balancer
 description:
     - Manage an AWS Network Elastic Load Balancer. See
       U(https://aws.amazon.com/blogs/aws/new-network-load-balancer-effortless-scaling-to-millions-of-requests-per-second/) for details.
-requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
 options:
   cross_zone_load_balancing:

--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -15,7 +15,6 @@ description:
     - Manage an AWS Elastic Load Balancer target group. See
       U(https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) or
       U(https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html) for details.
-requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
 options:
   deregistration_delay_timeout:

--- a/plugins/modules/elb_target_group_info.py
+++ b/plugins/modules/elb_target_group_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about ELB target groups in AWS
 description:
     - Gather information about ELB target groups in AWS
     - This module was called C(elb_target_group_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: Rob White (@wimnat)
 options:
   load_balancer_arn:

--- a/plugins/modules/elb_target_info.py
+++ b/plugins/modules/elb_target_info.py
@@ -26,10 +26,6 @@ options:
       - Whether or not to get target groups not used by any load balancers.
     type: bool
     default: true
-
-requirements:
-    - boto3
-    - botocore
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/execute_lambda.py
+++ b/plugins/modules/execute_lambda.py
@@ -19,9 +19,6 @@ extends_documentation_fragment:
 - amazon.aws.ec2
 
 author: "Ryan Scott Brown (@ryansb) <ryansb@redhat.com>"
-requirements:
-  - python >= 2.6
-  - boto3
 notes:
   - Async invocation will always return an empty C(output) key.
   - Synchronous invocation may result in a function timeout, resulting in an

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -97,7 +97,9 @@ author:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/iam.py
+++ b/plugins/modules/iam.py
@@ -98,7 +98,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -75,12 +75,13 @@ options:
       - Defaults to C(false).
     type: bool
 
-requirements: [ "boto" ]
 author: Jonathan I. Davila (@defionscode)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/iam_cert.py
+++ b/plugins/modules/iam_cert.py
@@ -80,7 +80,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -67,7 +67,6 @@ options:
     required: false
     default: false
     type: bool
-requirements: [ botocore, boto3 ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -53,10 +53,6 @@ author: "Dan Kozlowski (@dkhenry)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto3
-    - botocore
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -23,10 +23,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto3
-    - botocore
 '''
 
 RETURN = """

--- a/plugins/modules/iam_password_policy.py
+++ b/plugins/modules/iam_password_policy.py
@@ -14,7 +14,6 @@ version_added: 1.0.0
 short_description: Update an IAM Password Policy
 description:
     - Module updates an IAM Password Policy on a given AWS account
-requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:

--- a/plugins/modules/iam_role.py
+++ b/plugins/modules/iam_role.py
@@ -89,7 +89,6 @@ options:
       - Remove tags not listed in I(tags) when tags is specified.
     default: true
     type: bool
-requirements: [ botocore, boto3 ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -14,7 +14,6 @@ short_description: Gather information on IAM roles
 description:
     - Gathers information about IAM roles.
     - This module was called C(iam_role_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author:
     - "Will Thames (@willthames)"
 options:

--- a/plugins/modules/iam_saml_federation.py
+++ b/plugins/modules/iam_saml_federation.py
@@ -24,8 +24,6 @@ DOCUMENTATION = '''
 module: iam_saml_federation
 version_added: 1.0.0
 short_description: Maintain IAM SAML federation configuration.
-requirements:
-    - boto3
 description:
     - Provides a mechanism to manage AWS IAM SAML Identity Federation providers (create/update/delete metadata).
 options:

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -15,7 +15,6 @@ description:
   - Retrieve the attributes of a server certificate.
   - This module was called C(iam_server_certificate_facts) before Ansible 2.9. The usage did not change.
 author: "Allen Sanabria (@linuxdynasty)"
-requirements: [boto3, botocore]
 options:
   name:
     description:

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -41,7 +41,6 @@ options:
     default: false
     type: bool
     aliases: ['purge_policy', 'purge_managed_policies']
-requirements: [ botocore, boto3 ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -36,9 +36,6 @@ options:
     required: false
     default: '/'
     type: str
-requirements:
-  - botocore
-  - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -16,7 +16,6 @@ description:
     - Update the retention period of a Kinesis Stream.
     - Update Tags on a Kinesis Stream.
     - Enable/disable server side encryption on a Kinesis Stream.
-requirements: [ boto3 ]
 author: Allen Sanabria (@linuxdynasty)
 options:
   name:

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Manage AWS Lambda functions
 description:
      - Allows for the management of Lambda functions.
-requirements: [ boto3 ]
 options:
   name:
     description:

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -46,8 +46,6 @@ options:
          A value of 0 (or omitted parameter) sets the alias to the $LATEST version.
     aliases: ['version']
     type: int
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -78,8 +78,6 @@ options:
         type: str
     required: true
     type: dict
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/lambda_facts.py
+++ b/plugins/modules/lambda_facts.py
@@ -39,8 +39,6 @@ options:
       - For query type 'mappings', this is the Amazon Resource Name (ARN) of the Amazon Kinesis or DynamoDB stream.
     type: str
 author: Pierre Jodouin (@pjodouin)
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -34,8 +34,6 @@ options:
       - When I(query=mappings), this is the Amazon Resource Name (ARN) of the Amazon Kinesis or DynamoDB stream.
     type: str
 author: Pierre Jodouin (@pjodouin)
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -97,8 +97,6 @@ options:
       -  Token string representing source ARN or account. Mutually exclusive with I(source_arn) or I(source_account).
     type: str
 
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/lightsail.py
+++ b/plugins/modules/lightsail.py
@@ -67,9 +67,6 @@ options:
     default: 300
     type: int
 
-requirements:
-  - boto3
-
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -221,16 +221,15 @@ options:
       - Used with I(command=create), I(command=replicate), I(command=restore).
       - Requires boto >= 2.26.0
     type: dict
-requirements:
-    - "python >= 2.6"
-    - "boto"
 author:
     - "Bruce Pennypacker (@bpennypacker)"
     - "Will Thames (@willthames)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 # FIXME: the command stuff needs a 'state' like alias to make things consistent -- MPD

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -228,7 +228,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -13,10 +13,6 @@ version_added: 1.0.0
 short_description: Manage RDS instances
 description:
     - Create, modify, and delete RDS instances.
-
-requirements:
-    - botocore
-    - boto3 >= 1.5.0
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/rds_instance_info.py
+++ b/plugins/modules/rds_instance_info.py
@@ -29,9 +29,6 @@ options:
       - A filter that specifies one or more DB instances to describe.
         See U(https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html)
     type: dict
-requirements:
-    - "python >= 2.7"
-    - "boto3"
 author:
     - "Will Thames (@willthames)"
     - "Michael De La Rue (@mikedlr)"

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: manage RDS parameter groups
 description:
      - Creates, modifies, and deletes RDS parameter groups.
-requirements: [ boto3 ]
 options:
   state:
     description:

--- a/plugins/modules/rds_snapshot.py
+++ b/plugins/modules/rds_snapshot.py
@@ -55,9 +55,6 @@ options:
       - whether to remove tags not present in the C(tags) parameter.
     default: True
     type: bool
-requirements:
-    - "python >= 2.6"
-    - "boto3"
 author:
     - "Will Thames (@willthames)"
     - "Michael De La Rue (@mikedlr)"

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -51,9 +51,6 @@ options:
     required: false
     choices: ['automated', 'manual', 'shared', 'public']
     type: str
-requirements:
-    - "python >= 2.6"
-    - "boto3"
 author:
     - "Will Thames (@willthames)"
 extends_documentation_fragment:

--- a/plugins/modules/redshift.py
+++ b/plugins/modules/redshift.py
@@ -179,7 +179,6 @@ options:
     type: bool
     default: 'yes'
     version_added: "1.3.0"
-requirements: [ 'boto3' ]
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2

--- a/plugins/modules/redshift_cross_region_snapshots.py
+++ b/plugins/modules/redshift_cross_region_snapshots.py
@@ -53,7 +53,6 @@ options:
     required: true
     aliases: [ "retention_period" ]
     type: int
-requirements: [ "botocore", "boto3" ]
 extends_documentation_fragment:
 - amazon.aws.ec2
 - amazon.aws.aws

--- a/plugins/modules/redshift_info.py
+++ b/plugins/modules/redshift_info.py
@@ -16,7 +16,6 @@ short_description: Gather information about Redshift cluster(s)
 description:
   - Gather information about Redshift cluster(s).
   - This module was called C(redshift_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 options:
   cluster_identifier:
     description:

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -40,11 +40,12 @@ options:
     aliases: ['subnets']
     type: list
     elements: str
-requirements: [ 'boto' ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -44,7 +44,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -13,7 +13,6 @@ DOCUMENTATION = r'''
 ---
 module: route53
 version_added: 1.0.0
-requirements: [ "boto3", "botocore" ]
 short_description: add or delete entries in Amazons Route 53 DNS service
 description:
      - Creates and deletes DNS records in Amazons Route 53 service.

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -82,7 +82,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 requirements:
-- python >= 2.6
 - boto >= 2.49.0
 '''
 

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -81,7 +81,9 @@ author: "zimbatm (@zimbatm)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
+requirements:
+- python >= 2.6
+- boto >= 2.49.0
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/route53_zone.py
+++ b/plugins/modules/route53_zone.py
@@ -12,7 +12,6 @@ short_description: add or delete Route53 zones
 version_added: 1.0.0
 description:
     - Creates and deletes Route53 private and public zones.
-requirements: [ boto3 ]
 options:
     zone:
         description:

--- a/plugins/modules/s3_bucket_notification.py
+++ b/plugins/modules/s3_bucket_notification.py
@@ -81,8 +81,6 @@ options:
       - Optional suffix to limit the notifications to objects with keys that end with matching
         characters.
     type: str
-requirements:
-    - boto3
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -129,11 +129,6 @@ options:
       - The I(retries) option does nothing and will be removed after 2022-06-01
     type: str
 
-requirements:
-  - boto3 >= 1.4.4
-  - botocore
-  - python-dateutil
-
 author: Ted Timmons (@tedder)
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/s3_website.py
+++ b/plugins/modules/s3_website.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Configure an s3 bucket as a website
 description:
     - Configure an s3 bucket as a website
-requirements: [ boto3 ]
 author: Rob White (@wimnat)
 options:
   name:

--- a/plugins/modules/sns.py
+++ b/plugins/modules/sns.py
@@ -81,10 +81,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.ec2
 - amazon.aws.aws
-
-requirements:
-  - boto3
-  - botocore
 '''
 
 EXAMPLES = """

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -69,8 +69,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [ "boto" ]
 '''
 
 EXAMPLES = r"""

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -19,8 +19,6 @@ author:
   - Fernando Jose Pando (@nand0p)
   - Nadir Lloret (@nadirollo)
   - Dennis Podkovyrin (@sbj-ss)
-requirements:
-  - boto3
 options:
   state:
     description:

--- a/plugins/modules/sts_assume_role.py
+++ b/plugins/modules/sts_assume_role.py
@@ -55,11 +55,6 @@ notes:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto3
-    - botocore
-    - python >= 2.6
 '''
 
 RETURN = '''

--- a/plugins/modules/sts_session_token.py
+++ b/plugins/modules/sts_session_token.py
@@ -34,11 +34,6 @@ notes:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto3
-    - botocore
-    - python >= 2.6
 '''
 
 RETURN = """

--- a/plugins/modules/wafv2_ip_set.py
+++ b/plugins/modules/wafv2_ip_set.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_ip_set
 description:
   - Create, modify and delete IP sets for WAFv2.
-requirements:
-  - boto3
-  - botocore
 options:
     state:
       description:

--- a/plugins/modules/wafv2_ip_set_info.py
+++ b/plugins/modules/wafv2_ip_set_info.py
@@ -14,9 +14,6 @@ author:
 short_description: Get information about wafv2 ip sets
 description:
   - Get information about existing wafv2 ip sets.
-requirements:
-  - boto3
-  - botocore
 options:
     name:
       description:

--- a/plugins/modules/wafv2_resources.py
+++ b/plugins/modules/wafv2_resources.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_web_acl
 description:
   - Apply or remove wafv2 to other aws resources.
-requirements:
-  - boto3
-  - botocore
 options:
     state:
       description:

--- a/plugins/modules/wafv2_resources_info.py
+++ b/plugins/modules/wafv2_resources_info.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_resources_info
 description:
   - List web acl resources.
-requirements:
-  - boto3
-  - botocore
 options:
     name:
       description:

--- a/plugins/modules/wafv2_rule_group.py
+++ b/plugins/modules/wafv2_rule_group.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_web_acl
 description:
   - Create, modify and delete wafv2 rule groups.
-requirements:
-  - boto3
-  - botocore
 options:
     state:
       description:

--- a/plugins/modules/wafv2_rule_group_info.py
+++ b/plugins/modules/wafv2_rule_group_info.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_web_acl_info
 description:
   - Get informations about existing wafv2 rule groups.
-requirements:
-  - boto3
-  - botocore
 options:
     state:
       description:

--- a/plugins/modules/wafv2_web_acl.py
+++ b/plugins/modules/wafv2_web_acl.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_web_acl
 description:
   - Create, modify or delete a wafv2 web acl.
-requirements:
-  - boto3
-  - botocore
 options:
     state:
       description:

--- a/plugins/modules/wafv2_web_acl_info.py
+++ b/plugins/modules/wafv2_web_acl_info.py
@@ -14,9 +14,6 @@ author:
 short_description: wafv2_web_acl
 description:
   - Info about web acl
-requirements:
-  - boto3
-  - botocore
 options:
     name:
       description:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto>=2.49.0
-botocore>=1.12.249
-boto3>=1.9.249
+botocore>=1.16.0
+boto3>=1.13.0

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,2 +1,3 @@
-boto3
 placebo
+botocore>=1.16.0
+boto3>=1.13.0


### PR DESCRIPTION
##### SUMMARY

The vast bulk of modules are now boto3 based, but some even list python2.6/boto as their requirements because they've picked the default from the aws docs fragment.

Switch the defaults over to reduce the copy&paste and reflect that

- boto v2 is deprecated
- python 2.6 is no longer supported by the AWS collections

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

lots of them

##### ADDITIONAL INFORMATION

Depends-On: https://github.com/ansible-collections/amazon.aws/pull/298