### PR TITLE
Add state "disabled" to route53_health_check module

### DIFF
--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -348,13 +348,13 @@ def main():
         if state_in == 'disabled':
             state_new = 1
         state_old = 0
-        if existing_check.Disabled == 'true':
-            state_old = 1
         if existing_check is None:
             action = "create"
             check_id = create_health_check(conn, wanted_config, state_new).HealthCheck.Id
             changed = True
         else:
+            if existing_check.Disabled == 'true':
+                state_old = 1
             diff = health_check_diff(existing_config, wanted_config)
             if diff or (state_new != state_old):
                 action = "update"


### PR DESCRIPTION
##### SUMMARY
Fixes #87 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
route53_health_check

##### ADDITIONAL INFORMATION
```
- name: Create a health-check for host1.example.com in disabled state
  community.aws.route53_health_check:
    state: disabled
    fqdn: host1.example.com
    type: HTTP_STR_MATCH
    resource_path: /
    string_match: "Hello"
    request_interval: 10
    failure_threshold: 2
  register: my_health_check
```
