### PR TITLE
Add vpc_endpint_subnets and vpc_endpoint_security_groups variable. Th…

### DIFF
--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -29,6 +29,20 @@ options:
     choices: [ "Interface", "Gateway", "GatewayLoadBalancer" ]
     type: str
     version_added: 1.5.0
+  vpc_endpoint_subnets:
+    description:
+      - The list of subnets to attach to the endpoint (Works only with Interface and GatewayLoadBalancer type endpoint).
+    required: false
+    default: None
+    type: list
+    version_added: 1.5.1
+  vpc_endpoint_security_groups:
+    description:
+      - The list of security groups to attach to the endpoint (Works only with Interface type endpoint).
+    required: false
+    default: None
+    type: list
+    version_added: 1.5.1
   service:
     description:
       - An AWS supported vpc endpoint service. Use the M(community.aws.ec2_vpc_endpoint_info)
@@ -329,6 +343,7 @@ def create_vpc_endpoint(client, module):
     params['VpcEndpointType'] = module.params.get('vpc_endpoint_type')
     params['ServiceName'] = module.params.get('service')
 
+
     if module.check_mode:
         changed = True
         result = 'Would have created VPC Endpoint if not in check mode'
@@ -336,6 +351,12 @@ def create_vpc_endpoint(client, module):
 
     if module.params.get('route_table_ids'):
         params['RouteTableIds'] = module.params.get('route_table_ids')
+
+    if module.params.get('vpc_endpoint_subnets'):
+        params['SubnetIds'] = module.params.get('vpc_endpoint_subnets')
+
+    if module.params.get('vpc_endpoint_security_groups'):
+        params['SecurityGroupIds'] = module.params.get('vpc_endpoint_security_groups')
 
     if module.params.get('client_token'):
         token_provided = True
@@ -434,6 +455,8 @@ def main():
     argument_spec = dict(
         vpc_id=dict(),
         vpc_endpoint_type=dict(default='Gateway', choices=['Interface', 'Gateway', 'GatewayLoadBalancer']),
+        vpc_endpoint_security_groups=dict(type='list', elements='str'),
+        vpc_endpoint_subnets=dict(type='list', elements='str'),
         service=dict(),
         policy=dict(type='json'),
         policy_file=dict(type='path', aliases=['policy_path']),

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -33,16 +33,16 @@ options:
     description:
       - The list of subnets to attach to the endpoint (Works only with Interface and GatewayLoadBalancer type endpoint).
     required: false
-    default: None
     type: list
-    version_added: 1.5.1
+    elements: str
+    version_added: 1.6.0
   vpc_endpoint_security_groups:
     description:
       - The list of security groups to attach to the endpoint (Works only with Interface type endpoint).
     required: false
-    default: None
     type: list
-    version_added: 1.5.1
+    elements: str
+    version_added: 1.6.0
   service:
     description:
       - An AWS supported vpc endpoint service. Use the M(community.aws.ec2_vpc_endpoint_info)


### PR DESCRIPTION
…eses varibales are used when you create an Interface type endpoint

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
VPC endpoin type variable has been defined in 1.5.0. But when you create an Interface type vpc endpoint, you should also declare on which subnets to attach it and with which security group

This PR add these 2 options:
- vpc_endpoint_security_groups
- vpc_endpoint_subnets

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_endpoint

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
