### PR TITLE
DNM: testing py3-only things

### DIFF
--- a/plugins/modules/aws_region_info.py
+++ b/plugins/modules/aws_region_info.py
@@ -79,6 +79,9 @@ def main():
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 
+    # Do some random thing that will only work in Python 3+
+    _myvar = {'foo': 'bar', 'baz': 'foo'}
+    _myunpackedvar = {**_myvar}
     # Replace filter key underscores with dashes, for compatibility
     sanitized_filters = dict(module.params.get('filters'))
     for k in module.params.get('filters').keys():


### PR DESCRIPTION
##### SUMMARY
Silly change on a module with a fast test suite to ensure 3-only sanity is all set.

Depends-on: https://github.com/ansible-collections/community.aws/pull/590
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
aws_region_info
