### PR TITLE
Add deprecation changelog for ec2.py inventory script

### DIFF
--- a/changelogs/fragments/deprecate_ec2_inv_script.yml
+++ b/changelogs/fragments/deprecate_ec2_inv_script.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-- script_inventory_ec2 - The ec2.py inventory script us being moved to a new repository. The script can now be downloaded from https://github.com/ansible-community/contrib-scripts/blob/main/inventory/ec2.py and will be removed from this collection in the 3.0 release. We recommend migrating from the script to the `amazon.aws.ec2` inventory plugin.
+- script_inventory_ec2 - The ec2.py inventory script is being moved to a new repository. The script can now be downloaded from https://github.com/ansible-community/contrib-scripts/blob/main/inventory/ec2.py and will be removed from this collection in the 3.0 release. We recommend migrating from the script to the `amazon.aws.ec2` inventory plugin.

--- a/changelogs/fragments/deprecate_ec2_inv_script.yml
+++ b/changelogs/fragments/deprecate_ec2_inv_script.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- script_inventory_ec2 - The ec2.py inventory script us being moved to a new repository. The script can now be downloaded from https://github.com/ansible-community/contrib-scripts/blob/main/inventory/ec2.py and will be removed from this collection in the 3.0 release. We recommend migrating from the script to the `amazon.aws.ec2` inventory plugin.


### PR DESCRIPTION
##### SUMMARY
Announce move of scripts/inventory/ec2.py to the new contrib scripts repo.

This changelog can merge once https://github.com/ansible-community/contrib-scripts/pull/4 merges (ie, the script has actually landed in the new repo)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
scripts/inventory/ec2.py