### PR TITLE
Allow specifying topic type for SNS module.

### DIFF
--- a/changelogs/fragments/sns_topic_type.yml
+++ b/changelogs/fragments/sns_topic_type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - sns_topic - Added ``topic_type`` parameter to select type of SNS topic (either FIFO or Standard)
+  - sns_topic - Added ``topic_type`` parameter to select type of SNS topic (either FIFO or Standard) (https://github.com/ansible-collections/community.aws/pull/599).

--- a/changelogs/fragments/sns_topic_type.yml
+++ b/changelogs/fragments/sns_topic_type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sns_topic - Added ``topic_type`` parameter to select type of SNS topic (either FIFO or Standard)

--- a/tests/integration/targets/sns_topic/aliases
+++ b/tests/integration/targets/sns_topic/aliases
@@ -1,4 +1,2 @@
-# reason: missing-policy
-unsupported
-
+ shippable/aws/group1
 cloud/aws

--- a/tests/integration/targets/sns_topic/aliases
+++ b/tests/integration/targets/sns_topic/aliases
@@ -1,2 +1,2 @@
- shippable/aws/group1
+shippable/aws/group1
 cloud/aws

--- a/tests/integration/targets/sns_topic/aliases
+++ b/tests/integration/targets/sns_topic/aliases
@@ -1,2 +1,1 @@
-shippable/aws/group1
 cloud/aws

--- a/tests/integration/targets/sns_topic/defaults/main.yml
+++ b/tests/integration/targets/sns_topic/defaults/main.yml
@@ -1,12 +1,13 @@
-sns_topic_topic_name: "{{ resource_prefix }}-topic"
+# we hash the resource_prefix to get a shorter, unique string
+unique_id: "{{ resource_prefix | hash('md5') }}"
+
+sns_topic_topic_name: "ansible-test-{{ unique_id }}-topic"
 sns_topic_subscriptions:
   - endpoint: "{{ sns_topic_subscriber_arn }}"
     protocol: "lambda"
 sns_topic_third_party_topic_arn: "arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged"
 sns_topic_third_party_region: "{{ sns_topic_third_party_topic_arn.split(':')[3] }}"
+
 sns_topic_lambda_function: "sns_topic_lambda"
-sns_topic_lambda_name: "{{ resource_prefix }}-{{ sns_topic_lambda_function }}"
-# IAM role names have to be less than 64 characters
-# we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') }}"
+sns_topic_lambda_name: "ansible-test-{{ unique_id }}-{{ sns_topic_lambda_function }}"
 sns_topic_lambda_role: "ansible-test-{{ unique_id }}-sns-lambda"

--- a/tests/integration/targets/sns_topic/defaults/main.yml
+++ b/tests/integration/targets/sns_topic/defaults/main.yml
@@ -8,6 +8,7 @@ sns_topic_subscriptions:
 sns_topic_third_party_topic_arn: "arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged"
 sns_topic_third_party_region: "{{ sns_topic_third_party_topic_arn.split(':')[3] }}"
 
+# additional test resource namings
 sns_topic_lambda_function: "sns_topic_lambda"
 sns_topic_lambda_name: "ansible-test-{{ unique_id }}-{{ sns_topic_lambda_function }}"
 sns_topic_lambda_role: "ansible-test-{{ unique_id }}-sns-lambda"

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -7,7 +7,8 @@
   collections:
     - community.general
   block:
-  - name: create minimal lambda role
+
+  - name: create minimal lambda role (needed for subscription test further down)
     iam_role:
       name: '{{ sns_topic_lambda_role }}'
       assume_role_policy_document: '{{ lookup("file", "lambda-trust-policy.json") }}'
@@ -15,33 +16,65 @@
       managed_policies:
       - 'arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess'
     register: iam_role
+
   - name: pause if role was created
     pause:
       seconds: 10
     when: iam_role is changed
 
-  - name: create topic
+  - name: create standard SNS topic
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       display_name: My topic name
     register: sns_topic_create
+
   - name: assert that creation worked
     assert:
       that:
       - sns_topic_create.changed
+
   - name: set sns_arn fact
     set_fact:
       sns_arn: '{{ sns_topic_create.sns_arn }}'
+
   - name: create topic again (expect changed=False)
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       display_name: My topic name
     register: sns_topic_no_change
+
   - name: assert that recreation had no effect
     assert:
       that:
       - not sns_topic_no_change.changed
       - sns_topic_no_change.sns_arn == sns_topic_create.sns_arn
+
+  - name: Create a FIFO topic (not providing .fifo suffix, should be done automatically)
+    sns_topic:
+      name: '{{ sns_topic_topic_name }}-fifo'
+      type: fifo
+      display_name: My FIFO topic
+    register: sns_fifo_topic
+
+  - name: assert that FIFO SNS topic creation worked
+    assert:
+      that:
+      - sns_fifo_topic.changed
+      - sns_fifo_topic.sns_topic.topic_type == 'fifo'
+      - sns_fifo_topic.sns_topic.name == '{{ sns_topic_topic_name }}-fifo.fifo'
+
+  - name: Run create a FIFO topic again for idempotence test
+    sns_topic:
+      name: '{{ sns_topic_topic_name }}-fifo.fifo'
+      type: fifo
+      display_name: My FIFO topic
+    register: sns_fifo_topic
+
+  - name: assert that FIFO SNS topic creation worked
+    assert:
+      that:
+      - not sns_fifo_topic.changed
+
   - name: update display name
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
@@ -52,7 +85,8 @@
       that:
       - sns_topic_update_name.changed
       - sns_topic_update_name.sns_topic.display_name == "My new topic name"
-  - name: add policy
+
+  - name: add access policy to SNS topic
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       display_name: My new topic name
@@ -62,17 +96,20 @@
     assert:
       that:
       - sns_topic_add_policy.changed
+
   - name: rerun same policy
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       display_name: My new topic name
       policy: '{{ lookup(''template'', ''initial-policy.json'') }}'
     register: sns_topic_rerun_policy
+
   - name: assert that rerunning policy had no effect
     assert:
       that:
       - not sns_topic_rerun_policy.changed
-  - name: update policy
+
+  - name: update SNS policy
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       display_name: My new topic name
@@ -82,6 +119,7 @@
     assert:
       that:
       - sns_topic_update_policy.changed
+
   - name: add delivery policy
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
@@ -97,6 +135,7 @@
             numMinDelayRetries: 0
             backoffFunction: linear
     register: sns_topic_add_delivery_policy
+
   - name: assert that adding delivery policy worked
     vars:
       delivery_policy: '{{ sns_topic_add_delivery_policy.sns_topic.delivery_policy | from_json }}'
@@ -106,6 +145,7 @@
       - delivery_policy.http.defaultHealthyRetryPolicy.minDelayTarget == 20
       - delivery_policy.http.defaultHealthyRetryPolicy.maxDelayTarget == 20
       - delivery_policy.http.defaultHealthyRetryPolicy.numRetries == 3
+
   - name: rerun same delivery policy
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
@@ -121,6 +161,7 @@
             numMinDelayRetries: 0
             backoffFunction: linear
     register: sns_topic_rerun_delivery_policy
+
   - name: assert that rerunning delivery_policy had no effect
     vars:
       delivery_policy: '{{ sns_topic_rerun_delivery_policy.sns_topic.delivery_policy | from_json }}'
@@ -130,6 +171,7 @@
       - delivery_policy.http.defaultHealthyRetryPolicy.minDelayTarget == 20
       - delivery_policy.http.defaultHealthyRetryPolicy.maxDelayTarget == 20
       - delivery_policy.http.defaultHealthyRetryPolicy.numRetries == 3
+
   - name: rerun a slightly different delivery policy
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
@@ -145,6 +187,7 @@
             numMinDelayRetries: 0
             backoffFunction: linear
     register: sns_topic_rerun_delivery_policy
+
   - name: assert that rerunning delivery_policy worked
     vars:
       delivery_policy: '{{ sns_topic_rerun_delivery_policy.sns_topic.delivery_policy | from_json }}'
@@ -154,15 +197,18 @@
       - delivery_policy.http.defaultHealthyRetryPolicy.minDelayTarget == 40
       - delivery_policy.http.defaultHealthyRetryPolicy.maxDelayTarget == 40
       - delivery_policy.http.defaultHealthyRetryPolicy.numRetries == 6
+
   - name: create temp dir
     tempfile:
       state: directory
     register: tempdir
+
   - name: ensure zip file exists
     archive:
       path: '{{ lookup(''first_found'', sns_topic_lambda_function) }}'
       dest: '{{ tempdir.path }}/{{ sns_topic_lambda_function }}.zip'
       format: zip
+
   - name: create lambda for subscribing (only auto-subscribing target available)
     lambda:
       name: '{{ sns_topic_lambda_name }}'
@@ -172,8 +218,10 @@
       role: '{{ sns_topic_lambda_role }}'
       handler: '{{ sns_topic_lambda_function }}.handler'
     register: lambda_result
+
   - set_fact:
       sns_topic_subscriber_arn: '{{ lambda_result.configuration.function_arn }}'
+
   - name: subscribe to topic
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
@@ -181,22 +229,26 @@
       purge_subscriptions: false
       subscriptions: '{{ sns_topic_subscriptions }}'
     register: sns_topic_subscribe
+
   - name: assert that subscribing worked
     assert:
       that:
       - sns_topic_subscribe.changed
       - sns_topic_subscribe.sns_topic.subscriptions|length == 1
+
   - name: run again with purge_subscriptions set to false
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       display_name: My new topic name
       purge_subscriptions: false
     register: sns_topic_no_purge
+
   - name: assert that not purging subscriptions had no effect
     assert:
       that:
       - not sns_topic_no_purge.changed
       - sns_topic_no_purge.sns_topic.subscriptions|length == 1
+
   - name: run again with purge_subscriptions set to true
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
@@ -208,26 +260,31 @@
       that:
       - sns_topic_purge.changed
       - sns_topic_purge.sns_topic.subscriptions|length == 0
+
   - name: delete topic
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       state: absent
+
   - name: no-op with third party topic (effectively get existing subscriptions)
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
       region: '{{ sns_topic_third_party_region }}'
     register: third_party_topic
+
   - name: subscribe to third party topic
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
       subscriptions: '{{ sns_topic_subscriptions }}'
       region: '{{ sns_topic_third_party_region }}'
     register: third_party_topic_subscribe
+
   - name: assert that subscribing worked
     assert:
       that:
       - third_party_topic_subscribe is changed
       - (third_party_topic_subscribe.sns_topic.subscriptions|length) - (third_party_topic.sns_topic.subscriptions|length) == 1
+
   - name: attempt to change name of third party topic
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
@@ -236,21 +293,25 @@
       region: '{{ sns_topic_third_party_region }}'
     ignore_errors: true
     register: third_party_name_change
+
   - name: assert that attempting to change display name does not work
     assert:
       that:
       - third_party_name_change is failed
+
   - name: unsubscribe from third party topic (purge_subscription defaults to true)
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
       subscriptions: '{{ third_party_topic.sns_topic.subscriptions }}'
       region: '{{ sns_topic_third_party_region }}'
     register: third_party_unsubscribe
+
   - name: assert that unsubscribing from third party topic works
     assert:
       that:
       - third_party_unsubscribe.changed
       - third_party_topic.sns_topic.subscriptions|length == third_party_unsubscribe.sns_topic.subscriptions|length
+
   - name: attempt to delete third party topic
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
@@ -259,25 +320,31 @@
       region: '{{ sns_topic_third_party_region }}'
     ignore_errors: true
     register: third_party_deletion
+
   - name: no-op after third party deletion
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
       region: '{{ sns_topic_third_party_region }}'
     register: third_party_deletion_facts
+
   - name: assert that attempting to delete third party topic does not work and preser
     assert:
       that:
       - third_party_deletion is failed
       - third_party_topic.sns_topic.subscriptions|length == third_party_deletion_facts.sns_topic.subscriptions|length
+
   always:
+
   - name: announce teardown start
     debug:
       msg: '************** TEARDOWN STARTS HERE *******************'
+
   - name: remove topic
     sns_topic:
       name: '{{ sns_topic_topic_name }}'
       state: absent
     ignore_errors: true
+
   - name: unsubscribe from third party topic
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
@@ -285,17 +352,20 @@
       purge_subscriptions: true
       region: '{{ sns_topic_third_party_region }}'
     ignore_errors: true
+
   - name: remove lambda
     lambda:
       name: '{{ sns_topic_lambda_name }}'
       state: absent
     ignore_errors: true
+
   - name: remove tempdir
     file:
       path: '{{ tempdir.path }}'
       state: absent
     when: tempdir is defined
     ignore_errors: true
+
   - name: remove iam role
     iam_role:
       name: '{{ sns_topic_lambda_role }}'

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -52,7 +52,7 @@
   - name: Create a FIFO topic (not providing .fifo suffix, should be done automatically)
     sns_topic:
       name: '{{ sns_topic_topic_name }}-fifo'
-      type: fifo
+      topic_type: fifo
       display_name: My FIFO topic
     register: sns_fifo_topic
 
@@ -66,7 +66,7 @@
   - name: Run create a FIFO topic again for idempotence test
     sns_topic:
       name: '{{ sns_topic_topic_name }}-fifo.fifo'
-      type: fifo
+      topic_type: fifo
       display_name: My FIFO topic
     register: sns_fifo_topic
 


### PR DESCRIPTION
##### SUMMARY
Adding a topic_type param to SNS module (simillar to SQS).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sns_topic module

##### ADDITIONAL INFORMATION
Simillar to SQS queues, SNS topics also allow specifying a type, that can either be 'Standard' or 'FIFO'. Furthermore if you have a FIFO SQS queue and want to subscribe that to an SNS topic, that one has to be FIFO too. Hence adding this flag is important and is actually just another option for the creat_topic action in Boto, see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.create_topic
