### PR TITLE
fix: typo for verifying environmentFiles

### DIFF
--- a/changelogs/600-ecs-task-defination-env-file-validations.yml
+++ b/changelogs/600-ecs-task-defination-env-file-validations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ecs_taskdefinition - fix typo in ecs task defination for env file validations (https://github.com/ansible-collections/community.aws/pull/600).

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -799,7 +799,7 @@ def main():
                 environment['value'] = to_text(environment['value'])
 
             for environment_file in container.get('environmentFiles', []):
-                if environment_file['value'] != 's3':
+                if environment_file['type'] != 's3':
                     module.fail_json(msg='The only supported value for environmentFiles is s3.')
 
             for linux_param in container.get('linuxParameters', {}):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Validation for `environmentFiles` is incorrect. We need to validate the type key of the code but we are actually validating the value key.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_taskdefinition.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
