### PR TITLE
ssm connection plugin - allow s3 bucket to use it's own region setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ community.aws Release Notes
 
 .. contents:: Topics
 
+v2.0.0
+======
+
+Minor Changes
+-------------
+- aws_ssm connection plugin - added support for an independent bucket region (https://github.com/ansible-collections/community.aws/pull/603).
 
 v1.5.0
 ======

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: community
 name: aws
-version: 1.5.0
+version: 2.0.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -513,11 +513,10 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name):
         ''' Generate URL for get_object / put_object '''
-        if self.has_option('bucket_region'):
-            region_name = self.get_option('bucket_region')
-        elif self.has_option('region'):
+        region_name = self.get_option('bucket_region')
+        if region_name is None:
             region_name = self.get_option('region')
-        else:
+        if region_name is None:
             region_name = 'us-east-1'
 
         client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -52,6 +52,7 @@ options:
     description: The region of the S3 bucket used for file transfers.
     vars:
     - name: ansible_aws_ssm_bucket_region
+    version_added: 2.0.0
   plugin:
     description: This defines the location of the session-manager-plugin binary.
     vars:
@@ -512,10 +513,13 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name):
         ''' Generate URL for get_object / put_object '''
-        try:
-            region_name = self.get_option('bucket_region') or self.get_option('region')
-        except KeyError:
+        if self.has_option('bucket_region'):
+            region_name = self.get_option('bucket_region')
+        elif self.has_option('region'):
+            region_name = self.get_option('region')
+        else:
             region_name = 'us-east-1'
+
         client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -512,7 +512,10 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name):
         ''' Generate URL for get_object / put_object '''
-        region_name = self.get_option('bucket_region') or self.get_option('region') or 'us-east-1'
+        try:
+            region_name = self.get_option('bucket_region') or self.get_option('region')
+        except KeyError:
+            region_name = 'us-east-1'
         client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -48,6 +48,10 @@ options:
     description: The name of the S3 bucket used for file transfers.
     vars:
     - name: ansible_aws_ssm_bucket_name
+  bucket_region:
+    description: The region of the S3 bucket used for file transfers.
+    vars:
+    - name: ansible_aws_ssm_bucket_region
   plugin:
     description: This defines the location of the session-manager-plugin binary.
     vars:
@@ -508,7 +512,7 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name):
         ''' Generate URL for get_object / put_object '''
-        region_name = self.get_option('region') or 'us-east-1'
+        region_name = self.get_option('bucket_region') or self.get_option('region') or 'us-east-1'
         client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 


### PR DESCRIPTION
##### SUMMARY
When using ssm to connect to systems in aws it is required that we utilize an s3 bucket to transfer files from the source to the destination server.  When the bucket resides in a different region than the destination server the wrong s3 endpoint is being selected.  This adds a new configuration value, ansible_aws_ssm_bucket_region, to allow the s3 buckets region to be set directly allowing the transfer to occur as would be expected.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/aws_ssm.py

