### PR TITLE
New module 'efs_tag'

### DIFF
--- a/plugins/modules/efs_tag.py
+++ b/plugins/modules/efs_tag.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+"""
+Copyright: (c) 2021, Milan Zink <zeten30@gmail.com>
+GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: efs_tag
+version_added: 2.0.0
+short_description: create and remove tags on Amazon EFS resources
+description:
+    - Creates and removes tags for Amazon EFS resources.
+    - Resources are referenced by their ID (filesystem or filesystem access point).
+author:
+  - Milan Zink (@zeten30)
+options:
+  resource:
+    description:
+      - EFS Filesystem ID or EFS Filesystem Access Point ID.
+    type: str
+    required: True
+  state:
+    description:
+      - Whether the tags should be present or absent on the resource.
+    default: present
+    choices: ['present', 'absent']
+    type: str
+  tags:
+    description:
+      - A dictionary of tags to add or remove from the resource.
+      - If the value provided for a tag is null and I(state=absent), the tag will be removed regardless of its current value.
+    type: dict
+    required: True
+  purge_tags:
+    description:
+      - Whether unspecified tags should be removed from the resource.
+      - Note that when combined with I(state=absent), specified tags with non-matching values are not purged.
+    type: bool
+    default: false
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+
+'''
+
+EXAMPLES = r'''
+- name: Ensure tags are present on a resource
+  community.aws.efs_tag:
+    resource: fs-123456ab
+    state: present
+    tags:
+      Name: MyEFS
+      Env: Production
+
+- name: Remove the Env tag if it's currently 'development'
+  community.aws.efs_tag:
+    resource: fsap-78945ff
+    state: absent
+    tags:
+      Env: development
+
+- name: Remove all tags except for Name
+  community.aws.efs_tag:
+    resource: fsap-78945ff
+    state: absent
+    tags:
+        Name: foo
+    purge_tags: true
+
+- name: Remove all tags
+  community.aws.efs_tag:
+    resource: fsap-78945ff
+    state: absent
+    tags: {}
+    purge_tags: true
+'''
+
+RETURN = r'''
+tags:
+  description: A dict containing the tags on the resource
+  returned: always
+  type: dict
+added_tags:
+  description: A dict of tags that were added to the resource
+  returned: If tags were added
+  type: dict
+removed_tags:
+  description: A dict of tags that were removed from the resource
+  returned: If tags were removed
+  type: dict
+'''
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    # Handled by AnsibleAWSModule
+    pass
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list, compare_aws_tags, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+
+MAX_AWS_RETRIES = 10  # How many retries to perform when an API call is failing
+WAIT_RETRY = 5  # how many seconds to wait between propagation status polls
+
+
+def get_tags(efs, module, resource):
+    '''
+    Get resource tags
+    '''
+    try:
+        return boto3_tag_list_to_ansible_dict(efs.list_tags_for_resource(aws_retry=True, ResourceId=resource)['Tags'])
+    except (BotoCoreError, ClientError) as get_tags_error:
+        module.fail_json_aws(get_tags_error, msg='Failed to fetch tags for resource {0}'.format(resource))
+
+
+def main():
+    '''
+    MAIN
+    '''
+    argument_spec = dict(
+        resource=dict(required=True),
+        tags=dict(type='dict', required=True),
+        purge_tags=dict(type='bool', default=False),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+    resource = module.params['resource']
+    tags = module.params['tags']
+    state = module.params['state']
+    purge_tags = module.params['purge_tags']
+
+    result = {'changed': False}
+
+    efs = module.client('efs', retry_decorator=AWSRetry.jittered_backoff())
+
+    current_tags = get_tags(efs, module, resource)
+
+    add_tags, remove = compare_aws_tags(current_tags, tags, purge_tags=purge_tags)
+
+    remove_tags = {}
+
+    if state == 'absent':
+        for key in tags:
+            if key in current_tags and (tags[key] is None or current_tags[key] == tags[key]):
+                remove_tags[key] = current_tags[key]
+
+    for key in remove:
+        remove_tags[key] = current_tags[key]
+
+    if remove_tags:
+        result['changed'] = True
+        result['removed_tags'] = remove_tags
+        if not module.check_mode:
+            try:
+                efs.untag_resource(aws_retry=True, ResourceId=resource, TagKeys=list(remove_tags.keys()))
+            except (BotoCoreError, ClientError) as remove_tag_error:
+                module.fail_json_aws(remove_tag_error, msg='Failed to remove tags {0} from resource {1}'.format(remove_tags, resource))
+
+    if state == 'present' and add_tags:
+        result['changed'] = True
+        result['added_tags'] = add_tags
+        current_tags.update(add_tags)
+        if not module.check_mode:
+            try:
+                tags = ansible_dict_to_boto3_tag_list(add_tags)
+                efs.tag_resource(aws_retry=True, ResourceId=resource, Tags=tags)
+            except (BotoCoreError, ClientError) as set_tag_error:
+                module.fail_json_aws(set_tag_error, msg='Failed to set tags {0} on resource {1}'.format(add_tags, resource))
+
+    result['tags'] = get_tags(efs, module, resource)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/efs/aliases
+++ b/tests/integration/targets/efs/aliases
@@ -1,7 +1,4 @@
-# reason: missing-policy
-# ansible/ansible#36520 - attempts were made to get it running in CI but were unsuccessful
-unsupported
-
 cloud/aws
 
 efs_info
+efs_tag

--- a/tests/integration/targets/efs/defaults/main.yml
+++ b/tests/integration/targets/efs/defaults/main.yml
@@ -1,0 +1,1 @@
+efs_name: "ansible-test-{{ tiny_prefix }}"

--- a/tests/integration/targets/efs/tasks/main.yml
+++ b/tests/integration/targets/efs/tasks/main.yml
@@ -13,7 +13,7 @@
     # ============================================================
     - name: Create VPC for testing
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc"
+        name: "{{ efs_name }}-vpc"
         cidr_block: 10.22.32.0/23
         tags:
           Name: Ansible ec2_instance Testing VPC
@@ -27,7 +27,7 @@
         cidr: 10.22.32.0/24
         az: "{{ aws_region }}a"
         resource_tags:
-          Name: "{{ resource_prefix }}-subnet-a"
+          Name: "{{ efs_name }}-subnet-a"
       register: testing_subnet_a
 
     - name: Create subnet in zone B for testing
@@ -37,7 +37,7 @@
         cidr: 10.22.33.0/24
         az: "{{ aws_region }}b"
         resource_tags:
-          Name: "{{ resource_prefix }}-subnet-b"
+          Name: "{{ efs_name }}-subnet-b"
       register: testing_subnet_b
 
     - name: Get default security group id for vpc
@@ -54,9 +54,9 @@
     - name: Create Efs for testing
       efs:
         state: present
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
         tags:
-            Name: "{{ resource_prefix }}-test-tag"
+            Name: "{{ efs_name }}-test-tag"
             Purpose: file-storage
         targets:
             - subnet_id: "{{testing_subnet_a.subnet.id}}"
@@ -76,19 +76,19 @@
     # ============================================================
     - name: Get EFS by creation token
       efs_info:
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
       register: efs_result
 
     - set_fact:
         efs_result_assertions:
           - efs_result is not changed
           - (efs_result.efs | length) == 1
-          - efs_result.efs[0].creation_token == "{{ resource_prefix }}-test-efs"
+          - efs_result.efs[0].creation_token == "{{ efs_name }}-test-efs"
           - efs_result.efs[0].file_system_id == created_efs.efs.file_system_id
           - efs_result.efs[0].number_of_mount_targets == 2
           - (efs_result.efs[0].mount_targets | length) == 2
-          - efs_result.efs[0].name == "{{ resource_prefix }}-test-tag"
-          - efs_result.efs[0].tags.Name == "{{ resource_prefix }}-test-tag"
+          - efs_result.efs[0].name == "{{ efs_name }}-test-tag"
+          - efs_result.efs[0].tags.Name == "{{ efs_name }}-test-tag"
           - efs_result.efs[0].tags.Purpose == "file-storage"
           - efs_result.efs[0].encrypted == false
           - efs_result.efs[0].life_cycle_state == "available"
@@ -113,7 +113,7 @@
     - name: Get EFS by tag
       efs_info:
         tags:
-          Name: "{{ resource_prefix }}-test-tag"
+          Name: "{{ efs_name }}-test-tag"
       register: efs_result
 
     - assert:
@@ -143,7 +143,7 @@
     - name: Get EFS by tag and target
       efs_info:
         tags:
-          Name: "{{ resource_prefix }}-test-tag"
+          Name: "{{ efs_name }}-test-tag"
         targets:
           - "{{testing_subnet_a.subnet.id}}"
       register: efs_result
@@ -157,9 +157,9 @@
     - name: Update Efs to use provisioned throughput_mode
       efs:
         state: present
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
         tags:
-            Name: "{{ resource_prefix }}-test-tag"
+            Name: "{{ efs_name }}-test-tag"
             Purpose: file-storage
         targets:
             - subnet_id: "{{testing_subnet_a.subnet.id}}"
@@ -176,9 +176,9 @@
     - name: Efs same value for provisioned_throughput_in_mibps
       efs:
         state: present
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
         tags:
-            Name: "{{ resource_prefix }}-test-tag"
+            Name: "{{ efs_name }}-test-tag"
             Purpose: file-storage
         targets:
             - subnet_id: "{{testing_subnet_a.subnet.id}}"
@@ -197,9 +197,9 @@
     - name: Efs new value for provisioned_throughput_in_mibps
       efs:
         state: present
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
         tags:
-            Name: "{{ resource_prefix }}-test-tag"
+            Name: "{{ efs_name }}-test-tag"
             Purpose: file-storage
         targets:
             - subnet_id: "{{testing_subnet_a.subnet.id}}"
@@ -211,12 +211,14 @@
     - assert:
         that:
           - efs_result is changed
-          - efs_result.efs["provisioned_throughput_in_mibps"] == 8.0
+    # Change of provisioned_throughput_in_mibps takes time
+    - pause:
+        seconds: 15
 
     # ============================================================
     - name: Check new facts with provisioned mode
       efs_info:
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
       register: efs_result
 
     - set_fact:
@@ -225,7 +227,7 @@
           - efs_result.efs[0].throughput_mode  == "provisioned"
           - efs_result.efs[0].provisioned_throughput_in_mibps == 8.0
           - (efs_result.efs | length) == 1
-          - efs_result.efs[0].creation_token == "{{ resource_prefix }}-test-efs"
+          - efs_result.efs[0].creation_token == "{{ efs_name }}-test-efs"
           - efs_result.efs[0].file_system_id == created_efs.efs.file_system_id
 
     - assert:
@@ -235,7 +237,7 @@
     - name: Query unknown EFS by tag
       efs_info:
         tags:
-          Name: "{{ resource_prefix }}-unknown"
+          Name: "{{ efs_name }}-unknown"
       register: efs_result
 
     - assert:
@@ -254,14 +256,190 @@
           - efs_result is not changed
           - (efs_result.efs | length) == 0
 
+    # ============================================================
+    # efs_tag module tests
+    - name: Add tags to EFS filesystem in check mode
+      efs_tag:
+        state: present
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          check_mode_tag: 'this tag should not be applied'
+      check_mode: yes
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - not efs_tag_result.tags.check_mode_tag is defined
+
+    - name: Add tags to EFS filesystem
+      efs_tag:
+        state: present
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          "Title Case": 'Hello Cruel World'
+          "lowercase spaced": 'hello cruel world'
+          CamelCase: 'SimpleCamelCase'
+          Env: IntegrationTests
+          snake_case: 'simple_snake_case'
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - efs_tag_result.tags.Env is defined
+          - efs_tag_result.tags.Env is search("IntegrationTests")
+          - efs_tag_result.tags.Name is defined
+          - efs_tag_result.tags.Name is search("{{ efs_name }}-test-tag")
+          - efs_tag_result.tags["CamelCase"] == 'SimpleCamelCase'
+          - efs_tag_result.tags["Title Case"] == 'Hello Cruel World'
+          - efs_tag_result.tags["lowercase spaced"] == 'hello cruel world'
+          - efs_tag_result.tags["snake_case"] == 'simple_snake_case'
+          - efs_tag_result is changed
+
+    - name: Add/Change tags on EFS filesystem - idempotency
+      efs_tag:
+        state: present
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          Env: IntegrationTests
+          snake_case: 'simple_snake_case'
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - not efs_tag_result is changed
+
+    - name: Remove specific EFS filesystem tag in check mode
+      efs_tag:
+        state: absent
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          snake_case: 'simple_snake_case'
+      check_mode: yes
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - efs_tag_result.tags["snake_case"] is defined
+          - efs_tag_result.tags["snake_case"] == 'simple_snake_case'
+
+    - name: Change tags on EFS filesystem
+      efs_tag:
+        state: present
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          Env: OtherIntegrationTests
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - efs_tag_result.tags.Env is defined
+          - efs_tag_result.tags.Env is search("OtherIntegrationTests")
+          - efs_tag_result is changed
+
+    - name: Change tags on EFS filesystem - idempotency
+      efs_tag:
+        state: present
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          Env: OtherIntegrationTests
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - efs_tag_result.tags.Env is defined
+          - efs_tag_result.tags.Env is search("OtherIntegrationTests")
+          - not efs_tag_result is changed
+
+    - name: Remove specific EFS filesystem tags
+      efs_tag:
+        state: absent
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          "Title Case": 'Hello Cruel World'
+          "lowercase spaced": 'hello cruel world'
+          CamelCase: 'SimpleCamelCase'
+          snake_case: 'simple_snake_case'
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - efs_tag_result.tags.Env is defined
+          - efs_tag_result.tags.Env is search("IntegrationTests")
+          - efs_tag_result.tags.Name is defined
+          - efs_tag_result.tags.Name is search("{{ efs_name }}-test-tag")
+          - not efs_tag_result.tags["CamelCase"] is defined
+          - not efs_tag_result.tags["Title Case"] is defined
+          - not efs_tag_result.tags["lowercase spaced"] is defined
+          - not efs_tag_result.tags["snake_case"] is defined
+
+    - name: Remove specific EFS filesystem tag - idempotency
+      efs_tag:
+        state: absent
+        resource: "{{ created_efs.efs.file_system_id }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        region: "{{ aws_region }}"
+        tags:
+          snake_case: 'simple_snake_case'
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - not efs_tag_result is changed
+
+    - name: Remove all tag on EFS filesystem
+      efs_tag:
+        state: absent
+        resource: "{{ created_efs.efs.file_system_id }}"
+        region: "{{ aws_region }}"
+        aws_access_key: '{{ aws_access_key }}'
+        aws_secret_key: '{{ aws_secret_key }}'
+        security_token: '{{ security_token | default(omit) }}'
+        tags: {}
+        purge_tags: true
+      register: efs_tag_result
+
+    - assert:
+        that:
+          - efs_tag_result.tags == {}
+
   # ============================================================
   always:
     - name: Delete EFS used for tests
       efs:
         state: absent
-        name: "{{ resource_prefix }}-test-efs"
+        name: "{{ efs_name }}-test-efs"
         tags:
-          Name: "{{ resource_prefix }}-test-tag"
+          Name: "{{ efs_name }}-test-tag"
           Purpose: file-storage
       register: removed
       until: removed is not failed
@@ -275,7 +453,7 @@
         cidr: 10.22.32.0/24
         az: "{{ aws_region }}a"
         resource_tags:
-          Name: "{{ resource_prefix }}-subnet-a"
+          Name: "{{ efs_name }}-subnet-a"
       register: removed
       until: removed is not failed
       ignore_errors: yes
@@ -288,7 +466,7 @@
         cidr: 10.22.33.0/24
         az: "{{ aws_region }}b"
         resource_tags:
-          Name: "{{ resource_prefix }}-subnet-b"
+          Name: "{{ efs_name }}-subnet-b"
       register: removed
       until: removed is not failed
       ignore_errors: yes
@@ -296,7 +474,7 @@
 
     - name: remove the VPC
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc"
+        name: "{{ efs_name }}-vpc"
         cidr_block: 10.22.32.0/23
         state: absent
       register: removed


### PR DESCRIPTION
##### SUMMARY
New module - efs_tag

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
efs_tag

##### ADDITIONAL INFORMATION
There's a similar 'ec2_tag' module amazon.aws.ec2_tag that allows tagging on various EC2 resources. I'm adding a module that allows all EFS resource tagging (both filesystem and access point)

```paste below
- name: Ensure tags are present on a resource
  community.aws.efs_tag:
    resource: fsap-123456ab
    state: present
    tags:
      Name: MyEFSAccessPoint
      Env: Production
```
