### PR TITLE
aws_s3_bucket_info/test: reduce the size of the bucket name

### DIFF
--- a/tests/integration/targets/aws_s3_bucket_info/defaults/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-name_pattern: "testbucket-ansible-integration"
+name_pattern: "info"
 
 testing_buckets:
-  - "{{ resource_prefix }}-{{ name_pattern }}-1"
-  - "{{ resource_prefix }}-{{ name_pattern }}-2"
+  - "ansible-test-{{ resource_prefix | hash('md5') }}-{{ name_pattern }}-1"
+  - "ansible-test-{{ resource_prefix | hash('md5') }}-{{ name_pattern }}-2"


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/975

##### SUMMARY

This to avoid the following error: `the length of an S3 bucket cannot exceed 63 characters`
<!--- Describe the change below, including rationale and design decisions -->


e.g: https://750481db341eaba0eeaa-e40c8df6565c395c864078b174c76972.ssl.cf5.rackcdn.com/610/532545f78724a305a7b9dc4e609d6ec55a434982/check/ansible-test-cloud-integration-aws-py36_3_of_3/4f187e0/job-output.txt

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
