### PR TITLE
Update hostname_variable tag override example.

### DIFF
--- a/scripts/inventory/ec2.ini
+++ b/scripts/inventory/ec2.ini
@@ -33,8 +33,8 @@ destination_variable = public_dns_name
 
 # This allows you to override the inventory_name with an ec2 variable, instead
 # of using the destination_variable above. Addressing (aka ansible_ssh_host)
-# will still use destination_variable. Tags should be written as 'tag_TAGNAME'.
-#hostname_variable = tag_Name
+# will still use destination_variable. Tags should be written as 'tag:TAGNAME'.
+#hostname_variable = tag:Name
 
 # For server inside a VPC, using DNS names may not make sense. When an instance
 # has 'subnet_id' set, this variable is used. If the subnet is public, setting


### PR DESCRIPTION
##### SUMMARY
Between Ansible Tower 3.6 and 3.7, the tag formatting changed for overriding the hostname variable. Users doing the 3.7 upgrade may be surprised when their inventories update with the ip##-##-##-##.example.com hostname format when they were previously able to import from AWS using the Name tag as the inventory identifier.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2\