### PR TITLE
cdaws_ssm - rename retries setting

### DIFF
--- a/changelogs/fragments/rename-connection-retries.yml
+++ b/changelogs/fragments/rename-connection-retries.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - rename ``retries`` to ``reconnection_retries`` to avoid conflict with task retries

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -58,7 +58,7 @@ options:
     vars:
     - name: ansible_aws_ssm_profile
     version_added: 1.5.0
-  retries:
+  reconnection_retries:
     description: Number of attempts to connect.
     default: 3
     type: integer
@@ -206,7 +206,7 @@ def _ssm_retry(func):
     """
     @wraps(func)
     def wrapped(self, *args, **kwargs):
-        remaining_tries = int(self.get_option('retries')) + 1
+        remaining_tries = int(self.get_option('reconnection_retries')) + 1
         cmd_summary = "%s..." % args[0]
         for attempt in range(remaining_tries):
             cmd = args[0]


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There was a bug in Ansible that would result in task retries overriding the connection retries. Using a different name for the connection retries setting avoids this issue on versions of Ansible that are missing the bug fix.<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/connection/aws_ssm.py`

##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/ansible/pull/75155.
