### PR TITLE
test: aws_msk_cluster is slow

### DIFF
--- a/tests/integration/targets/aws_msk_cluster/aliases
+++ b/tests/integration/targets/aws_msk_cluster/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+slow


### PR DESCRIPTION
The aws_msk_cluster test takes a bit of time. Let's be sure this does
not become a problem in the future by isolating it on its own
dedicated job.