### PR TITLE
Cleanup / unused imports

### DIFF
--- a/changelogs/fragments/629-imports-cleanup.yml
+++ b/changelogs/fragments/629-imports-cleanup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- various community.aws modules - remove unused imports (https://github.com/ansible-collections/community.aws/pull/629)

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -200,7 +200,6 @@ endpoints:
 
 import datetime
 import json
-import time
 import traceback
 
 try:

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -109,8 +109,6 @@ vpc_endpoints:
       vpc_id: "vpc-1111ffff"
 '''
 
-import json
-
 try:
     import botocore
 except ImportError:

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -208,8 +208,8 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import normalize_boto3_result
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -200,8 +200,6 @@ result:
   type: list
 '''
 
-import json
-
 try:
     import botocore
 except ImportError:

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -180,10 +180,7 @@ tags:
   }
 '''
 
-import re
-import datetime
 import time
-from functools import reduce
 
 try:
     import botocore.exceptions
@@ -192,10 +189,8 @@ except ImportError:
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 

--- a/plugins/modules/kinesis_stream.py
+++ b/plugins/modules/kinesis_stream.py
@@ -183,7 +183,7 @@ tags:
 import time
 
 try:
-    import botocore.exceptions
+    import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 

--- a/plugins/modules/wafv2_ip_set.py
+++ b/plugins/modules/wafv2_ip_set.py
@@ -116,7 +116,8 @@ name:
   returned: Always, as long as the ip set exists
   type: str
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
 
 try:

--- a/plugins/modules/wafv2_ip_set.py
+++ b/plugins/modules/wafv2_ip_set.py
@@ -117,13 +117,14 @@ name:
   type: str
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class IpSet:

--- a/plugins/modules/wafv2_ip_set_info.py
+++ b/plugins/modules/wafv2_ip_set_info.py
@@ -69,7 +69,8 @@ name:
   returned: Always, as long as the ip set exists
   type: str
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 try:

--- a/plugins/modules/wafv2_ip_set_info.py
+++ b/plugins/modules/wafv2_ip_set_info.py
@@ -70,13 +70,13 @@ name:
   type: str
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def list_ip_sets(wafv2, scope, fail_json_aws, Nextmarker=None):

--- a/plugins/modules/wafv2_resources.py
+++ b/plugins/modules/wafv2_resources.py
@@ -60,14 +60,14 @@ resource_arns:
   type: list
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
 
 
 def get_web_acl(wafv2, name, scope, id, fail_json_aws):

--- a/plugins/modules/wafv2_resources.py
+++ b/plugins/modules/wafv2_resources.py
@@ -59,8 +59,9 @@ resource_arns:
   returned: Always, as long as the wafv2 exists
   type: list
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
 
 try:

--- a/plugins/modules/wafv2_resources_info.py
+++ b/plugins/modules/wafv2_resources_info.py
@@ -48,8 +48,9 @@ resource_arns:
   returned: Always, as long as the wafv2 exists
   type: list
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
 
 try:

--- a/plugins/modules/wafv2_resources_info.py
+++ b/plugins/modules/wafv2_resources_info.py
@@ -49,14 +49,14 @@ resource_arns:
   type: list
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
 
 
 def get_web_acl(wafv2, name, scope, id, fail_json_aws):

--- a/plugins/modules/wafv2_rule_group.py
+++ b/plugins/modules/wafv2_rule_group.py
@@ -200,7 +200,8 @@ visibility_config:
         metric_name: blub
         sampled_requests_enabled: False
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
 from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_rule_groups, compare_priority_rules, wafv2_snake_dict_to_camel_dict
 

--- a/plugins/modules/wafv2_rule_group.py
+++ b/plugins/modules/wafv2_rule_group.py
@@ -201,14 +201,18 @@ visibility_config:
         sampled_requests_enabled: False
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
-from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_rule_groups, compare_priority_rules, wafv2_snake_dict_to_camel_dict
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import compare_priority_rules
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_rule_groups
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_snake_dict_to_camel_dict
 
 
 class RuleGroup:

--- a/plugins/modules/wafv2_rule_group_info.py
+++ b/plugins/modules/wafv2_rule_group_info.py
@@ -94,14 +94,14 @@ visibility_config:
         sampled_requests_enabled: False
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_rule_groups
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_rule_groups
 
 
 def get_rule_group(wafv2, name, scope, id, fail_json_aws):

--- a/plugins/modules/wafv2_rule_group_info.py
+++ b/plugins/modules/wafv2_rule_group_info.py
@@ -93,8 +93,9 @@ visibility_config:
         metric_name: blub
         sampled_requests_enabled: False
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_rule_groups
 
 try:

--- a/plugins/modules/wafv2_web_acl.py
+++ b/plugins/modules/wafv2_web_acl.py
@@ -191,14 +191,18 @@ visibility_config:
     sampled_requests_enabled: false
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
-from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls, compare_priority_rules, wafv2_snake_dict_to_camel_dict
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import compare_priority_rules
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_snake_dict_to_camel_dict
 
 
 class WebACL:

--- a/plugins/modules/wafv2_web_acl.py
+++ b/plugins/modules/wafv2_web_acl.py
@@ -190,7 +190,8 @@ visibility_config:
     metric_name: blub
     sampled_requests_enabled: false
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
 from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls, compare_priority_rules, wafv2_snake_dict_to_camel_dict
 

--- a/plugins/modules/wafv2_web_acl_info.py
+++ b/plugins/modules/wafv2_web_acl_info.py
@@ -89,14 +89,14 @@ visibility_config:
     sampled_requests_enabled: false
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
 
 
 def get_web_acl(wafv2, name, scope, id, fail_json_aws):

--- a/plugins/modules/wafv2_web_acl_info.py
+++ b/plugins/modules/wafv2_web_acl_info.py
@@ -88,8 +88,9 @@ visibility_config:
     metric_name: blub
     sampled_requests_enabled: false
 """
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code, get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.community.aws.plugins.module_utils.wafv2 import wafv2_list_web_acls
 
 try:

--- a/scripts/inventory/ec2.py
+++ b/scripts/inventory/ec2.py
@@ -160,7 +160,8 @@ from ansible.module_utils.six.moves import configparser
 
 HAS_BOTO3 = False
 try:
-    import boto3  # noqa
+    # Used so that we can cleanly fail, some of our (optional) dependencies need this
+    import boto3  # pylint: disable=unused-import
     HAS_BOTO3 = True
 except ImportError:
     pass

--- a/scripts/inventory/ec2.py
+++ b/scripts/inventory/ec2.py
@@ -140,23 +140,22 @@ These settings would produce a destination_format as the following:
 'webserver-ansible-blue-172.31.0.1'
 '''
 
-import sys
-import os
 import argparse
+import json
+import os
 import re
-from time import time
+import sys
+from collections import defaultdict
 from copy import deepcopy
 from datetime import date, datetime
+from time import time
+
 import boto
 from boto import ec2
-from boto import rds
 from boto import elasticache
+from boto import rds
 from boto import route53
 from boto import sts
-
-from ansible.module_utils import six
-from ansible_collections.amazon.aws.plugins.module_utils import ec2 as ec2_utils
-from ansible.module_utils.six.moves import configparser
 
 HAS_BOTO3 = False
 try:
@@ -166,9 +165,10 @@ try:
 except ImportError:
     pass
 
-from collections import defaultdict
+from ansible.module_utils import six
+from ansible.module_utils.six.moves import configparser
+from ansible_collections.amazon.aws.plugins.module_utils import ec2 as ec2_utils
 
-import json
 
 DEFAULTS = {
     'all_elasticache_clusters': 'False',

--- a/tests/unit/compat/builtins.py
+++ b/tests/unit/compat/builtins.py
@@ -26,7 +26,7 @@ __metaclass__ = type
 # One unittest needs to import builtins via __import__() so we need to have
 # the string that represents it
 try:
-    import __builtin__
+    import __builtin__  # pylint: disable=unused-import
 except ImportError:
     BUILTINS = 'builtins'
 else:

--- a/tests/unit/plugins/modules/test_aws_acm.py
+++ b/tests/unit/plugins/modules/test_aws_acm.py
@@ -18,7 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 from ansible_collections.community.aws.plugins.modules.aws_acm import pem_chain_split, chain_compare
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_text
 from pprint import pprint
 
 

--- a/tests/unit/plugins/modules/test_aws_acm.py
+++ b/tests/unit/plugins/modules/test_aws_acm.py
@@ -17,12 +17,12 @@
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
-from ansible.module_utils._text import to_text
 
 from pprint import pprint
 
 from ansible_collections.community.aws.plugins.modules.aws_acm import chain_compare
 from ansible_collections.community.aws.plugins.modules.aws_acm import pem_chain_split
+from ansible.module_utils._text import to_text
 
 
 def test_chain_compare():

--- a/tests/unit/plugins/modules/test_aws_acm.py
+++ b/tests/unit/plugins/modules/test_aws_acm.py
@@ -17,9 +17,12 @@
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
-from ansible_collections.community.aws.plugins.modules.aws_acm import pem_chain_split, chain_compare
 from ansible.module_utils._text import to_text
+
 from pprint import pprint
+
+from ansible_collections.community.aws.plugins.modules.aws_acm import chain_compare
+from ansible_collections.community.aws.plugins.modules.aws_acm import pem_chain_split
 
 
 def test_chain_compare():

--- a/tests/unit/plugins/modules/test_aws_direct_connect_confirm_connection.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_confirm_connection.py
@@ -9,7 +9,6 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
-from ansible_collections.community.aws.tests.unit.compat.mock import MagicMock
 from ansible_collections.community.aws.tests.unit.compat.mock import patch
 from ansible_collections.community.aws.tests.unit.compat.mock import call
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import AnsibleExitJson

--- a/tests/unit/plugins/modules/test_aws_direct_connect_confirm_connection.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_confirm_connection.py
@@ -9,8 +9,8 @@ except ImportError:
     pass
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
-from ansible_collections.community.aws.tests.unit.compat.mock import patch
 from ansible_collections.community.aws.tests.unit.compat.mock import call
+from ansible_collections.community.aws.tests.unit.compat.mock import patch
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import AnsibleExitJson
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import AnsibleFailJson
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import ModuleTestCase

--- a/tests/unit/plugins/modules/test_aws_direct_connect_connection.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_connection.py
@@ -7,7 +7,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
+# Magic...  Incorrectly identified by pylint as unused
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
 from ansible_collections.community.aws.plugins.modules import aws_direct_connect_connection
 
 

--- a/tests/unit/plugins/modules/test_aws_direct_connect_connection.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_connection.py
@@ -8,7 +8,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 # Magic...  Incorrectly identified by pylint as unused
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
+
 from ansible_collections.community.aws.plugins.modules import aws_direct_connect_connection
 
 

--- a/tests/unit/plugins/modules/test_aws_direct_connect_link_aggregation_group.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_link_aggregation_group.py
@@ -10,7 +10,9 @@ __metaclass__ = type
 import pytest
 import os
 import collections
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
+
+# Magic...  Incorrectly identified by pylint as unused
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
 from ansible_collections.community.aws.plugins.modules import aws_direct_connect_link_aggregation_group as lag_module
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
 

--- a/tests/unit/plugins/modules/test_aws_direct_connect_link_aggregation_group.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_link_aggregation_group.py
@@ -12,9 +12,13 @@ import os
 import collections
 
 # Magic...  Incorrectly identified by pylint as unused
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+
 from ansible_collections.community.aws.plugins.modules import aws_direct_connect_link_aggregation_group as lag_module
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/plugins/modules/test_aws_direct_connect_virtual_interface.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_virtual_interface.py
@@ -7,7 +7,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
+# Magic...  Incorrectly identified by pylint as unused
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
 from ansible_collections.community.aws.plugins.modules import aws_direct_connect_virtual_interface
 
 

--- a/tests/unit/plugins/modules/test_aws_direct_connect_virtual_interface.py
+++ b/tests/unit/plugins/modules/test_aws_direct_connect_virtual_interface.py
@@ -8,7 +8,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 # Magic...  Incorrectly identified by pylint as unused
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
+
 from ansible_collections.community.aws.plugins.modules import aws_direct_connect_virtual_interface
 
 

--- a/tests/unit/plugins/modules/test_data_pipeline.py
+++ b/tests/unit/plugins/modules/test_data_pipeline.py
@@ -13,7 +13,8 @@ import collections
 
 import pytest
 # Magic...  Incorrectly identified by pylint as unused
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
 
 from ansible_collections.community.aws.plugins.modules import data_pipeline
 from ansible.module_utils._text import to_text

--- a/tests/unit/plugins/modules/test_data_pipeline.py
+++ b/tests/unit/plugins/modules/test_data_pipeline.py
@@ -7,17 +7,18 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import collections
 import os
 import json
-import collections
-
 import pytest
+
+from ansible.module_utils._text import to_text
+
 # Magic...  Incorrectly identified by pylint as unused
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
 
 from ansible_collections.community.aws.plugins.modules import data_pipeline
-from ansible.module_utils._text import to_text
 
 # test_api_gateway.py requires the `boto3` and `botocore` modules
 boto3 = pytest.importorskip('boto3')

--- a/tests/unit/plugins/modules/test_data_pipeline.py
+++ b/tests/unit/plugins/modules/test_data_pipeline.py
@@ -12,7 +12,8 @@ import json
 import collections
 
 import pytest
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
+# Magic...  Incorrectly identified by pylint as unused
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep  # pylint: disable=unused-import
 
 from ansible_collections.community.aws.plugins.modules import data_pipeline
 from ansible.module_utils._text import to_text

--- a/tests/unit/plugins/modules/test_ec2_vpc_vpn.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_vpn.py
@@ -6,8 +6,10 @@ __metaclass__ = type
 
 import pytest
 import os
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep
+
+# Magic...  Incorrectly identified by pylint as unused
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
 
 import ansible_collections.amazon.aws.plugins.module_utils.core as aws_core
 import ansible_collections.amazon.aws.plugins.module_utils.ec2 as aws_ec2

--- a/tests/unit/plugins/modules/test_ec2_vpc_vpn.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_vpn.py
@@ -4,8 +4,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import pytest
 import os
+import pytest
 
 # Magic...  Incorrectly identified by pylint as unused
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import

--- a/tests/unit/plugins/modules/test_lambda.py
+++ b/tests/unit/plugins/modules/test_lambda.py
@@ -17,6 +17,7 @@ from ansible_collections.community.aws.tests.unit.plugins.modules.utils import A
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import ModuleTestCase
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import set_module_args
 
+
 if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("lambda.py requires the `boto3` and `botocore` modules")
 

--- a/tests/unit/plugins/modules/test_lambda.py
+++ b/tests/unit/plugins/modules/test_lambda.py
@@ -11,13 +11,9 @@ __metaclass__ = type
 import copy
 import pytest
 
-from ansible.module_utils import basic
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
-from ansible_collections.community.aws.tests.unit.compat.mock import MagicMock
-from ansible_collections.community.aws.tests.unit.compat.mock import Mock
 from ansible_collections.community.aws.tests.unit.compat.mock import patch
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import AnsibleExitJson
-from ansible_collections.community.aws.tests.unit.plugins.modules.utils import AnsibleFailJson
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import ModuleTestCase
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import set_module_args
 


### PR DESCRIPTION
##### SUMMARY

Running a slightly more nit-picky pylint picked up on a number of unused imports.  For general code cleanliness we should clean these up.  (When we don't, we often see things copied and pasted all over the place)

Also
- reorders various imports (in the same files) based on the recommendations from PEP.
- splits imports (in the same files) onto single lines to make rebase-conflicts easier to fix.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/ec2_vpc_endpoint.py
plugins/modules/ec2_vpc_endpoint_info.py
plugins/modules/ec2_vpc_peering_info.py
plugins/modules/kinesis_stream.py
plugins/modules/wafv2_ip_set.py
plugins/modules/wafv2_ip_set_info.py
plugins/modules/wafv2_resources.py
plugins/modules/wafv2_resources_info.py
plugins/modules/wafv2_rule_group.py
plugins/modules/wafv2_rule_group_info.py
plugins/modules/wafv2_web_acl.py
plugins/modules/wafv2_web_acl_info.py
scripts/inventory/ec2.py
tests/unit/compat/builtins.py
tests/unit/plugins/modules/test_aws_acm.py
tests/unit/plugins/modules/test_aws_direct_connect_confirm_connection.py
tests/unit/plugins/modules/test_aws_direct_connect_connection.py
tests/unit/plugins/modules/test_aws_direct_connect_link_aggregation_group.py
tests/unit/plugins/modules/test_aws_direct_connect_virtual_interface.py
tests/unit/plugins/modules/test_data_pipeline.py
tests/unit/plugins/modules/test_ec2_vpc_vpn.py
tests/unit/plugins/modules/test_lambda.py

##### ADDITIONAL INFORMATION
