### PR TITLE
tests: use the new tiny_prefix variable

### DIFF
--- a/tests/integration/cloud-config-vcenter.ini
+++ b/tests/integration/cloud-config-vcenter.ini
@@ -1,0 +1,8 @@
+[DEFAULT]
+vcenter_username: administrator@vsphere.local
+vcenter_password: w$q-6(`C2/fS?!I#1Lie
+vcenter_hostname: vcenter.test
+vmware_validate_certs: false
+esxi1_username: zuul
+esxi1_hostname: esxi1.test
+esxi1_password: 8Td8BLBsiBfesj556

--- a/tests/integration/integration.cfg
+++ b/tests/integration/integration.cfg
@@ -1,0 +1,6 @@
+
+[persistent_connection]
+log_messages = True
+ssh_type = paramiko
+[defaults]
+log_path = ~/ansible-debug.txt

--- a/tests/integration/targets/aws_codebuild/defaults/main.yml
+++ b/tests/integration/targets/aws_codebuild/defaults/main.yml
@@ -3,5 +3,4 @@
 
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') | truncate(8, True, '') }}"
-iam_role_name: "ansible-test-sts-{{ unique_id }}-codebuild-service-role"
+iam_role_name: "ansible-test-sts-{{ tiny_prefix }}-codebuild-service-role"

--- a/tests/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/tests/integration/targets/aws_codepipeline/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # defaults file for aws_codepipeline
-unique_id: "{{ resource_prefix | hash('md5') }}"
-codepipeline_name: "{{ unique_id }}-test-codepipeline"
+codepipeline_name: "{{ tiny_prefix }}-test-codepipeline"
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-codepipeline_service_role_name: "ansible-test-sts-{{ unique_id | truncate(6, True, '') }}-codepipeline-role"
+codepipeline_service_role_name: "ansible-test-sts-{{ tiny_prefix | truncate(6, True, '') }}-codepipeline-role"

--- a/tests/integration/targets/aws_msk_cluster/defaults/main.yml
+++ b/tests/integration/targets/aws_msk_cluster/defaults/main.yml
@@ -7,7 +7,7 @@ vpc_subnets:
 vpc_subnet_name_prefix: "{{ resource_prefix }}"
 
 msk_config_name: "{{ resource_prefix }}-config"
-msk_cluster_name: "ansible-test-{{ (resource_prefix | hash('md5'))[:7] }}-msk-cluster"
+msk_cluster_name: "{{ tiny_prefix }}-msk-cluster"
 msk_version: 2.6.0
 msk_broker_nodes: 2
 

--- a/tests/integration/targets/aws_s3_bucket_info/defaults/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 name_pattern: "testbucket-ansible-integration"
-unique_id: "{{ resource_prefix | hash('md5') | truncate(24, True, '')  }}"
-
 testing_buckets:
-  - "{{ unique_id }}-{{ name_pattern }}-1"
-  - "{{ unique_id }}-{{ name_pattern }}-2"
+  - "{{ tiny_prefix }}-{{ name_pattern }}-1"
+  - "{{ tiny_prefix }}-{{ name_pattern }}-2"

--- a/tests/integration/targets/aws_ses_rule_set/defaults/main.yaml
+++ b/tests/integration/targets/aws_ses_rule_set/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
-default_rule_set: "{{ resource_prefix | hash('md5') }}-default-rule-set"
-second_rule_set: "{{ resource_prefix | hash('md5') }}-second-rule-set"
+default_rule_set: "{{ tiny_prefix }}-default-rule-set"
+second_rule_set: "{{ tiny_prefix }}-second-rule-set"
 
 # See comment in obtain-lock.yaml for definitions of these variables
 max_obtain_lock_attempts: 10

--- a/tests/integration/targets/aws_step_functions_state_machine/defaults/main.yml
+++ b/tests/integration/targets/aws_step_functions_state_machine/defaults/main.yml
@@ -1,5 +1,4 @@
 # the random_num is generated in a set_fact task at the start of the testsuite
-state_machine_name: "{{ resource_prefix | hash('md5') }}_step_function_{{ random_num }}"
-unique_id: "{{ resource_prefix | hash('md5') }}"
-step_functions_role_name: "ansible-test-{{ unique_id }}-step-function"
+state_machine_name: "{{ tiny_prefix }}_step_function_{{ random_num }}"
+step_functions_role_name: "ansible-test-{{ tiny_prefix }}-step-function"
 execution_name: "{{ resource_prefix }}_sfn_execution"

--- a/tests/integration/targets/ec2_launch_template/defaults/main.yml
+++ b/tests/integration/targets/ec2_launch_template/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 ec2_ami_name: amzn2-ami-hvm-2.*-x86_64-gp2
-test_role_name: ansible-test-{{ resource_prefix | hash('md5') }}
+test_role_name: ansible-test-{{ tiny_prefix }}

--- a/tests/integration/targets/elb_target/playbooks/roles/elb_lambda_target/defaults/main.yml
+++ b/tests/integration/targets/elb_target/playbooks/roles/elb_lambda_target/defaults/main.yml
@@ -1,5 +1,4 @@
-unique_id: "ansible-test-{{ resource_prefix | hash('md5') }}"
-lambda_role_name: '{{ unique_id }}-elb-target'
+lambda_role_name: '{{ tiny_prefix }}-elb-target'
 #lambda_role_name: '{{ resource_prefix }}-elb-target'
-lambda_name: '{{ unique_id }}-elb-target'
-elb_target_group_name: "{{ unique_id | truncate(8, True, '') }}-elb-tg"
+lambda_name: '{{ tiny_prefix }}-elb-target'
+elb_target_group_name: "{{ tiny_prefix | truncate(8, True, '') }}-elb-tg"

--- a/tests/integration/targets/elb_target/playbooks/roles/elb_target/defaults/main.yml
+++ b/tests/integration/targets/elb_target/playbooks/roles/elb_target/defaults/main.yml
@@ -1,10 +1,9 @@
 ---
 ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
 
-unique_id: "ansible-test-{{ resource_prefix | hash('md5') | truncate(8, True, '') }}"
-tg_name: "{{ unique_id }}-tg"
-tg_tcpudp_name: "{{ unique_id }}-tgtcpudp"
-lb_name: "{{ unique_id }}-lb"
+tg_name: "{{ tiny_prefix }}-tg"
+tg_tcpudp_name: "{{ tiny_prefix }}-tgtcpudp"
+lb_name: "{{ tiny_prefix }}-lb"
 
 healthy_state:
    state: 'healthy'

--- a/tests/integration/targets/elb_target/playbooks/version_fail.yml
+++ b/tests/integration/targets/elb_target/playbooks/version_fail.yml
@@ -14,8 +14,7 @@
       - name: set up testing target group (type=ip)
         elb_target_group:
           state: present
-          #name: "{{ unique_id }}-tg"
-          name: "ansible-test-{{ resource_prefix | regex_search('([0-9]+)$') }}-tg"
+          name: "{{ tiny_prefix }}-tg"
           health_check_port: 80
           protocol: http
           port: 80
@@ -37,5 +36,4 @@
       - name: Remove testing target group (type=ip)
         elb_target_group:
           state: absent
-          #name: "{{ unique_id }}-tg"
-          name: "ansible-test-{{ resource_prefix | regex_search('([0-9]+)$') }}-tg"
+          name: "{{ tiny_prefix }}-tg"

--- a/tests/integration/targets/lambda/defaults/main.yml
+++ b/tests/integration/targets/lambda/defaults/main.yml
@@ -2,6 +2,5 @@
 # defaults file for lambda integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') }}"
-lambda_function_name: '{{ unique_id }}'
-lambda_role_name: 'ansible-test-{{ unique_id }}-lambda'
+lambda_function_name: '{{ tiny_prefix }}'
+lambda_role_name: 'ansible-test-{{ tiny_prefix }}-lambda'

--- a/tests/integration/targets/lambda_alias/defaults/main.yml
+++ b/tests/integration/targets/lambda_alias/defaults/main.yml
@@ -2,6 +2,5 @@
 # defaults file for lambda integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') }}"
-lambda_function_name: 'ansible-test-{{ unique_id }}'
-lambda_role_name: 'ansible-test-{{ unique_id }}-lambda'
+lambda_function_name: 'ansible-test-{{ tiny_prefix }}'
+lambda_role_name: 'ansible-test-{{ tiny_prefix }}-lambda'

--- a/tests/integration/targets/lambda_policy/defaults/main.yml
+++ b/tests/integration/targets/lambda_policy/defaults/main.yml
@@ -2,6 +2,5 @@
 # defaults file for lambda_policy integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') }}"
-lambda_function_name: '{{ unique_id }}-api-endpoint'
-lambda_role_name: 'ansible-test-{{ unique_id }}-lambda-policy'
+lambda_function_name: '{{ tiny_prefix }}-api-endpoint'
+lambda_role_name: 'ansible-test-{{ tiny_prefix }}-lambda-policy'

--- a/tests/integration/targets/redshift/defaults/main.yml
+++ b/tests/integration/targets/redshift/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # defaults file for test_redshift
-unique_id: "{{ resource_prefix | hash('md5') }}"
-redshift_cluster_name: 'ansible-test-{{ unique_id }}'
+redshift_cluster_name: 'ansible-test-{{ tiny_prefix }}'
 reshift_master_password: "th1s_is_A_test"
 redshift_master_username: "master_user"
 node_type: "dc2.large"

--- a/tests/integration/targets/s3_bucket_notification/defaults/main.yml
+++ b/tests/integration/targets/s3_bucket_notification/defaults/main.yml
@@ -3,7 +3,6 @@
 lambda_function_name: '{{ resource_prefix }}'
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') |truncate(8, True, '') }}"
-bucket_name: '{{ unique_id }}-bucket'
-lambda_name: '{{ unique_id }}-lambda'
-lambda_role_name: 'ansible-test-{{ unique_id }}-s3-notifications'
+bucket_name: '{{ tiny_prefix }}-bucket'
+lambda_name: '{{ tiny_prefix }}-lambda'
+lambda_role_name: 'ansible-test-{{ tiny_prefix }}-s3-notifications'

--- a/tests/integration/targets/s3_lifecycle/defaults/main.yml
+++ b/tests/integration/targets/s3_lifecycle/defaults/main.yml
@@ -1,2 +1,1 @@
-unique_id: "{{ resource_prefix | hash('md5') |truncate(8, True, '') }}"
-bucket_name: '{{ unique_id }}-s3-lifecycle'
+bucket_name: '{{ tiny_prefix }}-s3-lifecycle'

--- a/tests/integration/targets/s3_logging/defaults/main.yml
+++ b/tests/integration/targets/s3_logging/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-unique_id: "{{ resource_prefix | hash('md5') |truncate(8, True, '') }}"                                               
-test_bucket: '{{ unique_id }}-s3-logging'
-log_bucket_1: '{{ unique_id }}-logs-1'
-log_bucket_2: '{{ unique_id }}-logs-2'
+test_bucket: '{{ tiny_prefix }}-s3-logging'
+log_bucket_1: '{{ tiny_prefix }}-logs-1'
+log_bucket_2: '{{ tiny_prefix }}-logs-2'

--- a/tests/integration/targets/s3_metrics_configuration/defaults/main.yml
+++ b/tests/integration/targets/s3_metrics_configuration/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-unique_id: "{{ resource_prefix | hash('md5') |truncate(8, True, '') }}"
-test_bucket: '{{ unique_id }}-testbucket'
+test_bucket: '{{ tiny_prefix }}-testbucket'

--- a/tests/integration/targets/s3_sync/defaults/main.yml
+++ b/tests/integration/targets/s3_sync/defaults/main.yml
@@ -1,3 +1,2 @@
-unique_id: "{{ resource_prefix | hash('md5') |truncate(8, True, '') }}"
-test_bucket: "{{ unique_id }}-testbucket-ansible"
-test_bucket_2: "{{ unique_id }}-testbucket-ansible-2"
+test_bucket: "{{ tiny_prefix }}-testbucket-ansible"
+test_bucket_2: "{{ tiny_prefix }}-testbucket-ansible-2"

--- a/tests/integration/targets/sns_topic/defaults/main.yml
+++ b/tests/integration/targets/sns_topic/defaults/main.yml
@@ -1,7 +1,5 @@
 # we hash the resource_prefix to get a shorter, unique string
-unique_id: "{{ resource_prefix | hash('md5') }}"
-
-sns_topic_topic_name: "ansible-test-{{ unique_id }}-topic"
+sns_topic_topic_name: "ansible-test-{{ tiny_prefix }}-topic"
 sns_topic_subscriptions:
   - endpoint: "{{ sns_topic_subscriber_arn }}"
     protocol: "lambda"
@@ -10,5 +8,5 @@ sns_topic_third_party_region: "{{ sns_topic_third_party_topic_arn.split(':')[3] 
 
 # additional test resource namings
 sns_topic_lambda_function: "sns_topic_lambda"
-sns_topic_lambda_name: "ansible-test-{{ unique_id }}-{{ sns_topic_lambda_function }}"
-sns_topic_lambda_role: "ansible-test-{{ unique_id }}-sns-lambda"
+sns_topic_lambda_name: "ansible-test-{{ tiny_prefix }}-{{ sns_topic_lambda_function }}"
+sns_topic_lambda_role: "ansible-test-{{ tiny_prefix }}-sns-lambda"

--- a/tests/integration/targets/sts_assume_role/defaults/main.yml
+++ b/tests/integration/targets/sts_assume_role/defaults/main.yml
@@ -1,2 +1,1 @@
-unique_id: "{{ resource_prefix | hash('md5') }}"
-iam_role_name: "ansible-test-sts-{{ unique_id }}"
+iam_role_name: "ansible-test-sts-{{ tiny_prefix }}"


### PR DESCRIPTION
##### SUMMARY

The new tiny_prefix variable has recently been introduced. It's
a 12 characters long string that is reused for the whole job.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests