### PR TITLE
Add support for SQS RawMessageDelievery attribute in subscriptions - issue #193

### DIFF
--- a/changelogs/fragments/640-sns_topic-sub_attr.yml
+++ b/changelogs/fragments/640-sns_topic-sub_attr.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sns_topic - Added ``attributes`` parameter to ``subscriptions`` items with support for RawMessageDelievery (SQS)

--- a/tests/integration/targets/sns_topic/defaults/main.yml
+++ b/tests/integration/targets/sns_topic/defaults/main.yml
@@ -1,8 +1,12 @@
 # we hash the resource_prefix to get a shorter, unique string
 sns_topic_topic_name: "ansible-test-{{ tiny_prefix }}-topic"
+sns_sqs_subscription_attributes: {}
 sns_topic_subscriptions:
   - endpoint: "{{ sns_topic_subscriber_arn }}"
     protocol: "lambda"
+  - endpoint: "{{ sns_topic_subscriber_sqs_arn }}"
+    protocol: sqs
+    attributes: "{{ sns_sqs_subscription_attributes }}"
 sns_topic_third_party_topic_arn: "arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged"
 sns_topic_third_party_region: "{{ sns_topic_third_party_topic_arn.split(':')[3] }}"
 
@@ -10,3 +14,5 @@ sns_topic_third_party_region: "{{ sns_topic_third_party_topic_arn.split(':')[3] 
 sns_topic_lambda_function: "sns_topic_lambda"
 sns_topic_lambda_name: "ansible-test-{{ tiny_prefix }}-{{ sns_topic_lambda_function }}"
 sns_topic_lambda_role: "ansible-test-{{ tiny_prefix }}-sns-lambda"
+
+sns_topic_sqs_name: "ansible-test-{{ tiny_prefix }}-sns"

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -251,6 +251,14 @@
       - delivery_policy.http.defaultHealthyRetryPolicy.maxDelayTarget == 40
       - delivery_policy.http.defaultHealthyRetryPolicy.numRetries == 6
 
+  - name: create SQS queue for subscribing
+    sqs_queue:
+      name: '{{ sns_topic_sqs_name }}'
+    register: sqs_result
+
+  - set_fact:
+      sns_topic_subscriber_sqs_arn: '{{ sqs_result.queue_arn }}'
+
   - name: create temp dir
     tempfile:
       state: directory
@@ -287,7 +295,37 @@
     assert:
       that:
       - sns_topic_subscribe.changed
-      - sns_topic_subscribe.sns_topic.subscriptions|length == 1
+      - sns_topic_subscribe.sns_topic.subscriptions|length == 2
+
+  - name: enable raw message delivery for sqs subscription (attributes)
+    set_fact:
+      sns_sqs_subscription_attributes:
+        RawMessageDelivery: true
+
+  - name: update topic subscriptions - raw message enabled
+    sns_topic:
+      name: '{{ sns_topic_topic_name }}'
+      display_name: My new topic name
+      purge_subscriptions: false
+      subscriptions: '{{ sns_topic_subscriptions }}'
+    register: sns_topic_subscribe_update_raw_on
+
+  - name: assert sqs subscription was updated
+    assert:
+      that:
+        - sns_topic_subscribe_update_raw_on.changed
+
+  - name: rerun topic subscriptions with raw message enabled - expect no changes
+    sns_topic:
+      name: '{{ sns_topic_topic_name }}'
+      display_name: My new topic name
+      purge_subscriptions: false
+      subscriptions: '{{ sns_topic_subscriptions }}'
+    register: rerun_sns_topic_subscribe_update_raw_on
+  - name: assert no changes after rerun
+    assert:
+      that:
+        - not rerun_sns_topic_subscribe_update_raw_on.changed
 
   - name: run again with purge_subscriptions set to false
     sns_topic:
@@ -300,7 +338,7 @@
     assert:
       that:
       - not sns_topic_no_purge.changed
-      - sns_topic_no_purge.sns_topic.subscriptions|length == 1
+      - sns_topic_no_purge.sns_topic.subscriptions|length == 2
 
   - name: run again with purge_subscriptions set to true
     sns_topic:
@@ -319,6 +357,10 @@
       name: '{{ sns_topic_topic_name }}'
       state: absent
 
+  - name: remove subscription attributes before dealing with third party topic
+    set_fact:
+      sns_sqs_subscription_attributes: {}
+
   - name: no-op with third party topic (effectively get existing subscriptions)
     sns_topic:
       name: '{{ sns_topic_third_party_topic_arn }}'
@@ -336,7 +378,7 @@
     assert:
       that:
       - third_party_topic_subscribe is changed
-      - (third_party_topic_subscribe.sns_topic.subscriptions|length) - (third_party_topic.sns_topic.subscriptions|length) == 1
+      - (third_party_topic_subscribe.sns_topic.subscriptions|length) - (third_party_topic.sns_topic.subscriptions|length) == 2
 
   - name: attempt to change name of third party topic
     sns_topic:
@@ -409,6 +451,12 @@
   - name: remove lambda
     lambda:
       name: '{{ sns_topic_lambda_name }}'
+      state: absent
+    ignore_errors: true
+
+  - name: remove SQS queue
+    sqs_queue:
+      name: '{{ sns_topic_sqs_name }}'
       state: absent
     ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support to configure `RawMessageDelievery` option when configuring sqs endpoints.

It use boto3 `set_subscription_attributes()` to configure changes.
It currently supports only this option, but should be easily extended in the future. 

Attributes are expected in the form as in the boto3 docs:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.set_subscription_attributes

Fixes https://github.com/ansible-collections/community.aws/issues/193
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
updates sns_topic.py to support new functionality

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
example:

- sns_topic:
    name: '{{ sns_topic_topic_name }}'
    display_name: My new topic name
    subscriptions:
    - endpoint: "{{ sqs_arn }}"
      protocol: sqs
      attributes:
        RawMessageDelivery: true
```