### PR TITLE
tests: flag elb_application_lb as slow

### DIFF
--- a/tests/integration/targets/elb_application_lb/aliases
+++ b/tests/integration/targets/elb_application_lb/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+slow


### PR DESCRIPTION
##### SUMMARY

elb_application_lb can take more than to 15 minutes to run.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests