### PR TITLE
tests: disable ec2_vpc_endpoint

### DIFF
--- a/tests/integration/targets/ec2_vpc_endpoint/aliases
+++ b/tests/integration/targets/ec2_vpc_endpoint/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-
+disabled
 ec2_vpc_endpoint_info


### PR DESCRIPTION
##### SUMMARY

Its test-suite fails in the CI.
See: https://github.com/ansible-collections/community.aws/issues/642


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
