### PR TITLE
Fix idempotency and logic to update existing aggregator

### DIFF
--- a/changelogs/fragments/645-aws_config_aggregator-fix-update-and-idempotency.yml
+++ b/changelogs/fragments/645-aws_config_aggregator-fix-update-and-idempotency.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - aws_config_aggregator - Fix idempotency when ``account_sources`` parameter is not specified (https://github.com/ansible-collections/community.aws/pull/645).
+  - aws_config_aggregator - Fix `KeyError` when updating existing aggregator (https://github.com/ansible-collections/community.aws/pull/645).

--- a/plugins/modules/aws_config_aggregator.py
+++ b/plugins/modules/aws_config_aggregator.py
@@ -14,6 +14,7 @@ version_added: 1.0.0
 short_description: Manage AWS Config aggregations across multiple accounts
 description:
     - Module manages AWS Config resources
+requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
 options:
@@ -128,13 +129,13 @@ def create_resource(client, module, params, result):
 def update_resource(client, module, params, result):
     current_params = client.describe_configuration_aggregators(
         ConfigurationAggregatorNames=[params['ConfigurationAggregatorName']]
-    )
+    )['ConfigurationAggregators'][0]
 
     del current_params['ConfigurationAggregatorArn']
     del current_params['CreationTime']
     del current_params['LastUpdatedTime']
 
-    if params != current_params['ConfigurationAggregators'][0]:
+    if params != current_params:
         try:
             client.put_configuration_aggregator(
                 ConfigurationAggregatorName=params['ConfigurationAggregatorName'],
@@ -180,8 +181,8 @@ def main():
     params = {}
     if name:
         params['ConfigurationAggregatorName'] = name
-    params['AccountAggregationSources'] = []
     if module.params.get('account_sources'):
+        params['AccountAggregationSources'] = []
         for i in module.params.get('account_sources'):
             tmp_dict = {}
             if i.get('account_ids'):

--- a/plugins/modules/aws_config_aggregator.py
+++ b/plugins/modules/aws_config_aggregator.py
@@ -133,10 +133,10 @@ def update_resource(client, module, params, result):
     )['ConfigurationAggregators'][0]
 
     if params['AccountAggregationSources'] != current_params.get('AccountAggregationSources', []):
-       result['changed'] = True
+        result['changed'] = True
 
     if params['OrganizationAggregationSource'] != current_params.get('OrganizationAggregationSource', {}):
-       result['changed'] = True
+        result['changed'] = True
 
     if result['changed']:
         try:

--- a/tests/integration/targets/aws_config/tasks/main.yaml
+++ b/tests/integration/targets/aws_config/tasks/main.yaml
@@ -158,7 +158,7 @@
         name: random_name
         state: present
         account_sources: []
-        organization_source: 
+        organization_source:
           all_aws_regions: true
           role_arn: "{{ config_iam_role.arn }}"
       register: output
@@ -168,7 +168,7 @@
       assert:
         that:
            - output.failed
-           - 'output.msg.startswith("missing required arguments: organization_source")'
+           - output.changed
 
     # ============================================================
     # Creation testing

--- a/tests/integration/targets/aws_config/tasks/main.yaml
+++ b/tests/integration/targets/aws_config/tasks/main.yaml
@@ -153,6 +153,23 @@
            - output.failed
            - 'output.msg.startswith("missing required arguments: organization_source")'
 
+    - name: test resource_type configuration_aggregator with organization_source parameter
+      aws_config_aggregator:
+        name: random_name
+        state: present
+        account_sources: []
+        organization_source: 
+          all_aws_regions: true
+          role_arn: "{{ config_iam_role.arn }}"
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with organization_source parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("missing required arguments: organization_source")'
+
     # ============================================================
     # Creation testing
     # ============================================================

--- a/tests/integration/targets/aws_config/tasks/main.yaml
+++ b/tests/integration/targets/aws_config/tasks/main.yaml
@@ -153,23 +153,6 @@
            - output.failed
            - 'output.msg.startswith("missing required arguments: organization_source")'
 
-    - name: test resource_type configuration_aggregator with organization_source parameter
-      aws_config_aggregator:
-        name: random_name
-        state: present
-        account_sources: []
-        organization_source:
-          all_aws_regions: true
-          role_arn: "{{ config_iam_role.arn }}"
-      register: output
-      ignore_errors: true
-
-    - name: assert failure when called with organization_source parameter
-      assert:
-        that:
-           - output.failed
-           - output.changed
-
     # ============================================================
     # Creation testing
     # ============================================================
@@ -217,6 +200,36 @@
     - assert:
         that:
           - output.changed
+
+    - name: Create aws_config_aggregator
+      aws_config_aggregator:
+        name: random_name
+        state: present
+        account_sources: []
+        organization_source:
+          all_aws_regions: true
+          role_arn: "{{ config_iam_role.arn }}"
+      register: output
+
+    - name: assert success
+      assert:
+        that:
+           - output is changed
+
+    - name: Create aws_config_aggregator - idempotency
+      aws_config_aggregator:
+        name: random_name
+        state: present
+        account_sources: []
+        organization_source:
+          all_aws_regions: true
+          role_arn: "{{ config_iam_role.arn }}"
+      register: output
+
+    - name: assert not changed
+      assert:
+        that:
+           - output is not changed
 
     # ============================================================
     # Update testing
@@ -266,6 +279,40 @@
     - assert:
         that:
           - output.changed
+
+    - name: Update aws_config_aggregator
+      aws_config_aggregator:
+        name: random_name
+        state: present
+        account_sources: []
+        organization_source:
+          all_aws_regions: false
+          aws_regions:
+            - '{{ aws_region }}'
+          role_arn: "{{ config_iam_role.arn }}"
+      register: output
+
+    - name: assert success
+      assert:
+        that:
+           - output is changed
+
+    - name: Update aws_config_aggregator - idempotency
+      aws_config_aggregator:
+        name: random_name
+        state: present
+        account_sources: []
+        organization_source:
+          all_aws_regions: false
+          aws_regions:
+            - '{{ aws_region }}'
+          role_arn: "{{ config_iam_role.arn }}"
+      register: output
+
+    - name: assert success
+      assert:
+        that:
+           - output is not changed
 
     # ============================================================
     # Read testing
@@ -317,6 +364,14 @@
           - not output.changed
 
   always:
+
+    - name: delete aws_config_aggregator
+      aws_config_aggregator:
+        name: random_name
+        state: absent
+      register: output
+      ignore_errors: true
+
     # ============================================================
     # Destroy testing
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`describe_configuration_aggregators` method returns output similar
to the following:

```
{
    "ConfigurationAggregators": [
        {
            "ConfigurationAggregatorName": "test-name",
            "ConfigurationAggregatorArn": "arn:aws:config:us-east-1:123412341234:config-aggregator/config-aggregator-xbxbvyq5",
            "OrganizationAggregationSource": {
                "RoleArn": "arn:aws:iam::123412341234:role/my-role",
                "AllAwsRegions": true
            },
            "CreationTime": 1619030767.047,
            "LastUpdatedTime": 1626463216.998
        }
    ]
}
```

As a result, lines 134-136 fail:

```
    del current_params['ConfigurationAggregatorArn']
    del current_params['CreationTime']
    del current_params['LastUpdatedTime']
```
as they try to delete attributes from the `current_params` as opposed
to `current_params['ConfigurationAggregators'][0]`.

The error message is:
```
KeyError: 'ConfigurationAggregators'
```

Additionally, if no `account_sources` attribute is specified, the module
fails idempotency check, because in that case `AccountAggregationSources`
attribute is present in `params`, but not in `current_params`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_config_aggregator

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->