### PR TITLE
Add keys_attr parameter to aws_kms_info

### DIFF
--- a/changelogs/fragments/648-kms_info.yml
+++ b/changelogs/fragments/648-kms_info.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- kms_info - added a new ``keys_attr`` parameter to continue returning the key details in the ``keys`` attribute as well as the ``kms_keys`` attribute (https://github.com/ansible-collections/community.aws/pull/648).
+breaking_changes:
+- kms_info - key details are now returned in the ``kms_keys`` attribute rather than the ``keys`` attribute (https://github.com/ansible-collections/community.aws/pull/648).


### PR DESCRIPTION
##### SUMMARY

Move the kms_info return value from "keys" (which conflicts with keys()) to kms_keys.  Add a parameter to support the old version

Fixes #597 

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

aws_kms_info

##### ADDITIONAL INFORMATION
