### PR TITLE
Update remaining _info modules so that they run in check_mode

### DIFF
--- a/changelogs/fragments/659-checkmode.yml
+++ b/changelogs/fragments/659-checkmode.yml
@@ -1,0 +1,8 @@
+minor_changes:
+- aws_sgw_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- ec2_asg_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- ec2_lc_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- iam_mfa_device_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- iam_server_certificate_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- wafv2_resources_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- wafv2_web_acl_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).

--- a/plugins/modules/aws_sgw_info.py
+++ b/plugins/modules/aws_sgw_info.py
@@ -343,7 +343,11 @@ def main():
         gather_volumes=dict(type='bool', default=True)
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
     if module._name == 'aws_sgw_facts':
         module.deprecate("The 'aws_sgw_facts' module has been renamed to 'aws_sgw_info'", date='2021-12-01', collection_name='community.aws')
     client = module.client('storagegateway')

--- a/plugins/modules/ec2_asg_info.py
+++ b/plugins/modules/ec2_asg_info.py
@@ -438,7 +438,12 @@ def main():
         name=dict(type='str'),
         tags=dict(type='dict'),
     )
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
     if module._name == 'ec2_asg_facts':
         module.deprecate("The 'ec2_asg_facts' module has been renamed to 'ec2_asg_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/ec2_lc_info.py
+++ b/plugins/modules/ec2_lc_info.py
@@ -207,7 +207,11 @@ def main():
         sort_end=dict(required=False, type='int'),
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
     if module._name == 'ec2_lc_facts':
         module.deprecate("The 'ec2_lc_facts' module has been renamed to 'ec2_lc_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/iam_mfa_device_info.py
+++ b/plugins/modules/iam_mfa_device_info.py
@@ -87,7 +87,10 @@ def main():
         user_name=dict(required=False, default=None),
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
     if module._name == 'iam_mfa_device_facts':
         module.deprecate("The 'iam_mfa_device_facts' module has been renamed to 'iam_mfa_device_info'", date='2021-12-01', collection_name='community.aws')
 

--- a/plugins/modules/iam_server_certificate_info.py
+++ b/plugins/modules/iam_server_certificate_info.py
@@ -142,7 +142,11 @@ def main():
         name=dict(type='str'),
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec,)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
     if module._name == 'iam_server_certificate_facts':
         module.deprecate("The 'iam_server_certificate_facts' module has been renamed to 'iam_server_certificate_info'",
                          date='2021-12-01', collection_name='community.aws')

--- a/plugins/modules/wafv2_resources_info.py
+++ b/plugins/modules/wafv2_resources_info.py
@@ -93,7 +93,8 @@ def main():
     )
 
     module = AnsibleAWSModule(
-        argument_spec=arg_spec
+        argument_spec=arg_spec,
+        supports_check_mode=True,
     )
 
     name = module.params.get("name")

--- a/plugins/modules/wafv2_web_acl_info.py
+++ b/plugins/modules/wafv2_web_acl_info.py
@@ -119,7 +119,8 @@ def main():
     )
 
     module = AnsibleAWSModule(
-        argument_spec=arg_spec
+        argument_spec=arg_spec,
+        supports_check_mode=True,
     )
 
     state = module.params.get("state")


### PR DESCRIPTION
##### SUMMARY

Update remaining _info modules so that they run in check_mode

https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#development-conventions
https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_best_practices.html#following-ansible-conventions

fixes: https://github.com/ansible-collections/community.aws/issues/659

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_sgw_info
ec2_asg_info
ec2_lc_info
iam_mfa_device_info
iam_server_certificate_info
wafv2_resources_info
wafv2_web_acl_info

##### ADDITIONAL INFORMATION

cc: @felixfontein 

It would be good to get this in before the upcoming sanity check: https://github.com/ansible/ansible/pull/75324

amazon.aws/pull/405


Depends-on: ansible/ansible-zuul-jobs#1014