### PR TITLE
Formally start the rds deprecation process

### DIFF
--- a/changelogs/fragments/663-deprecate-rds.yml
+++ b/changelogs/fragments/663-deprecate-rds.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- rds - the boto based ``rds`` module has been deprecated in favour of the boto3 based ``rds_instance`` module.
+  The ``rds`` module will be removed in release 3.0.0 (https://github.com/ansible-collections/community.aws/pull/663).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -481,6 +481,13 @@ plugin_routing:
           lambda_facts has been deprecated and will be removed.
           The lambda_info module returns the same information, but not as
           ansible_facts.  See the module documentation for more information.
+    rds:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: >-
+            The rds module is based upon a deprecated version of the AWS SDKs
+            and is deprecated in favor of the rds_instance and rds_snapshot modules.
+            Please update your tasks.
     rds_instance_facts:
       deprecation:
         removal_date: 2021-12-01

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -10,13 +10,16 @@ DOCUMENTATION = r'''
 ---
 module: rds
 version_added: 1.0.0
+deprecated:
+  removed_in: 3.0.0
+  why: The rds module is based upon a deprecated version of the AWS SDK.
+  alternative: Use M(rds_instance), M(rds_instance_info), and M(rds_snapshot).
 short_description: create, delete, or modify Amazon rds instances, rds snapshots, and related facts
 description:
     - Creates, deletes, or modifies rds resources.
     - When creating an instance it can be either a new instance or a read-only replica of an existing instance.
-    - This module has a dependency on python-boto >= 2.5 and will soon be deprecated.
     - The 'promote' command requires boto >= 2.18.0. Certain features such as tags rely on boto.rds2 (boto >= 2.26.0).
-    - Please use boto3 based M(community.aws.rds_instance) instead.
+    - Please use the boto3 based M(community.aws.rds_instance) instead.
 options:
   command:
     description:
@@ -1353,6 +1356,9 @@ def main():
         argument_spec=argument_spec,
         check_boto3=False,
     )
+
+    module.deprecate("The 'rds' module has been deprecated and replaced by the 'rds_instance' module'",
+                     version='3.0.0', collection_name='community.aws')
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1804,6 +1804,8 @@ plugins/modules/rds.py import-3.5!skip
 plugins/modules/rds.py import-3.6!skip
 plugins/modules/rds.py import-3.7!skip
 plugins/modules/rds.py metaclass-boilerplate!skip
+plugins/modules/rds.py validate-modules:deprecation-mismatch  # Ansible 2.9 docs don't support deprecation properly
+plugins/modules/rds.py validate-modules:invalid-documentation  # Ansible 2.9 docs don't support deprecation properly
 plugins/modules/rds_instance.py compile-2.6!skip
 plugins/modules/rds_instance.py compile-2.7!skip
 plugins/modules/rds_instance.py compile-3.5!skip


### PR DESCRIPTION
##### SUMMARY

The rds module is based upon the deprecated `boto` (not `boto3`/`botocore`) SDK and its functionality has been replaced by the rds_instance, rds_snapshot and rds_instance_info modules.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

rds

##### ADDITIONAL INFORMATION

See also https://github.com/ansible-collections/community.aws/issues/632