### PR TITLE
Fixup ec2_vpc_endpoint_service_info test failures

### DIFF
--- a/tests/integration/targets/ec2_vpc_endpoint_service_info/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint_service_info/tasks/main.yml
@@ -5,13 +5,9 @@
       aws_secret_key: '{{ aws_secret_key }}'
       security_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
-    # Needed until added to the group in Ansible 2.9
-    ec2_vpc_endpoint_service_info:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
-
+  collections:
+    - amazon.aws
+    - community.aws
   block:
 
   - name: 'List all available services (Check Mode)'


### PR DESCRIPTION
##### SUMMARY

We've been seeing failures with ec2_vpc_endpoint_service_info integration tests which look to be related to ansible 2.12 changes

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_endpoint_service_info

##### ADDITIONAL INFORMATION

https://dashboard.zuul.ansible.com/t/ansible/build/db72a3848b964f41a720ac7632aa2848/log/job-output.txt

```
ERROR! Could not resolve action ansible.legacy.ec2_vpc_endpoint_service_info in module_defaults
```
