### PR TITLE
sns_topic_info new module

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -172,6 +172,7 @@ action_groups:
   - s3_website
   - sns
   - sns_topic
+  - sns_topic_info
   - sqs_queue
   - sts_assume_role
   - sts_session_token

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -12,15 +12,14 @@ module: sns_topic_info
 short_description: sns_topic_info module
 version_added: 3.2.0
 description:
-  - The M(community.aws.sns_topic_info) module allows to get all AWS SNS topics or properties of a specific AWS SNS topic.
+- The M(community.aws.sns_topic_info) module allows to get all AWS SNS topics or properties of a specific AWS SNS topic.
 author:
 - "Alina Buzachis (@alinabuzachis)"
 options:
-  topic_arn:
-    description:
-      - The ARN of the AWS SNS topic for which you wish to find subscriptions or list attributes.
-    required: false
-    type: str
+    topic_arn:
+        description: The ARN of the AWS SNS topic for which you wish to find subscriptions or list attributes.
+        required: false
+        type: str
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -38,11 +37,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-changed:
-  description: True if listing the AWS SNS topics succeeds
-  type: bool
-  returned: always
-  sample: false
 result:
   description:
     - The result contaning the details of one or all AWS SNS topics.
@@ -55,80 +49,80 @@ result:
         returned: always
         sample: "arn:aws:sns:us-east-2:111111111111:my_topic_name"
     sns_topic:
-        description: Dict of sns topic details
+        description: Dict of sns topic details.
         type: complex
         returned: always
         contains:
             delivery_policy:
-                description: Delivery policy for the SNS topic
+                description: Delivery policy for the SNS topic.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: >
                     {"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,
                     "numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}}
             display_name:
-                description: Display name for SNS topic
+                description: Display name for SNS topic.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: My topic name
             owner:
-                description: AWS account that owns the topic
+                description: AWS account that owns the topic.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: '111111111111'
             policy:
-                description: Policy for the SNS topic
+                description: Policy for the SNS topic.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: >
                     {"Version":"2012-10-17","Id":"SomePolicyId","Statement":[{"Sid":"ANewSid","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111111111:root"},
                     "Action":"sns:Subscribe","Resource":"arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic","Condition":{"StringEquals":{"sns:Protocol":"email"}}}]}
             subscriptions:
-                description: List of subscribers to the topic in this AWS account
+                description: List of subscribers to the topic in this AWS account.
                 returned: always
                 type: list
                 sample: []
             subscriptions_added:
-                description: List of subscribers added in this run
+                description: List of subscribers added in this run.
                 returned: always
                 type: list
                 sample: []
             subscriptions_confirmed:
-                description: Count of confirmed subscriptions
+                description: Count of confirmed subscriptions.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: '0'
             subscriptions_deleted:
-                description: Count of deleted subscriptions
+                description: Count of deleted subscriptions.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: '0'
             subscriptions_existing:
-                description: List of existing subscriptions
+                description: List of existing subscriptions.
                 returned: always
                 type: list
                 sample: []
             subscriptions_new:
-                description: List of new subscriptions
+                description: List of new subscriptions.
                 returned: always
                 type: list
                 sample: []
             subscriptions_pending:
-                description: Count of pending subscriptions
+                description: Count of pending subscriptions.
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: '0'
             subscriptions_purge:
-                description: Whether or not purge_subscriptions was set
+                description: Whether or not purge_subscriptions was set.
                 returned: always
                 type: bool
                 sample: true
             topic_arn:
-                description: ARN of the SNS topic (equivalent to sns_arn)
+                description: ARN of the SNS topic (equivalent to sns_arn).
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic
-              topic_type:
+            topic_type:
                 description: The type of topic.
                 type: str
                 sample: "standard"

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+module: sns_topic_info
+short_description: sns_topic_info module
+version_added: 2.0.0
+description:
+    - The M(community.aws.sns_topic_info) module allows to get all AWS SNS topics or properties of a specific AWS SNS topic.
+author:
+  - "Alina Buzachis (@alinabuzachis)"
+options:
+  topic_arn:
+    description:
+      - TThe ARN of the AWS SNS topic for which you wish to find subscriptions or list attributes.
+    required: false
+    type: str
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+'''
+
+EXAMPLES = r"""
+
+"""
+
+RETURN = r'''
+changed:
+  description: True if listing the AWS SNS topics succeeds
+  type: bool
+  returned: always
+  sample: false
+result:
+  description:
+    - The result contaning the details of one or all AWS SNS topics.
+  returned: suceess
+  type: list
+  contains:
+    sns_arn:
+        description: The ARN of the topic.
+        type: str
+        returned: always
+        sample: "arn:aws:sns:us-east-2:111111111111:my_topic_name"
+    sns_topic:
+        description: Dict of sns topic details
+        type: complex
+        returned: always
+        contains:
+            delivery_policy:
+                description: Delivery policy for the SNS topic
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: >
+                {"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,
+                "numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}}
+            display_name:
+                description: Display name for SNS topic
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: My topic name
+            owner:
+                description: AWS account that owns the topic
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: '111111111111'
+            policy:
+                description: Policy for the SNS topic
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: >
+                {"Version":"2012-10-17","Id":"SomePolicyId","Statement":[{"Sid":"ANewSid","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111111111:root"},
+                "Action":"sns:Subscribe","Resource":"arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic","Condition":{"StringEquals":{"sns:Protocol":"email"}}}]}
+            subscriptions:
+                description: List of subscribers to the topic in this AWS account
+                returned: always
+                type: list
+                sample: []
+            subscriptions_confirmed:
+                description: Count of confirmed subscriptions
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: '0'
+            subscriptions_deleted:
+                description: Count of deleted subscriptions
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: '0'
+            subscriptions_pending:
+                description: Count of pending subscriptions
+                returned: when topic is owned by this AWS account
+                type: str
+                sample: '0'
+            topic_arn:
+            description: ARN of the SNS topic (equivalent to sns_arn)
+            returned: when topic is owned by this AWS account
+            type: str
+            sample: arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic
+'''
+
+
+import json
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+
+
+@AWSRetry.jittered_backoff()
+def _list_topics_with_backoff(connection):
+    paginator = connection.get_paginator('list_topics')
+    return paginator.paginate().build_full_result()['Topics']
+
+
+@AWSRetry.jittered_backoff(catch_extra_error_codes=['NotFound'])
+def _list_topic_subscriptions_with_backoff(connection, topic_arn):
+    paginator = connection.get_paginator('list_subscriptions_by_topic')
+    return paginator.paginate(TopicArn=topic_arn).build_full_result()['Subscriptions']
+
+
+@AWSRetry.jittered_backoff(catch_extra_error_codes=['NotFound'])
+def _list_subscriptions_with_backoff(connection):
+    paginator = connection.get_paginator('list_subscriptions')
+    return paginator.paginate().build_full_result()['Subscriptions']
+
+
+def _list_topic_subscriptions(connection, module, topic_arn):
+        try:
+            return _list_topic_subscriptions_with_backoff(connection, topic_arn)
+        except is_boto3_error_code('AuthorizationError'):
+            try:
+                # potentially AuthorizationError when listing subscriptions for third party topic
+                return [sub for sub in _list_subscriptions_with_backoff()
+                        if sub['TopicArn'] == topic_arn]
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't get subscriptions list for topic %s" % topic_arn)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(e, msg="Couldn't get subscriptions list for topic %s" % topic_arn)
+
+
+def list_topics(connection, module):
+    try:
+        topics = _list_topics_with_backoff(connection)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't get topic list")
+    
+    return [get_info(connection, module, t['TopicArn']) for t in topics]
+
+
+def get_info(connection, module, topic_arn):
+    info = {
+        'sns_arn': topic_arn,
+    }
+    try:
+        info['sns_topic'] = camel_dict_to_snake_dict(connection.get_topic_attributes(TopicArn=topic_arn)['Attributes'])
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't get attributes for topic.")
+
+    info['sns_topic']['delivery_policy'] = json.loads(info['sns_topic'].pop('effective_delivery_policy'))
+    info['sns_topic']['policy'] = json.loads(info['sns_topic']['policy'])
+    info['sns_topic']['subscriptions'] = [camel_dict_to_snake_dict(sub) for sub in _list_topic_subscriptions(connection, module, topic_arn)]
+
+    return info
+
+
+def main():
+    argument_spec = dict(
+        topic_arn=dict(type='str', required=False),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True)
+
+    topic_arn = module.params.get('topic_arn')
+    check_mode = module.check_mode
+
+    try:
+        connection = module.client('sns', retry_decorator=AWSRetry.jittered_backoff())
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Failed to connect to AWS.')
+    
+    if topic_arn:
+        results = get_info(connection, module, topic_arn)
+    else:
+        results = list_topics(connection, module)
+
+    module.exit_json(result=results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -46,7 +46,7 @@ changed:
 result:
   description:
     - The result contaning the details of one or all AWS SNS topics.
-  returned: suceess
+  returned: success
   type: list
   contains:
     sns_arn:
@@ -63,10 +63,9 @@ result:
                 description: Delivery policy for the SNS topic
                 returned: when topic is owned by this AWS account
                 type: str
-                sample: {
-                    "http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,
-                    "numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}
-                }
+                sample: >
+                    {"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,
+                    "numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}}
             display_name:
                 description: Display name for SNS topic
                 returned: when topic is owned by this AWS account
@@ -81,12 +80,16 @@ result:
                 description: Policy for the SNS topic
                 returned: when topic is owned by this AWS account
                 type: str
-                sample: {
-                    "Version":"2012-10-17","Id":"SomePolicyId","Statement":[{"Sid":"ANewSid","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111111111:root"},
-                    "Action":"sns:Subscribe","Resource":"arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic","Condition":{"StringEquals":{"sns:Protocol":"email"}}}]
-                }
+                sample: >
+                    {"Version":"2012-10-17","Id":"SomePolicyId","Statement":[{"Sid":"ANewSid","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111111111:root"},
+                    "Action":"sns:Subscribe","Resource":"arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic","Condition":{"StringEquals":{"sns:Protocol":"email"}}}]}
             subscriptions:
                 description: List of subscribers to the topic in this AWS account
+                returned: always
+                type: list
+                sample: []
+            subscriptions_added:
+                description: List of subscribers added in this run
                 returned: always
                 type: list
                 sample: []
@@ -100,16 +103,35 @@ result:
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: '0'
+            subscriptions_existing:
+                description: List of existing subscriptions
+                returned: always
+                type: list
+                sample: []
+            subscriptions_new:
+                description: List of new subscriptions
+                returned: always
+                type: list
+                sample: []
             subscriptions_pending:
                 description: Count of pending subscriptions
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: '0'
+            subscriptions_purge:
+                description: Whether or not purge_subscriptions was set
+                returned: always
+                type: bool
+                sample: true
             topic_arn:
                 description: ARN of the SNS topic (equivalent to sns_arn)
                 returned: when topic is owned by this AWS account
                 type: str
                 sample: arn:aws:sns:us-east-2:111111111111:ansible-test-dummy-topic
+              topic_type:
+                description: The type of topic.
+                type: str
+                sample: "standard"
 '''
 
 

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: sns_topic_info
 short_description: sns_topic_info module
-version_added: 3.1.0
+version_added: 3.2.0
 description:
   - The M(community.aws.sns_topic_info) module allows to get all AWS SNS topics or properties of a specific AWS SNS topic.
 author:

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: sns_topic_info
 short_description: sns_topic_info module
-version_added: 3.0.0
+version_added: 3.1.0
 description:
   - The M(community.aws.sns_topic_info) module allows to get all AWS SNS topics or properties of a specific AWS SNS topic.
 author:

--- a/tests/integration/targets/sns_topic/aliases
+++ b/tests/integration/targets/sns_topic/aliases
@@ -1,1 +1,3 @@
 cloud/aws
+
+sns_topic_info

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -1,11 +1,10 @@
 - module_defaults:
-    group/aws: &creds
+    group/aws:
       aws_secret_key: '{{ aws_secret_key }}'
       aws_access_key: '{{ aws_access_key }}'
       security_token: '{{ security_token|default(omit) }}'
       region: '{{ aws_region }}'
-  collections:
-    - community.general
+
   block:
 
   - name: create minimal lambda role (needed for subscription test further down)
@@ -22,9 +21,18 @@
       seconds: 10
     when: iam_role is changed
   
+  - name: list all the topics (check_mode)
+    sns_topic_info:
+    check_mode: true
+    register: sns_topic_list
+  
+  - name: assert success
+    assert:
+      that:
+          - sns_topic_list is successful
+  
   - name: list all the topics
     sns_topic_info:
-      <<: *creds
     register: sns_topic_list
   
   - name: assert success
@@ -46,6 +54,41 @@
   - name: set sns_arn fact
     set_fact:
       sns_arn: '{{ sns_topic_create.sns_arn }}'
+  
+  - name: get info on specific topic (check_mode)
+    sns_topic_info:
+      topic_arn: "{{ sns_arn }}"
+    check_mode: true
+    register: sns_topic_info
+  
+  - name: assert success
+    assert:
+      that:
+      - sns_topic_info is successful
+      - "'result' in sns_topic_info"
+      - sns_topic_info.result["sns_arn"] == "{{ sns_arn }}"
+      - "'sns_topic' in sns_topic_info.result"
+      - "'display_name' in sns_topic_info.result['sns_topic']"
+      - sns_topic_info.result["sns_topic"]["display_name"] == "My topic name"
+      - "'owner' in sns_topic_info.result['sns_topic']"
+      - "'policy' in sns_topic_info.result['sns_topic']"
+  
+  - name: get info on specific topic
+    sns_topic_info:
+      topic_arn: "{{ sns_arn }}"
+    register: sns_topic_info
+  
+  - name: assert success
+    assert:
+      that:
+      - sns_topic_info is successful
+      - "'result' in sns_topic_info"
+      - sns_topic_info.result["sns_arn"] == "{{ sns_arn }}"
+      - "'sns_topic' in sns_topic_info.result"
+      - "'display_name' in sns_topic_info.result['sns_topic']"
+      - sns_topic_info.result["sns_topic"]["display_name"] == "My topic name"
+      - "'owner' in sns_topic_info.result['sns_topic']"
+      - "'policy' in sns_topic_info.result['sns_topic']"
 
   - name: create topic again (expect changed=False)
     sns_topic:

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -1,5 +1,5 @@
 - module_defaults:
-    group/aws:
+    group/aws: &creds
       aws_secret_key: '{{ aws_secret_key }}'
       aws_access_key: '{{ aws_access_key }}'
       security_token: '{{ security_token|default(omit) }}'
@@ -21,6 +21,16 @@
     pause:
       seconds: 10
     when: iam_role is changed
+  
+  - name: list all the topics
+    sns_topic_info:
+      <<: *creds
+    register: sns_topic_list
+  
+  - name: assert success
+    assert:
+      that:
+          - sns_topic_list is successful
 
   - name: create standard SNS topic
     sns_topic:

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -20,25 +20,25 @@
     pause:
       seconds: 10
     when: iam_role is changed
-  
+
   - name: list all the topics (check_mode)
     sns_topic_info:
     check_mode: true
     register: sns_topic_list
-  
+
   - name: assert success
     assert:
       that:
-          - sns_topic_list is successful
-  
+      - sns_topic_list is successful
+
   - name: list all the topics
     sns_topic_info:
     register: sns_topic_list
-  
+
   - name: assert success
     assert:
       that:
-          - sns_topic_list is successful
+      - sns_topic_list is successful
 
   - name: create standard SNS topic
     sns_topic:
@@ -54,13 +54,13 @@
   - name: set sns_arn fact
     set_fact:
       sns_arn: '{{ sns_topic_create.sns_arn }}'
-  
+
   - name: get info on specific topic (check_mode)
     sns_topic_info:
       topic_arn: "{{ sns_arn }}"
     check_mode: true
     register: sns_topic_info
-  
+
   - name: assert success
     assert:
       that:
@@ -72,12 +72,12 @@
       - sns_topic_info.result["sns_topic"]["display_name"] == "My topic name"
       - "'owner' in sns_topic_info.result['sns_topic']"
       - "'policy' in sns_topic_info.result['sns_topic']"
-  
+
   - name: get info on specific topic
     sns_topic_info:
       topic_arn: "{{ sns_arn }}"
     register: sns_topic_info
-  
+
   - name: assert success
     assert:
       that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`sns_topic_info` -  new module allowing to get all AWS SNS topics or properties of a specific AWS SNS topic.

Fixes https://github.com/ansible-collections/community.aws/issues/601

Requires https://github.com/ansible-collections/community.aws/pull/879

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sns_topic_info
