### PR TITLE
Adding s3_origin_config to docs in parameters and return values (from changes in PR #39)

### DIFF
--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -153,11 +153,11 @@ options:
             - See also U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html).
           type: bool
         s3_origin_config:
-          description: Specify origin access identity for S3 origins
+          description: Specify origin access identity for S3 origins.
           type: dict
           suboptions:
             origin_access_identity:
-              description: Existing origin access identity in the format C(origin-access-identity/cloudfront/OID_ID)
+              description: Existing origin access identity in the format C(origin-access-identity/cloudfront/OID_ID).
               type: str
         custom_origin_config:
           description: Connection information about the origin.
@@ -1289,7 +1289,7 @@ origins:
           contains:
             origin_access_identity:
               type: str
-              description: The origin access id as a path
+              description: The origin access id as a path.
               sample: origin-access-identity/cloudfront/EXAMPLEID
     quantity:
       description: Count of origins.

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -149,9 +149,15 @@ options:
         s3_origin_access_identity_enabled:
           description:
             - Use an origin access identity to configure the origin so that viewers can only access objects in an Amazon S3 bucket through CloudFront.
-            - Will automatically create an Identity for you.
+            - Will automatically create an Identity for you if no I(s3_origin_config) is specified.
             - See also U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html).
           type: bool
+        s3_origin_config:
+          type: dict
+          suboptions:
+            origin_access_identity:
+              description: Existing origin access identity in the format C(origin-access-identity/cloudfront/OID_ID)
+              type: str
         custom_origin_config:
           description: Connection information about the origin.
           type: dict
@@ -1275,6 +1281,15 @@ origins:
           returned: always
           type: str
           sample: ''
+        s3_origin_config:
+          descrption: Origin access identity configuration for S3 Origin.
+          returned: when s3_origin_access_identity_enabled is true
+          type: dict
+          contains:
+            origin_access_identity:
+              type: str
+              description: The origin access id as a path
+              sample: origin-access-identity/cloudfront/EXAMPLEID
     quantity:
       description: Count of origins.
       returned: always

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -153,6 +153,7 @@ options:
             - See also U(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html).
           type: bool
         s3_origin_config:
+          description: Specify origin access identity for S3 origins
           type: dict
           suboptions:
             origin_access_identity:
@@ -1282,7 +1283,7 @@ origins:
           type: str
           sample: ''
         s3_origin_config:
-          descrption: Origin access identity configuration for S3 Origin.
+          description: Origin access identity configuration for S3 Origin.
           returned: when s3_origin_access_identity_enabled is true
           type: dict
           contains:


### PR DESCRIPTION
https://github.com/ansible-collections/community.aws/pull/39

Adding `s3_origin_config` to docs in parameters and return values

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
