### PR TITLE
Add supports_check_mode to cloudformation_exports_info cloudfront_info

### DIFF
--- a/changelogs/fragments/659-checkmode.yml
+++ b/changelogs/fragments/659-checkmode.yml
@@ -6,3 +6,5 @@ minor_changes:
 - iam_server_certificate_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
 - wafv2_resources_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
 - wafv2_web_acl_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- cloudformation_exports_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).
+- cloudfront_info - ensure module runs in check_mode (https://github.com/ansible-collections/community.aws/issues/659).

--- a/plugins/modules/cloudformation_exports_info.py
+++ b/plugins/modules/cloudformation_exports_info.py
@@ -67,7 +67,7 @@ def main():
         original_message=''
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     cloudformation_client = module.client('cloudformation')
 
     try:

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -553,7 +553,7 @@ def main():
         summary=dict(required=False, default=False, type='bool'),
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     is_old_facts = module._name == 'cloudfront_facts'
     if is_old_facts:
         module.deprecate("The 'cloudfront_facts' module has been renamed to 'cloudfront_info', "


### PR DESCRIPTION
##### SUMMARY

as _info modules they should run in check mode

See also #659 (missed in my first pass)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

cloudformation_exports_info
cloudfront_info

##### ADDITIONAL INFORMATION

https://dashboard.zuul.ansible.com/t/ansible/build/a5f8c6effd7745eca0b06a5a1bef7b08

```
ERROR: plugins/modules/cloudformation_exports_info.py:0:0: invalid-ansiblemodule-schema: AnsibleModule.supports_check_mode: not a valid value for dictionary value @ data['supports_check_mode']. Got False
ERROR: plugins/modules/cloudfront_info.py:0:0: invalid-ansiblemodule-schema: AnsibleModule.supports_check_mode: not a valid value for dictionary value @ data['supports_check_mode']. Got False
```