### PR TITLE
Wrap Kafka tests in custom virtualenv

### DIFF
--- a/tests/integration/targets/aws_msk_cluster/aliases
+++ b/tests/integration/targets/aws_msk_cluster/aliases
@@ -1,2 +1,4 @@
-cloud/aws
+# Needs to install recent botocore environment
 slow
+
+cloud/aws

--- a/tests/integration/targets/aws_msk_cluster/meta/main.yml
+++ b/tests/integration/targets/aws_msk_cluster/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/aws_msk_cluster/tasks/main.yml
+++ b/tests/integration/targets/aws_msk_cluster/tasks/main.yml
@@ -9,7 +9,6 @@
   collections:
     - amazon.aws
   block:
-
     - name: collect availability zone info
       aws_az_info:
       register: az_info
@@ -41,37 +40,60 @@
     - set_fact:
         subnet_ids: '{{ subnets | community.general.json_query("results[].subnet.id") | list }}'
 
-    - name: create msk configuration
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions:
-          - "{{ msk_version }}"
-      register: msk_config
+    - pip:
+        name: virtualenv
+    - set_fact:
+        virtualenv: "{{ remote_tmp_dir }}/virtualenv"
+        virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
+    - set_fact:
+        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
+    - pip:
+        name:
+          - 'boto3>=1.13.0'
+          - 'botocore==1.17.48'
+          - 'coverage<5'
+        virtualenv: '{{ virtualenv }}'
+        virtualenv_command: '{{ virtualenv_command }}'
+        virtualenv_site_packages: no
 
-    - name: create tests
-      include_tasks: test_create.yml
+     # ============================================================
+    - name: Wrap test in virtualenv
+      vars:
+        ansible_python_interpreter: "{{ virtualenv }}/bin/python"
+      block:
+        - name: create msk configuration
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions:
+              - "{{ msk_version }}"
+          register: msk_config
 
-    - name: update tests
-      include_tasks: test_update.yml
+        - name: create tests
+          include_tasks: test_create.yml
 
-    - name: delete tests
-      include_tasks: test_delete.yml
+        - name: update tests
+          include_tasks: test_update.yml
+
+        - name: delete tests
+          include_tasks: test_delete.yml
+
+      always:
+
+        - name: delete msk cluster
+          aws_msk_cluster:
+            name: "{{ msk_cluster_name }}"
+            state: absent
+            wait: true
+          ignore_errors: yes
+
+        - name: remove msk configuration
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: absent
+          ignore_errors: yes
 
   always:
-
-    - name: delete msk cluster
-      aws_msk_cluster:
-        name: "{{ msk_cluster_name }}"
-        state: absent
-        wait: true
-      ignore_errors: yes
-
-    - name: remove msk configuration
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: absent
-      ignore_errors: yes
 
     - name: remove subnets
       ec2_vpc_subnet:

--- a/tests/integration/targets/aws_msk_config/aliases
+++ b/tests/integration/targets/aws_msk_config/aliases
@@ -1,1 +1,4 @@
+# Needs to install recent botocore environment
+slow
+
 cloud/aws

--- a/tests/integration/targets/aws_msk_config/meta/main.yml
+++ b/tests/integration/targets/aws_msk_config/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/aws_msk_config/tasks/main.yml
+++ b/tests/integration/targets/aws_msk_config/tasks/main.yml
@@ -10,140 +10,160 @@
     - amazon.aws
   block:
 
-    - name: create msk configuration (check mode)
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions: "{{ msk_kafka_versions }}"
-        config: "{{ msk_configs[0] }}"
-      check_mode: yes
-      register: msk_config
+    - pip:
+        name: virtualenv
+    - set_fact:
+        virtualenv: "{{ remote_tmp_dir }}/virtualenv"
+        virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
+    - set_fact:
+        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
+    - pip:
+        name:
+          - 'boto3>=1.13.0'
+          - 'botocore==1.17.48'
+          - 'coverage<5'
+        virtualenv: '{{ virtualenv }}'
+        virtualenv_command: '{{ virtualenv_command }}'
+        virtualenv_site_packages: no
 
-    - name: assert that the msk configuration be created
-      assert:
-        that:
-          - msk_config is changed
+    - name: Wrap test in virtualenv
+      vars:
+        ansible_python_interpreter: "{{ virtualenv }}/bin/python"
+      block:
+        - name: create msk configuration (check mode)
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions: "{{ msk_kafka_versions }}"
+            config: "{{ msk_configs[0] }}"
+          check_mode: yes
+          register: msk_config
 
-    - name: create msk configuration
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions: "{{ msk_kafka_versions }}"
-        config: "{{ msk_configs[0] }}"
-      register: msk_config
+        - name: assert that the msk configuration be created
+          assert:
+            that:
+              - msk_config is changed
 
-    - name: assert that the msk configuration is created
-      assert:
-        that:
-          - msk_config is changed
+        - name: create msk configuration
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions: "{{ msk_kafka_versions }}"
+            config: "{{ msk_configs[0] }}"
+          register: msk_config
 
-    - name: create msk configuration (idempotency)
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions: "{{ msk_kafka_versions }}"
-        config: "{{ msk_configs[0] }}"
-      register: msk_config
+        - name: assert that the msk configuration is created
+          assert:
+            that:
+              - msk_config is changed
 
-    - name: assert that the msk configuration wasn't changed
-      assert:
-        that:
-          - msk_config is not changed
+        - name: create msk configuration (idempotency)
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions: "{{ msk_kafka_versions }}"
+            config: "{{ msk_configs[0] }}"
+          register: msk_config
 
-    - name: validate return values
-      assert:
-        that:
-          - msk_config.revision == 1
-          - "msk_config.arn.startswith('arn:aws:kafka:{{ aws_region }}:')"
-          - "'auto.create.topics.enable=True' in msk_config.server_properties"
-          - "'zookeeper.session.timeout.ms=18000' in msk_config.server_properties"
+        - name: assert that the msk configuration wasn't changed
+          assert:
+            that:
+              - msk_config is not changed
 
-    - name: update msk configuration (check mode)
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions: "{{ msk_kafka_versions }}"
-        config: "{{ msk_configs[1] }}"
-      check_mode: yes
-      register: msk_config
+        - name: validate return values
+          assert:
+            that:
+              - msk_config.revision == 1
+              - "msk_config.arn.startswith('arn:aws:kafka:{{ aws_region }}:')"
+              - "'auto.create.topics.enable=True' in msk_config.server_properties"
+              - "'zookeeper.session.timeout.ms=18000' in msk_config.server_properties"
 
-    - name: assert that the msk configuration be changed
-      assert:
-        that:
-          - msk_config is changed
+        - name: update msk configuration (check mode)
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions: "{{ msk_kafka_versions }}"
+            config: "{{ msk_configs[1] }}"
+          check_mode: yes
+          register: msk_config
 
-    - name: update msk configuration
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions: "{{ msk_kafka_versions }}"
-        config: "{{ msk_configs[1] }}"
-      register: msk_config
+        - name: assert that the msk configuration be changed
+          assert:
+            that:
+              - msk_config is changed
 
-    - name: assert that the msk configuration is changed
-      assert:
-        that:
-          - msk_config is changed
+        - name: update msk configuration
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions: "{{ msk_kafka_versions }}"
+            config: "{{ msk_configs[1] }}"
+          register: msk_config
 
-    - name: validate return values (update)
-      assert:
-        that:
-          - msk_config.revision == 2
-          - "'auto.create.topics.enable=True' not in msk_config.server_properties"
-          - "'num.io.threads=8' in msk_config.server_properties"
-          - "'zookeeper.session.timeout.ms=36000' in msk_config.server_properties"
+        - name: assert that the msk configuration is changed
+          assert:
+            that:
+              - msk_config is changed
 
-    - name: update msk configuration (idempotency)
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "present"
-        kafka_versions: "{{ msk_kafka_versions }}"
-        config: "{{ msk_configs[1] }}"
-      register: msk_config
+        - name: validate return values (update)
+          assert:
+            that:
+              - msk_config.revision == 2
+              - "'auto.create.topics.enable=True' not in msk_config.server_properties"
+              - "'num.io.threads=8' in msk_config.server_properties"
+              - "'zookeeper.session.timeout.ms=36000' in msk_config.server_properties"
 
-    - name: assert that the msk configuration wasn't changed
-      assert:
-        that:
-          - msk_config is not changed
+        - name: update msk configuration (idempotency)
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "present"
+            kafka_versions: "{{ msk_kafka_versions }}"
+            config: "{{ msk_configs[1] }}"
+          register: msk_config
 
-    - name: delete msk configuration (check mode)
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "absent"
-      check_mode: yes
-      register: msk_config
+        - name: assert that the msk configuration wasn't changed
+          assert:
+            that:
+              - msk_config is not changed
 
-    - name: assert that the msk configuration be changed
-      assert:
-        that:
-          - msk_config is changed
+        - name: delete msk configuration (check mode)
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "absent"
+          check_mode: yes
+          register: msk_config
 
-    - name: delete msk configuration
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "absent"
-      register: msk_config
+        - name: assert that the msk configuration be changed
+          assert:
+            that:
+              - msk_config is changed
 
-    - name: assert that the msk configuration is changed
-      assert:
-        that:
-          - msk_config is changed
+        - name: delete msk configuration
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "absent"
+          register: msk_config
 
-    - name: delete msk configuration (idempotency)
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: "absent"
-      register: msk_config
+        - name: assert that the msk configuration is changed
+          assert:
+            that:
+              - msk_config is changed
 
-    - name: assert that the msk configuration wasn't changed
-      assert:
-        that:
-          - msk_config is not changed
+        - name: delete msk configuration (idempotency)
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: "absent"
+          register: msk_config
 
-  always:
+        - name: assert that the msk configuration wasn't changed
+          assert:
+            that:
+              - msk_config is not changed
 
-    - name: remove msk configuration
-      aws_msk_config:
-        name: "{{ msk_config_name }}"
-        state: absent
-      ignore_errors: yes
+      always:
+
+        - name: remove msk configuration
+          aws_msk_config:
+            name: "{{ msk_config_name }}"
+            state: absent
+          ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

aws_msk_config and aws_msk_cluster need recent versions of botocore, explicitly install these so we can still test against our minimum supported boto3/botocore versions

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_msk_config
aws_msk_cluster

##### ADDITIONAL INFORMATION

fixes: #678 