### PR TITLE
aws_s3_bucket_info - Add a check for botocore>='1.18.11' when pulling bucket_ownership_controls

### DIFF
--- a/changelogs/fragments/682-aws_s3_bucket_info-botocore.yml
+++ b/changelogs/fragments/682-aws_s3_bucket_info-botocore.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_s3_bucket_info - added test for botocore>=1.18.11 when attempting to fetch bucket ownership controls (https://github.com/ansible-collections/community.aws/pull/682)

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -78,7 +78,9 @@ options:
         type: bool
         default: False
       bucket_ownership_controls:
-        description: Retrive S3 ownership controls.
+        description:
+        - Retrive S3 ownership controls.
+        - Access to bucket ownership controls requires botocore>=1.18.11.
         type: bool
         default: False
       bucket_website:
@@ -592,6 +594,9 @@ def main():
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
                          "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
+
+    if module.params.get("bucket_ownership_controls"):
+        module.require_botocore_at_least('1.18.11', reason='to retreive bucket ownership controls')
 
     # Get parameters
     name = module.params.get("name")

--- a/tests/integration/targets/aws_s3_bucket_info/meta/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
+  - setup_remote_tmp_dir
   - setup_ec2

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/basic.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/basic.yml
@@ -1,0 +1,72 @@
+---
+- name: Get simple S3 bucket list
+  aws_s3_bucket_info:
+  register: bucket_list
+
+- name: Assert result.changed == False and bucket list was retrieved
+  assert:
+    that:
+      - bucket_list.changed == False
+      - bucket_list.buckets
+
+- name: Get complex S3 bucket list
+  aws_s3_bucket_info:
+    name_filter: "{{ name_pattern }}"
+    bucket_facts:
+      bucket_accelerate_configuration: true
+      bucket_acl: true
+      bucket_cors: true
+      bucket_encryption: true
+      bucket_lifecycle_configuration: true
+      bucket_location: true
+      bucket_logging: true
+      bucket_notification_configuration: true
+      bucket_policy: true
+      bucket_policy_status: true
+      bucket_replication: true
+      bucket_request_payment: true
+      bucket_tagging: true
+      bucket_website: true
+      public_access_block: true
+    transform_location: true
+  register: bucket_list
+
+- name: Assert that buckets list contains requested bucket facts
+  assert:
+    that:
+      - item.name is search(name_pattern)
+      - item.bucket_accelerate_configuration is defined
+      - item.bucket_acl is defined
+      - item.bucket_cors is defined
+      - item.bucket_encryption is defined
+      - item.bucket_lifecycle_configuration is defined
+      - item.bucket_location is defined
+      - item.bucket_logging is defined
+      - item.bucket_notification_configuration is defined
+      - item.bucket_policy is defined
+      - item.bucket_policy_status is defined
+      - item.bucket_replication is defined
+      - item.bucket_request_payment is defined
+      - item.bucket_tagging is defined
+      - item.bucket_website is defined
+      - item.public_access_block is defined
+  loop: "{{ bucket_list.buckets }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Assert that retrieved bucket facts contains valid data
+  assert:
+    that:
+      - item.bucket_acl.Owner is defined
+      - item.bucket_tagging.snake_case is defined
+      - item.bucket_tagging.CamelCase is defined
+      - item.bucket_tagging["lowercase spaced"] is defined
+      - item.bucket_tagging["Title Case"] is defined
+      - item.bucket_tagging.snake_case == 'simple_snake_case'
+      - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
+      - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
+      - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
+      - item.bucket_location.LocationConstraint == aws_region
+  loop: "{{ bucket_list.buckets }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/bucket_ownership_controls.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/bucket_ownership_controls.yml
@@ -1,0 +1,108 @@
+---
+- name: Test community.aws.aws_s3_bucket_info
+  block:
+    - pip:
+        name: virtualenv
+    - set_fact:
+        virtualenv: "{{ remote_tmp_dir }}/virtualenv"
+        virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
+    - set_fact:
+        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
+    - pip:
+        name:
+          - 'boto3>=1.13.0'
+          - 'botocore==1.18.11'
+          - 'coverage<5'
+        virtualenv: '{{ virtualenv }}'
+        virtualenv_command: '{{ virtualenv_command }}'
+        virtualenv_site_packages: no
+    - name: Wrap test in virtualenv
+      vars:
+        ansible_python_interpreter: "{{ virtualenv }}/bin/python"
+      block:
+
+        - name: Get S3 bucket ownership controls
+          aws_s3_bucket_info:
+            name_filter: "{{ name_pattern }}"
+            bucket_facts:
+              bucket_ownership_controls: true
+            transform_location: true
+          register: bucket_list
+
+        - name: Assert that buckets list contains requested bucket facts
+          assert:
+            that:
+              - item.name is search(name_pattern)
+              - item.bucket_ownership_controls is defined
+          loop: "{{ bucket_list.buckets }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Get complex S3 bucket list (including ownership controls)
+          aws_s3_bucket_info:
+            name_filter: "{{ name_pattern }}"
+            bucket_facts:
+              bucket_accelerate_configuration: true
+              bucket_acl: true
+              bucket_cors: true
+              bucket_encryption: true
+              bucket_lifecycle_configuration: true
+              bucket_location: true
+              bucket_logging: true
+              bucket_notification_configuration: true
+              bucket_ownership_controls: true
+              bucket_policy: true
+              bucket_policy_status: true
+              bucket_replication: true
+              bucket_request_payment: true
+              bucket_tagging: true
+              bucket_website: true
+              public_access_block: true
+            transform_location: true
+          register: bucket_list
+
+        - name: Assert that buckets list contains requested bucket facts
+          assert:
+            that:
+              - item.name is search(name_pattern)
+              - item.bucket_accelerate_configuration is defined
+              - item.bucket_acl is defined
+              - item.bucket_cors is defined
+              - item.bucket_encryption is defined
+              - item.bucket_lifecycle_configuration is defined
+              - item.bucket_location is defined
+              - item.bucket_logging is defined
+              - item.bucket_notification_configuration is defined
+              - item.bucket_ownership_controls is defined
+              - item.bucket_policy is defined
+              - item.bucket_policy_status is defined
+              - item.bucket_replication is defined
+              - item.bucket_request_payment is defined
+              - item.bucket_tagging is defined
+              - item.bucket_website is defined
+              - item.public_access_block is defined
+          loop: "{{ bucket_list.buckets }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Assert that retrieved bucket facts contains valid data
+          assert:
+            that:
+              - item.bucket_acl.Owner is defined
+              - item.bucket_tagging.snake_case is defined
+              - item.bucket_tagging.CamelCase is defined
+              - item.bucket_tagging["lowercase spaced"] is defined
+              - item.bucket_tagging["Title Case"] is defined
+              - item.bucket_tagging.snake_case == 'simple_snake_case'
+              - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
+              - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
+              - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
+              - item.bucket_location.LocationConstraint == aws_region
+          loop: "{{ bucket_list.buckets }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+  always:
+    - file:
+        path: "{{ virtualenv }}"
+        state: absent

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/main.yml
@@ -7,7 +7,7 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - name: Create simple s3_buckets
+    - name: Create a simple s3_bucket
       s3_bucket:
         name: "{{ item }}"
         state: present
@@ -19,79 +19,8 @@
       register: output
       loop: "{{ testing_buckets }}"
 
-    - name: Get simple S3 bucket list
-      aws_s3_bucket_info:
-      register: bucket_list
-
-    - name: Assert result.changed == False and bucket list was retrieved
-      assert:
-        that:
-          - bucket_list.changed == False
-          - bucket_list.buckets
-
-    - name: Get complex S3 bucket list
-      aws_s3_bucket_info:
-        name_filter: "{{ name_pattern }}"
-        bucket_facts:
-          bucket_accelerate_configuration: true
-          bucket_acl: true
-          bucket_cors: true
-          bucket_encryption: true
-          bucket_lifecycle_configuration: true
-          bucket_location: true
-          bucket_logging: true
-          bucket_notification_configuration: true
-          bucket_ownership_controls: true
-          bucket_policy: true
-          bucket_policy_status: true
-          bucket_replication: true
-          bucket_request_payment: true
-          bucket_tagging: true
-          bucket_website: true
-          public_access_block: true
-        transform_location: true
-      register: bucket_list
-
-    - name: Assert that buckets list contains requested bucket facts
-      assert:
-        that:
-          - item.name is search(name_pattern)
-          - item.bucket_accelerate_configuration is defined
-          - item.bucket_acl is defined
-          - item.bucket_cors is defined
-          - item.bucket_encryption is defined
-          - item.bucket_lifecycle_configuration is defined
-          - item.bucket_location is defined
-          - item.bucket_logging is defined
-          - item.bucket_notification_configuration is defined
-          - item.bucket_ownership_controls is defined
-          - item.bucket_policy is defined
-          - item.bucket_policy_status is defined
-          - item.bucket_replication is defined
-          - item.bucket_request_payment is defined
-          - item.bucket_tagging is defined
-          - item.bucket_website is defined
-          - item.public_access_block is defined
-      loop: "{{ bucket_list.buckets }}"
-      loop_control:
-        label: "{{ item.name }}"
-
-    - name: Assert that retrieved bucket facts contains valid data
-      assert:
-        that:
-          - item.bucket_acl.Owner is defined
-          - item.bucket_tagging.snake_case is defined
-          - item.bucket_tagging.CamelCase is defined
-          - item.bucket_tagging["lowercase spaced"] is defined
-          - item.bucket_tagging["Title Case"] is defined
-          - item.bucket_tagging.snake_case == 'simple_snake_case'
-          - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
-          - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
-          - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
-          - item.bucket_location.LocationConstraint == aws_region
-      loop: "{{ bucket_list.buckets }}"
-      loop_control:
-        label: "{{ item.name }}"
+    - include_tasks: basic.yml
+    - include_tasks: bucket_ownership_controls.yml
 
   always:
     - name: Delete simple s3_buckets


### PR DESCRIPTION
##### SUMMARY

Fetching bucket_ownership_controls requires botocore>='1.18.11' add a check and update the tests to explicitly require this version of botocore when testing accessing bucket_ownership_controls

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_s3_bucket_info

##### ADDITIONAL INFORMATION

Depends-On: https://github.com/ansible-collections/community.aws/pull/686