### PR TITLE
Fixup / ignore new pylint 2.9.3 issues

### DIFF
--- a/changelogs/fragments/686-pylint.yml
+++ b/changelogs/fragments/686-pylint.yml
@@ -1,2 +1,4 @@
 minor_changes:
 - ecs_task - remove unused import (https://github.com/ansible-collections/community.aws/pull/686).
+- ec2_vpc_vgw - fix arguments-renamed pylint issue (https://github.com/ansible-collections/community.aws/pull/686).
+- ec2_vpc_vpn - fix arguments-renamed pylint issue (https://github.com/ansible-collections/community.aws/pull/686).

--- a/changelogs/fragments/686-pylint.yml
+++ b/changelogs/fragments/686-pylint.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_task - remove unused import (https://github.com/ansible-collections/community.aws/pull/686).

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -131,16 +131,16 @@ class VGWRetry(AWSRetry):
         return (error.response['Error']['Code'], error.response['Error']['Message'],)
 
     @staticmethod
-    def found(response_codes, catch_extra_error_codes=None):
+    def found(response_code, catch_extra_error_codes=None):
         retry_on = ['The maximum number of mutating objects has been reached.']
 
         if catch_extra_error_codes:
             retry_on.extend(catch_extra_error_codes)
-        if not isinstance(response_codes, tuple):
-            response_codes = (response_codes,)
+        if not isinstance(response_code, tuple):
+            response_code = (response_code,)
 
-        for code in response_codes:
-            if super().found(response_codes, catch_extra_error_codes):
+        for code in response_code:
+            if super().found(response_code, catch_extra_error_codes):
                 return True
 
         return False

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -324,16 +324,16 @@ class VPNRetry(AWSRetry):
         return (error.response['Error']['Code'], error.response['Error']['Message'],)
 
     @staticmethod
-    def found(response_codes, catch_extra_error_codes=None):
+    def found(response_code, catch_extra_error_codes=None):
         retry_on = ['The maximum number of mutating objects has been reached.']
 
         if catch_extra_error_codes:
             retry_on.extend(catch_extra_error_codes)
-        if not isinstance(response_codes, tuple):
-            response_codes = (response_codes,)
+        if not isinstance(response_code, tuple):
+            response_code = (response_code,)
 
-        for code in response_codes:
-            if super().found(response_codes, catch_extra_error_codes):
+        for code in response_code:
+            if super().found(response_code, catch_extra_error_codes):
                 return True
 
         return False

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -234,7 +234,6 @@ task:
 '''
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names, ansible_dict_to_boto3_tag_list
 
 try:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,1 +1,1 @@
-plugins/modules/route53.py validate-modules:parameter-state-invalid-choice
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,3 +1,3 @@
-plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/iam.py pylint:unnecessary-comprehension # iam.py is boto2 so any refactoring can get complex, also it does not have tests
-plugins/modules/route53.py validate-modules:parameter-state-invalid-choice
+plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
+plugins/modules/iam.py pylint:unnecessary-comprehension # no tests and module is deprecated
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,12 @@
+plugins/modules/aws_kms_info.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/aws_ses_rule_set.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
 plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
+plugins/modules/cloudwatchevent_rule.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/elb_target_group.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/iam_group.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/iam.py pylint:use-a-generator # no tests and module is deprecated
 plugins/modules/iam.py pylint:unnecessary-comprehension # no tests and module is deprecated
+plugins/modules/iam_role.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/iam_user.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/rds_instance.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,3 @@
-plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/iam.py pylint:unnecessary-comprehension # iam.py is boto2 so any refactoring can get complex, also it does not have tests
-plugins/modules/route53.py validate-modules:parameter-state-invalid-choice
+plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
+plugins/modules/iam.py pylint:unnecessary-comprehension # no tests and module is deprecated
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -46,12 +46,12 @@ class DictDataLoader(DataLoader):
 
     # TODO: the real _get_file_contents returns a bytestring, so we actually convert the
     #       unicode/text it's created with to utf-8
-    def _get_file_contents(self, path):
-        path = to_text(path)
-        if path in self._file_mapping:
-            return (to_bytes(self._file_mapping[path]), False)
+    def _get_file_contents(self, file_name):
+        file_name = to_text(file_name)
+        if file_name in self._file_mapping:
+            return (to_bytes(self._file_mapping[file_name]), False)
         else:
-            raise AnsibleParserError("file not found: %s" % path)
+            raise AnsibleParserError("file not found: %s" % file_name)
 
     def path_exists(self, path):
         path = to_text(path)


### PR DESCRIPTION
##### SUMMARY

The devel containers have been updated to include a new version of pylint ( https://github.com/ansible-collections/overview/issues/45#issuecomment-897333102 )

fixup arguments-renamed
fixup unused-import
ignore pylint:use-a-generator (Should be an easy fix but not worth blocking gating)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/ec2_vpc_vgw.py
plugins/modules/ec2_vpc_vpn.py
plugins/modules/ecs_task.py
tests/sanity/ignore-2.10.txt
tests/sanity/ignore-2.11.txt
tests/sanity/ignore-2.12.txt
tests/unit/mock/loader.py

##### ADDITIONAL INFORMATION