### PR TITLE
s3_sync: Integration test fix: empty buckets before deleting

### DIFF
--- a/tests/integration/targets/s3_sync/tasks/main.yml
+++ b/tests/integration/targets/s3_sync/tasks/main.yml
@@ -145,6 +145,60 @@
           - output is changed
 
   always:
+
+    - name: Empty all buckets before deleting
+      block:
+        - name: list test_bucket objects
+          aws_s3:
+            bucket: "{{ test_bucket }}"
+            mode: list
+          register: objects
+          ignore_errors: true
+
+        - name: remove objects from test_bucket
+          aws_s3:
+            bucket: "{{ test_bucket }}"
+            mode: delobj
+            object: "{{ obj }}"
+          with_items: "{{ objects.s3_keys }}"
+          loop_control:
+            loop_var: obj      
+          ignore_errors: true
+        
+        - name: list test_bucket_2 objects
+          aws_s3:
+            bucket: "{{ test_bucket_2 }}"
+            mode: list
+          register: objects
+          ignore_errors: true
+
+        - name: remove objects from test_bucket_2
+          aws_s3:
+            bucket: "{{ test_bucket_2 }}"
+            mode: delobj
+            object: "{{ obj }}"
+          with_items: "{{ objects.s3_keys }}"
+          loop_control:
+            loop_var: obj      
+          ignore_errors: true
+        
+        - name: list test_bucket_3 objects
+          aws_s3:
+            bucket: "{{ test_bucket_3 }}"
+            mode: list
+          register: objects
+          ignore_errors: true
+
+        - name: remove objects from test_bucket_3
+          aws_s3:
+            bucket: "{{ test_bucket_3 }}"
+            mode: delobj
+            object: "{{ obj }}"
+          with_items: "{{ objects.s3_keys }}"
+          loop_control:
+            loop_var: obj      
+          ignore_errors: true
+
     - name: Ensure all buckets are deleted
       s3_bucket:
         name: "{{item}}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added tasks to empty buckets before deleting them.

S3 requires a bucket to be empty before it can be deleted.
The integration tests in the s3_sync try to delete the buckets without emptying them.

Fixes #694.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration/targets/s3_sync

