### PR TITLE
iam_role: replace UpdateRoleDescription with use UpdateRole

### DIFF
--- a/changelogs/fragments/697-iam_role-replace-UpdateRoleDescription-with-UpdateRole.yml
+++ b/changelogs/fragments/697-iam_role-replace-UpdateRoleDescription-with-UpdateRole.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- iam_role - Modified iam_role to replace update_role_description with update_role (https://github.com/ansible-collections/community.aws/pull/697).
+- iam_role - Modified iam_role internal code to replace update_role_description with update_role (https://github.com/ansible-collections/community.aws/pull/697).

--- a/changelogs/fragments/697-iam_role-replace-UpdateRoleDescription-with-UpdateRole.yml
+++ b/changelogs/fragments/697-iam_role-replace-UpdateRoleDescription-with-UpdateRole.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- iam_role - Modified iam_role to replace update_role_description with update_role (https://github.com/ansible-collections/community.aws/pull/697).

--- a/plugins/modules/iam_role.py
+++ b/plugins/modules/iam_role.py
@@ -327,7 +327,7 @@ def update_role_description(connection, module, params, role):
         return True
 
     try:
-        connection.update_role_description(RoleName=params['RoleName'], Description=params['Description'], aws_retry=True)
+        connection.update_role(RoleName=params['RoleName'], Description=params['Description'], aws_retry=True)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Unable to update description for role {0}".format(params['RoleName']))
     return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modified `iam_role.py` to replace `update_role_description` (deprecated) with `update_role` action call.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iam_role

