### PR TITLE
Add additional test constraint for setuptools

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,4 @@
 placebo
 botocore>=1.16.0
 boto3>=1.13.0
+setuptools < 58.0.2 ; python_version >= '3.5' # setuptools 58.0.2 breaks installation of packages, such as coverage, that reference the 'use_2to3' feature


### PR DESCRIPTION
##### SUMMARY
Add additional constraint for ``setuptools`` on Python >= 3.5 due to a bug in the recently released version of ``setuptools`` related to the 'use_2to3' feature.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
tests/unit/requirements.txt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
