### PR TITLE
Fix RDS Enhanced Monitoring bug

### DIFF
--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -989,11 +989,10 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
 
 
 def get_changing_options_with_consistent_keys(modify_params, instance):
-    inconsistent_parameters = list(modify_params.keys())
     changing_params = {}
 
     for param in modify_params:
-        current_option = instance.get('PendingModifiedValues', {}).get(param)
+        current_option = instance.get('PendingModifiedValues', {}).get(param, None)
         if current_option is None:
             current_option = instance[param]
         if modify_params[param] != current_option:


### PR DESCRIPTION
##### SUMMARY
This is a fix for an issue when an RDS instance already exists and you wish to enable enhanced monitoring, for the full details see the linked old reported issue:
https://github.com/ansible/ansible/issues/51772

But in summary currently if you enable enhanced monitoring on an RDS instance that already exists where it isn't already enabled then the following is returned:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'MonitoringRoleArn'
fatal: [localhost_eu-west-1-pdv-qa-1 -> 127.0.0.1]: FAILED! => changed=false 
  module_stderr: |-
    Traceback (most recent call last):
      File "master:/opt/mitogen/mitogen-0.2.9/ansible_mitogen/runner.py", line 975, in _run
        self._run_code(code, mod)
      File "master:/opt/mitogen/mitogen-0.2.9/ansible_mitogen/runner.py", line 939, in _run_code
        exec(code, vars(mod))
      File "master:/tmp/build/4bef5c86/framework/library/cloud/aws/rds_instance.py", line 1245, in <module>
      File "master:/tmp/build/4bef5c86/framework/library/cloud/aws/rds_instance.py", line 1210, in main
      File "master:/tmp/build/4bef5c86/framework/library/cloud/aws/rds_instance.py", line 855, in get_parameters
      File "master:/tmp/build/4bef5c86/framework/library/cloud/aws/rds_instance.py", line 885, in get_options_with_changing_values
      File "master:/tmp/build/4bef5c86/framework/library/cloud/aws/rds_instance.py", line 983, in get_changing_options_with_consistent_keys
    KeyError: 'MonitoringRoleArn'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error

```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
