### PR TITLE
SSM connection - set S3 addressing style

### DIFF
--- a/changelogs/fragments/722-ssm_connection-s3_addressing_style.yml
+++ b/changelogs/fragments/722-ssm_connection-s3_addressing_style.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_ssm - set S3 addressing style to avoid redirects (https://github.com/ansible-collections/community.aws/pull/722).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -540,7 +540,7 @@ class Connection(ConnectionBase):
 
         client = session.client(
             service,
-            config=Config(signature_version="s3v4")
+            config=Config(signature_version='s3v4', s3={'addressing_style': 'virtual'})
         )
         return client
 


### PR DESCRIPTION
##### SUMMARY

Fixes #705 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_ssm

##### ADDITIONAL INFORMATION

I confirm the connection issue described in #705 (I got the redirect error multiple times with different accounts + new buckets), which is fixed by applying the proposed patch, i.e. using the 'path' addressing style.
