### PR TITLE
Migrate redshift_subnet_group to boto3

### DIFF
--- a/changelogs/fragments/724-redshift_subnet_group-boto3.yml
+++ b/changelogs/fragments/724-redshift_subnet_group-boto3.yml
@@ -1,0 +1,7 @@
+minor_changes:
+- redshift_subnet_group - the module has been migrated to the boto3 AWS SDK (https://github.com/ansible-collections/community.aws/pull/724).
+- redshift_subnet_group - added support for check_mode (https://github.com/ansible-collections/community.aws/pull/724).
+- redshift_subnet_group - the ``group_description`` option has been renamed to ``description`` and is now optional.
+  The old parameter name will continue to work (https://github.com/ansible-collections/community.aws/pull/724).
+- redshift_subnet_group - the ``group_subnets`` option has been renamed to ``subnets`` and is now only required when creating a new group.
+  The old parameter name will continue to work (https://github.com/ansible-collections/community.aws/pull/724).

--- a/plugins/modules/redshift_subnet_group.py
+++ b/plugins/modules/redshift_subnet_group.py
@@ -17,7 +17,7 @@ description:
 options:
   state:
     description:
-      - Specifies whether the subnet should be present or absent.
+      - Specifies whether the subnet group should be present or absent.
     default: 'present'
     choices: ['present', 'absent' ]
     type: str
@@ -35,6 +35,7 @@ options:
   subnets:
     description:
       - List of subnet IDs that make up the cluster subnet group.
+      - At least one subnet must be provided when creating a cluster subnet group.
     aliases: ['group_subnets']
     type: list
     elements: str
@@ -122,11 +123,13 @@ def get_subnet_group(name):
 
 
 def create_subnet_group(name, description, subnets):
+
+    if not subnets:
+        module.fail_json(msg='At least one subnet must be provided when creating a subnet group')
+
     try:
         if not description:
             description = name
-        if not subnets:
-            subnets = []
         client.create_cluster_subnet_group(
             aws_retry=True,
             ClusterSubnetGroupName=name,
@@ -198,9 +201,9 @@ def main():
     )
 
     state = module.params.get('state')
-    name = module.params.get('group_name')
-    description = module.params.get('group_description')
-    subnets = module.params.get('group_subnets')
+    name = module.params.get('name')
+    description = module.params.get('description')
+    subnets = module.params.get('subnets')
 
     client = module.client('redshift', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/tests/integration/targets/redshift_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/redshift_subnet_group/tasks/main.yml
@@ -93,8 +93,7 @@
       assert:
         that:
           - create_group is successful
-          # XXX Not idempotent
-          #- create_group is not changed
+          - create_group is not changed
           - '"group" in create_group'
           - '"name" in create_group.group'
           - '"vpc_id" in create_group.group'
@@ -108,9 +107,10 @@
         state: present
         group_name: '{{ group_name }}'
         group_description: '{{ description_updated }}'
-        group_subnets:
-        - '{{ subnet_id_a }}'
-        - '{{ subnet_id_b }}'
+        ## No longer mandatory
+        # group_subnets:
+        # - '{{ subnet_id_a }}'
+        # - '{{ subnet_id_b }}'
       register: update_description
 
     - name: Check result - Update Subnet Group Description
@@ -129,17 +129,17 @@
         state: present
         group_name: '{{ group_name }}'
         group_description: '{{ description_updated }}'
-        group_subnets:
-        - '{{ subnet_id_a }}'
-        - '{{ subnet_id_b }}'
+        ## No longer mandatory
+        # group_subnets:
+        # - '{{ subnet_id_a }}'
+        # - '{{ subnet_id_b }}'
       register: update_description
 
     - name: Check result - Update Subnet Group Description - idempotency
       assert:
         that:
           - update_description is successful
-          # XXX Not idempotent
-          #- update_description is not changed
+          - update_description is not changed
           - '"group" in update_description'
           - '"name" in update_description.group'
           - '"vpc_id" in update_description.group'
@@ -152,7 +152,8 @@
       redshift_subnet_group:
         state: present
         group_name: '{{ group_name }}'
-        group_description: '{{ description_updated }}'
+        ## No longer mandatory
+        # group_description: '{{ description_updated }}'
         group_subnets:
         - '{{ subnet_id_c }}'
         - '{{ subnet_id_d }}'
@@ -173,7 +174,8 @@
       redshift_subnet_group:
         state: present
         group_name: '{{ group_name }}'
-        group_description: '{{ description_updated }}'
+        ## No longer mandatory
+        # group_description: '{{ description_updated }}'
         group_subnets:
         - '{{ subnet_id_c }}'
         - '{{ subnet_id_d }}'
@@ -183,8 +185,7 @@
       assert:
         that:
           - update_subnets is successful
-          # XXX Not idempotent
-          #- update_subnets is not changed
+          - update_subnets is not changed
           - '"group" in update_subnets'
           - '"name" in update_subnets.group'
           - '"vpc_id" in update_subnets.group'

--- a/tests/integration/targets/redshift_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/redshift_subnet_group/tasks/main.yml
@@ -17,6 +17,26 @@
 
     # ============================================================
 
+    - name: Create Subnet Group with no subnets - check_mode
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+      register: create_group
+      ignore_errors: True
+      check_mode: True
+
+    - name: Check result - Create Subnet Group with no subnets - check_mode
+      assert:
+        that:
+          - create_group is failed
+          # Check we caught the issue before trying to create
+          - '"CreateClusterSubnetGroup" not in create_group.resource_actions'
+          # Check that we don't refer to the boto3 parameter
+          - '"subnetIds" not in create_group.msg'
+          # Loosely check the message
+          - '"subnet" in create_group.msg'
+          - '"At least" in create_group.msg'
+
     - name: Create Subnet Group with no subnets
       redshift_subnet_group:
         state: present
@@ -81,6 +101,23 @@
 
     # ============================================================
 
+    - name: Create Subnet Group - check_mode
+      redshift_subnet_group:
+        state: present
+        group_name: '{{ group_name }}'
+        group_description: '{{ description_default }}'
+        group_subnets:
+        - '{{ subnet_id_a }}'
+        - '{{ subnet_id_b }}'
+      register: create_group
+      check_mode: True
+
+    - name: Check result - Create Subnet Group - check_mode
+      assert:
+        that:
+          - create_group is successful
+          - create_group is changed
+
     - name: Create Subnet Group
       redshift_subnet_group:
         state: present
@@ -112,6 +149,23 @@
           - subnet_id_c not in create_group.cluster_subnet_group.subnet_ids
           - subnet_id_d not in create_group.cluster_subnet_group.subnet_ids
           - create_group.cluster_subnet_group.vpc_id == vpc_id
+
+    - name: Create Subnet Group - idempotency - check_mode
+      redshift_subnet_group:
+        state: present
+        group_name: '{{ group_name }}'
+        group_description: '{{ description_default }}'
+        group_subnets:
+        - '{{ subnet_id_a }}'
+        - '{{ subnet_id_b }}'
+      register: create_group
+      check_mode: True
+
+    - name: Check result - Create Subnet Group - idempotency - check_mode
+      assert:
+        that:
+          - create_group is successful
+          - create_group is not changed
 
     - name: Create Subnet Group - idempotency
       redshift_subnet_group:
@@ -147,6 +201,24 @@
 
     # ============================================================
 
+    - name: Update Subnet Group Description - check_mode
+      redshift_subnet_group:
+        state: present
+        group_name: '{{ group_name }}'
+        group_description: '{{ description_updated }}'
+        ## No longer mandatory
+        # group_subnets:
+        # - '{{ subnet_id_a }}'
+        # - '{{ subnet_id_b }}'
+      register: update_description
+      check_mode: True
+
+    - name: Check result - Update Subnet Group Description - check_mode
+      assert:
+        that:
+          - update_description is successful
+          - update_description is changed
+
     - name: Update Subnet Group Description
       redshift_subnet_group:
         state: present
@@ -179,6 +251,24 @@
           - subnet_id_c not in update_description.cluster_subnet_group.subnet_ids
           - subnet_id_d not in update_description.cluster_subnet_group.subnet_ids
           - update_description.cluster_subnet_group.vpc_id == vpc_id
+
+    - name: Update Subnet Group Description - idempotency - check_mode
+      redshift_subnet_group:
+        state: present
+        group_name: '{{ group_name }}'
+        group_description: '{{ description_updated }}'
+        ## No longer mandatory
+        # group_subnets:
+        # - '{{ subnet_id_a }}'
+        # - '{{ subnet_id_b }}'
+      register: update_description
+      check_mode: True
+
+    - name: Check result - Update Subnet Group Description - idempotency - check_mode
+      assert:
+        that:
+          - update_description is successful
+          - update_description is not changed
 
     - name: Update Subnet Group Description - idempotency
       redshift_subnet_group:
@@ -215,6 +305,24 @@
 
     # ============================================================
 
+    - name: Update Subnet Group subnets - check_mode
+      redshift_subnet_group:
+        state: present
+        group_name: '{{ group_name }}'
+        ## No longer mandatory
+        # group_description: '{{ description_updated }}'
+        group_subnets:
+        - '{{ subnet_id_c }}'
+        - '{{ subnet_id_d }}'
+      register: update_subnets
+      check_mode: True
+
+    - name: Check result - Update Subnet Group subnets - check_mode
+      assert:
+        that:
+          - update_subnets is successful
+          - update_subnets is changed
+
     - name: Update Subnet Group subnets
       redshift_subnet_group:
         state: present
@@ -247,6 +355,24 @@
           - subnet_id_c in update_subnets.cluster_subnet_group.subnet_ids
           - subnet_id_d in update_subnets.cluster_subnet_group.subnet_ids
           - update_subnets.cluster_subnet_group.vpc_id == vpc_id
+
+    - name: Update Subnet Group subnets - idempotency - check_mode
+      redshift_subnet_group:
+        state: present
+        group_name: '{{ group_name }}'
+        ## No longer mandatory
+        # group_description: '{{ description_updated }}'
+        group_subnets:
+        - '{{ subnet_id_c }}'
+        - '{{ subnet_id_d }}'
+      register: update_subnets
+      check_mode: True
+
+    - name: Check result - Update Subnet Group subnets - idempotency - check_mode
+      assert:
+        that:
+          - update_subnets is successful
+          - update_subnets is not changed
 
     - name: Update Subnet Group subnets - idempotency
       redshift_subnet_group:
@@ -283,6 +409,18 @@
 
     # ============================================================
 
+    - name: Delete Subnet Group - check_mode
+      redshift_subnet_group:
+        state: absent
+        group_name: '{{ group_name }}'
+      register: delete_group
+      check_mode: True
+
+    - name: Check result - Delete Subnet Group - check_mode
+      assert:
+        that:
+          - delete_group is changed
+
     - name: Delete Subnet Group
       redshift_subnet_group:
         state: absent
@@ -293,6 +431,18 @@
       assert:
         that:
           - delete_group is changed
+
+    - name: Delete Subnet Group - idempotency - check_mode
+      redshift_subnet_group:
+        state: absent
+        group_name: '{{ group_name }}'
+      register: delete_group
+      check_mode: True
+
+    - name: Check result - Delete Subnet Group - idempotency - check_mode
+      assert:
+        that:
+          - delete_group is not changed
 
     - name: Delete Subnet Group - idempotency
       redshift_subnet_group:
@@ -306,6 +456,21 @@
           - delete_group is not changed
 
     # ============================================================
+
+    - name: Create minimal Subnet Group - check_mode
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+      register: create_group
+      check_mode: True
+
+    - name: Check result - Create minimal Subnet Group - check_mode
+      assert:
+        that:
+          - create_group is successful
+          - create_group is changed
 
     - name: Create minimal Subnet Group
       redshift_subnet_group:
@@ -336,6 +501,21 @@
           - subnet_id_c not in create_group.cluster_subnet_group.subnet_ids
           - subnet_id_d not in create_group.cluster_subnet_group.subnet_ids
           - create_group.cluster_subnet_group.vpc_id == vpc_id
+
+    - name: Create minimal Subnet Group - idempotency - check_mode
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+      register: create_group
+      check_mode: True
+
+    - name: Check result - Create minimal Subnet Group - idempotency - check_mode
+      assert:
+        that:
+          - create_group is successful
+          - create_group is not changed
 
     - name: Create minimal Subnet Group - idempotency
       redshift_subnet_group:
@@ -369,6 +549,23 @@
 
     # ============================================================
 
+    - name: Full Update Subnet Group - check_mode
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        description: '{{ description_updated }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+        - '{{ subnet_id_b }}'
+      register: update_complex
+      check_mode: True
+
+    - name: Check result - Full Update Subnet Group - check_mode
+      assert:
+        that:
+          - update_complex is successful
+          - update_complex is changed
+
     - name: Full Update Subnet Group
       redshift_subnet_group:
         state: present
@@ -400,6 +597,23 @@
           - subnet_id_c not in update_complex.cluster_subnet_group.subnet_ids
           - subnet_id_d not in update_complex.cluster_subnet_group.subnet_ids
           - update_complex.cluster_subnet_group.vpc_id == vpc_id
+
+    - name: Full Update Subnet Group - idempotency - check_mode
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        description: '{{ description_updated }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+        - '{{ subnet_id_b }}'
+      register: update_complex
+      check_mode: True
+
+    - name: Check result - Full Update Subnet Group - idempotency - check_mode
+      assert:
+        that:
+          - update_complex is successful
+          - update_complex is not changed
 
     - name: Full Update Subnet Group - idempotency
       redshift_subnet_group:

--- a/tests/integration/targets/redshift_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/redshift_subnet_group/tasks/main.yml
@@ -14,6 +14,28 @@
       security_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
+
+    # ============================================================
+
+    - name: Create Subnet Group with no subnets
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+      register: create_group
+      ignore_errors: True
+
+    - name: Check result - Create Subnet Group with no subnets
+      assert:
+        that:
+          - create_group is failed
+          # Check we caught the issue before trying to create
+          - '"CreateClusterSubnetGroup" not in create_group.resource_actions'
+          # Check that we don't refer to the boto3 parameter
+          - '"subnetIds" not in create_group.msg'
+          # Loosely check the message
+          - '"subnet" in create_group.msg'
+          - '"At least" in create_group.msg'
+
     # ============================================================
     # Setup infra needed for tests
     - name: create a VPC
@@ -56,6 +78,7 @@
         subnet_id_b: '{{ vpc_subnet_create.results[1].subnet.id }}'
         subnet_id_c: '{{ vpc_subnet_create.results[2].subnet.id }}'
         subnet_id_d: '{{ vpc_subnet_create.results[3].subnet.id }}'
+
     # ============================================================
 
     - name: Create Subnet Group
@@ -215,6 +238,103 @@
       assert:
         that:
           - delete_group is not changed
+
+    # ============================================================
+
+    - name: Create minimal Subnet Group
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+      register: create_group
+
+    - name: Check result - Create minimal Subnet Group
+      assert:
+        that:
+          - create_group is successful
+          - create_group is changed
+          - '"group" in create_group'
+          - '"name" in create_group.group'
+          - '"vpc_id" in create_group.group'
+          - create_group.group.name == group_name
+          - create_group.group.vpc_id == vpc_id
+
+    - name: Create minimal Subnet Group - idempotency
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+      register: create_group
+
+    - name: Check result - Create minimal Subnet Group - idempotency
+      assert:
+        that:
+          - create_group is successful
+          - create_group is not changed
+          - '"group" in create_group'
+          - '"name" in create_group.group'
+          - '"vpc_id" in create_group.group'
+          - create_group.group.name == group_name
+          - create_group.group.vpc_id == vpc_id
+
+    # ============================================================
+
+    - name: Full Update Subnet Group
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        description: '{{ description_updated }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+        - '{{ subnet_id_b }}'
+      register: update_complex
+
+    - name: Check result - Full Update Subnet Group
+      assert:
+        that:
+          - update_complex is successful
+          - update_complex is changed
+          - '"group" in update_complex'
+          - '"name" in update_complex.group'
+          - '"vpc_id" in update_complex.group'
+          - update_complex.group.name == group_name
+          - update_complex.group.vpc_id == vpc_id
+
+    - name: Full Update Subnet Group - idempotency
+      redshift_subnet_group:
+        state: present
+        name: '{{ group_name }}'
+        description: '{{ description_updated }}'
+        subnets:
+        - '{{ subnet_id_a }}'
+        - '{{ subnet_id_b }}'
+      register: update_complex
+
+    - name: Check result - Full Update Subnet Group - idempotency
+      assert:
+        that:
+          - update_complex is successful
+          - update_complex is not changed
+          - '"group" in update_complex'
+          - '"name" in update_complex.group'
+          - '"vpc_id" in update_complex.group'
+          - update_complex.group.name == group_name
+          - update_complex.group.vpc_id == vpc_id
+
+    # ============================================================
+
+    - name: Delete Subnet Group
+      redshift_subnet_group:
+        state: absent
+        name: '{{ group_name }}'
+      register: delete_group
+
+    - name: Check result - Delete Subnet Group
+      assert:
+        that:
+          - delete_group is changed
 
   always:
 

--- a/tests/integration/targets/redshift_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/redshift_subnet_group/tasks/main.yml
@@ -101,6 +101,17 @@
           - '"vpc_id" in create_group.group'
           - create_group.group.name == group_name
           - create_group.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in create_group'
+          - '"description" in create_group.cluster_subnet_group'
+          - '"subnet_ids" in create_group.cluster_subnet_group'
+          - '"vpc_id" in create_group.cluster_subnet_group'
+          - create_group.cluster_subnet_group.name == group_name
+          - create_group.cluster_subnet_group.description == description_default
+          - subnet_id_a in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_b in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in create_group.cluster_subnet_group.subnet_ids
+          - create_group.cluster_subnet_group.vpc_id == vpc_id
 
     - name: Create Subnet Group - idempotency
       redshift_subnet_group:
@@ -122,6 +133,17 @@
           - '"vpc_id" in create_group.group'
           - create_group.group.name == group_name
           - create_group.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in create_group'
+          - '"description" in create_group.cluster_subnet_group'
+          - '"subnet_ids" in create_group.cluster_subnet_group'
+          - '"vpc_id" in create_group.cluster_subnet_group'
+          - create_group.cluster_subnet_group.name == group_name
+          - create_group.cluster_subnet_group.description == description_default
+          - subnet_id_a in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_b in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in create_group.cluster_subnet_group.subnet_ids
+          - create_group.cluster_subnet_group.vpc_id == vpc_id
 
     # ============================================================
 
@@ -146,6 +168,17 @@
           - '"vpc_id" in update_description.group'
           - update_description.group.name == group_name
           - update_description.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in update_description'
+          - '"description" in update_description.cluster_subnet_group'
+          - '"subnet_ids" in update_description.cluster_subnet_group'
+          - '"vpc_id" in update_description.cluster_subnet_group'
+          - update_description.cluster_subnet_group.name == group_name
+          - update_description.cluster_subnet_group.description == description_updated
+          - subnet_id_a in update_description.cluster_subnet_group.subnet_ids
+          - subnet_id_b in update_description.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in update_description.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in update_description.cluster_subnet_group.subnet_ids
+          - update_description.cluster_subnet_group.vpc_id == vpc_id
 
     - name: Update Subnet Group Description - idempotency
       redshift_subnet_group:
@@ -168,6 +201,17 @@
           - '"vpc_id" in update_description.group'
           - update_description.group.name == group_name
           - update_description.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in update_description'
+          - '"description" in update_description.cluster_subnet_group'
+          - '"subnet_ids" in update_description.cluster_subnet_group'
+          - '"vpc_id" in update_description.cluster_subnet_group'
+          - update_description.cluster_subnet_group.name == group_name
+          - update_description.cluster_subnet_group.description == description_updated
+          - subnet_id_a in update_description.cluster_subnet_group.subnet_ids
+          - subnet_id_b in update_description.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in update_description.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in update_description.cluster_subnet_group.subnet_ids
+          - update_description.cluster_subnet_group.vpc_id == vpc_id
 
     # ============================================================
 
@@ -192,6 +236,17 @@
           - '"vpc_id" in update_subnets.group'
           - update_subnets.group.name == group_name
           - update_subnets.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in update_subnets'
+          - '"description" in update_subnets.cluster_subnet_group'
+          - '"subnet_ids" in update_subnets.cluster_subnet_group'
+          - '"vpc_id" in update_subnets.cluster_subnet_group'
+          - update_subnets.cluster_subnet_group.name == group_name
+          - update_subnets.cluster_subnet_group.description == description_updated
+          - subnet_id_a not in update_subnets.cluster_subnet_group.subnet_ids
+          - subnet_id_b not in update_subnets.cluster_subnet_group.subnet_ids
+          - subnet_id_c in update_subnets.cluster_subnet_group.subnet_ids
+          - subnet_id_d in update_subnets.cluster_subnet_group.subnet_ids
+          - update_subnets.cluster_subnet_group.vpc_id == vpc_id
 
     - name: Update Subnet Group subnets - idempotency
       redshift_subnet_group:
@@ -214,6 +269,17 @@
           - '"vpc_id" in update_subnets.group'
           - update_subnets.group.name == group_name
           - update_subnets.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in update_subnets'
+          - '"description" in update_subnets.cluster_subnet_group'
+          - '"subnet_ids" in update_subnets.cluster_subnet_group'
+          - '"vpc_id" in update_subnets.cluster_subnet_group'
+          - update_subnets.cluster_subnet_group.name == group_name
+          - update_subnets.cluster_subnet_group.description == description_updated
+          - subnet_id_a not in update_subnets.cluster_subnet_group.subnet_ids
+          - subnet_id_b not in update_subnets.cluster_subnet_group.subnet_ids
+          - subnet_id_c in update_subnets.cluster_subnet_group.subnet_ids
+          - subnet_id_d in update_subnets.cluster_subnet_group.subnet_ids
+          - update_subnets.cluster_subnet_group.vpc_id == vpc_id
 
     # ============================================================
 
@@ -259,6 +325,17 @@
           - '"vpc_id" in create_group.group'
           - create_group.group.name == group_name
           - create_group.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in create_group'
+          - '"description" in create_group.cluster_subnet_group'
+          - '"subnet_ids" in create_group.cluster_subnet_group'
+          - '"vpc_id" in create_group.cluster_subnet_group'
+          - create_group.cluster_subnet_group.name == group_name
+          - create_group.cluster_subnet_group.description == group_name
+          - subnet_id_a in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_b not in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in create_group.cluster_subnet_group.subnet_ids
+          - create_group.cluster_subnet_group.vpc_id == vpc_id
 
     - name: Create minimal Subnet Group - idempotency
       redshift_subnet_group:
@@ -278,6 +355,17 @@
           - '"vpc_id" in create_group.group'
           - create_group.group.name == group_name
           - create_group.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in create_group'
+          - '"description" in create_group.cluster_subnet_group'
+          - '"subnet_ids" in create_group.cluster_subnet_group'
+          - '"vpc_id" in create_group.cluster_subnet_group'
+          - create_group.cluster_subnet_group.name == group_name
+          - create_group.cluster_subnet_group.description == group_name
+          - subnet_id_a in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_b not in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in create_group.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in create_group.cluster_subnet_group.subnet_ids
+          - create_group.cluster_subnet_group.vpc_id == vpc_id
 
     # ============================================================
 
@@ -301,6 +389,17 @@
           - '"vpc_id" in update_complex.group'
           - update_complex.group.name == group_name
           - update_complex.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in update_complex'
+          - '"description" in update_complex.cluster_subnet_group'
+          - '"subnet_ids" in update_complex.cluster_subnet_group'
+          - '"vpc_id" in update_complex.cluster_subnet_group'
+          - update_complex.cluster_subnet_group.name == group_name
+          - update_complex.cluster_subnet_group.description == description_updated
+          - subnet_id_a in update_complex.cluster_subnet_group.subnet_ids
+          - subnet_id_b in update_complex.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in update_complex.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in update_complex.cluster_subnet_group.subnet_ids
+          - update_complex.cluster_subnet_group.vpc_id == vpc_id
 
     - name: Full Update Subnet Group - idempotency
       redshift_subnet_group:
@@ -322,6 +421,17 @@
           - '"vpc_id" in update_complex.group'
           - update_complex.group.name == group_name
           - update_complex.group.vpc_id == vpc_id
+          - '"cluster_subnet_group" in update_complex'
+          - '"description" in update_complex.cluster_subnet_group'
+          - '"subnet_ids" in update_complex.cluster_subnet_group'
+          - '"vpc_id" in update_complex.cluster_subnet_group'
+          - update_complex.cluster_subnet_group.name == group_name
+          - update_complex.cluster_subnet_group.description == description_updated
+          - subnet_id_a in update_complex.cluster_subnet_group.subnet_ids
+          - subnet_id_b in update_complex.cluster_subnet_group.subnet_ids
+          - subnet_id_c not in update_complex.cluster_subnet_group.subnet_ids
+          - subnet_id_d not in update_complex.cluster_subnet_group.subnet_ids
+          - update_complex.cluster_subnet_group.vpc_id == vpc_id
 
     # ============================================================
 


### PR DESCRIPTION
##### SUMMARY

Migrate redshift_subnet_group to boto3

note: while there additional features (tagging springs to mind) that could be added, I'm trying to avoid scope creep and mostly just want to knock out migrations of the remaining old-boto modules.  That said, I am converting tags using the boto3_tag_list_to_ansible_dict helper, in the return values this is just to avoid needing to change formats in future

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

redshift_subnet_group

##### ADDITIONAL INFORMATION

Depends-On: #719 