### PR TITLE
Fix EIP allocation with in_vpc not set

### DIFF
--- a/changelogs/fragments/731-ec2_eip-not_in_vpc.yml
+++ b/changelogs/fragments/731-ec2_eip-not_in_vpc.yml
@@ -1,0 +1,2 @@
+bug_fixes:
+- ec2_eip - fix bug when allocating an EIP but not associating it to a VPC (https://github.com/ansible-collections/community.aws/pull/731).

--- a/changelogs/fragments/731-ec2_eip-not_in_vpc.yml
+++ b/changelogs/fragments/731-ec2_eip-not_in_vpc.yml
@@ -1,2 +1,2 @@
-bug_fixes:
+bugfixes:
 - ec2_eip - fix bug when allocating an EIP but not associating it to a VPC (https://github.com/ansible-collections/community.aws/pull/731).

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -344,10 +344,11 @@ def address_is_associated_with_device(ec2, module, address, device_id, is_instan
 
 def allocate_address(ec2, module, domain, reuse_existing_ip_allowed, check_mode, tag_dict=None, public_ipv4_pool=None):
     """ Allocate a new elastic IP address (when needed) and return it """
+    if not domain:
+        domain = 'standard'
+
     if reuse_existing_ip_allowed:
         filters = []
-        if not domain:
-            domain = 'standard'
         filters.append({'Name': 'domain', "Values": [domain]})
 
         if tag_dict is not None:

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -662,6 +662,25 @@
       state: absent
       name: '{{ resource_prefix }}-vpc'
       cidr_block: '{{ vpc_cidr }}'
+
+  - name: Create an EIP outside a VPC
+    ec2_eip:
+      state: present
+      in_vpc: '{{ omit }}'
+    register: unbound_eip
+  - assert:
+      that:
+      - unbound_eip is successful
+      - unbound_eip is changed
+  - name: Release EIP
+    ec2_eip:
+      state: absent
+      public_ip: '{{ unbound_eip.public_ip }}'
+    register: release_unbound_eip
+  - assert:
+      that:
+      - release_unbound_eip is successful
+      - release_unbound_eip is changed
   # =====================================================
   always:
   - name: Cleanup instance (by id)
@@ -734,6 +753,12 @@
       state: absent
       public_ip: '{{ no_tagged_eip.public_ip }}'
     when: no_tagged_eip is changed
+    ignore_errors: true
+  - name: Cleanup unbound_eip
+    ec2_eip:
+      state: absent
+      public_ip: '{{ unbound_eip.public_ip }}'
+    when: unbound_eip is changed
     ignore_errors: true
   - name: Cleanup VPC
     ec2_vpc_net:


### PR DESCRIPTION
##### SUMMARY

Our integration tests were setting in_vpc (because most use-cases need it) so we missed that setting the minimum possible configuration for an EIP resulted in an exception:
```
ec2_eip:
  state: present
  in_vpc: '{{ omit }}'
```

```TASK [ec2_eip : Create an EIP outside a VPC] ***********************************
task path: /root/ansible_collections/community/aws/tests/output/.tmp/integration/ec2_eip-hkuj00lj-ÅÑŚÌβŁÈ/tests/integration/targets/ec2_eip/tasks/main.yml:666
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c 'echo ~root && sleep 0'
<testhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289 `" && echo ansible-tmp-1632477941.356962-3535-26932306567289="` echo /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289 `" ) && sleep 0'
Using module file /root/ansible_collections/community/aws/plugins/modules/ec2_eip.py
<testhost> PUT /root/.ansible/tmp/ansible-local-1077my3ghuvo/tmp0lqxcnwq TO /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289/AnsiballZ_ec2_eip.py
<testhost> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289/ /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289/AnsiballZ_ec2_eip.py && sleep 0'
<testhost> EXEC /bin/sh -c 'ANSIBLE_DEBUG_BOTOCORE_LOGS=True /usr/bin/python3.9 /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289/AnsiballZ_ec2_eip.py && sleep 0'
<testhost> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1632477941.356962-3535-26932306567289/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_ec2_eip_payload_rqxrzx_j/ansible_ec2_eip_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_eip.py", line 376, in allocate_address
  File "/tmp/ansible_ec2_eip_payload_rqxrzx_j/ansible_ec2_eip_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/core.py", line 334, in deciding_wrapper
    return retrying_wrapper(*args, **kwargs)
  File "/tmp/ansible_ec2_eip_payload_rqxrzx_j/ansible_ec2_eip_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py", line 118, in _retry_wrapper
    return _retry_func(
  File "/tmp/ansible_ec2_eip_payload_rqxrzx_j/ansible_ec2_eip_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py", line 68, in _retry_func
    return func()
  File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 337, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 628, in _make_api_call
    request_dict = self._convert_to_request_dict(
  File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 676, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
  File "/usr/local/lib/python3.9/dist-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Domain, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
fatal: [testhost]: FAILED! => {
    "boto3_version": "1.15.0",
    "botocore_version": "1.18.0",
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_reassociation": false,
            "aws_access_key": "AKIAQAEICK57ETHUOKNO",
            "aws_ca_bundle": null,
            "aws_config": null,
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "debug_botocore_endpoint_logs": true,
            "device_id": null,
            "ec2_url": null,
            "in_vpc": false,
            "private_ip_address": null,
            "profile": null,
            "public_ip": null,
            "public_ipv4_pool": null,
            "region": "us-east-1",
            "release_on_disassociation": false,
            "reuse_existing_ip_allowed": false,
            "security_token": null,
            "state": "present",
            "tag_name": null,
            "tag_value": null,
            "validate_certs": true,
            "wait_timeout": null
        }
    },
    "msg": "Couldn't allocate Elastic IP address: Parameter validation failed:\nInvalid type for parameter Domain, value: None, type: <class 'NoneType'>, valid types: <class 'str'>",
    "resource_actions": []
}
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_eip

##### ADDITIONAL INFORMATION