### PR TITLE
Deprecate passing file names to the iam_server_certificate module

### DIFF
--- a/changelogs/fragments/735-iam_server_certificate-file-names.yml
+++ b/changelogs/fragments/735-iam_server_certificate-file-names.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- iam_server_certificate - Passing file names to the ``cert``, ``chain_cert`` and ``key`` parameters has been deprecated.
+  We recommend using a lookup plugin to read the files instead, see the documentation for an example (https://github.com/ansible-collections/community.aws/pull/735).

--- a/plugins/modules/iam_server_certificate.py
+++ b/plugins/modules/iam_server_certificate.py
@@ -56,17 +56,23 @@ options:
   cert_chain:
     description:
       - The path to, or content of, the CA certificate chain in PEM encoded format.
-        As of 2.4 content is accepted. If the parameter is not a file, it is assumed to be content.
+      - If the parameter is not a file, it is assumed to be content.
+      - Passing a file name is deprecated, and support will be dropped in
+        version 4.0.0 of this collection.
     type: str
   cert:
     description:
       - The path to, or content of the certificate body in PEM encoded format.
-        As of 2.4 content is accepted. If the parameter is not a file, it is assumed to be content.
+      - If the parameter is not a file, it is assumed to be content.
+      - Passing a file name is deprecated, and support will be dropped in
+        version 4.0.0 of this collection.
     type: str
   key:
     description:
       - The path to, or content of the private key in PEM encoded format.
-        As of 2.4 content is accepted. If the parameter is not a file, it is assumed to be content.
+        If the parameter is not a file, it is assumed to be content.
+      - Passing a file name is deprecated, and support will be dropped in
+        version 4.0.0 of this collection.
     type: str
   dup_ok:
     description:
@@ -231,16 +237,31 @@ def load_data(cert, key, cert_chain):
     if cert and os.path.isfile(cert):
         with open(cert, 'r') as cert_fh:
             cert = cert_fh.read().rstrip()
+        module.deprecate(
+            'Passing a file name as the cert argument has been deprecated.  '
+            'Please use a lookup instead, see the documentation for examples.',
+            version='4.0.0', collection_name='community.aws')
     if key and os.path.isfile(key):
         with open(key, 'r') as key_fh:
             key = key_fh.read().rstrip()
+        module.deprecate(
+            'Passing a file name as the key argument has been deprecated.  '
+            'Please use a lookup instead, see the documentation for examples.',
+            version='4.0.0', collection_name='community.aws')
     if cert_chain and os.path.isfile(cert_chain):
         with open(cert_chain, 'r') as cert_chain_fh:
             cert_chain = cert_chain_fh.read()
+        module.deprecate(
+            'Passing a file name as the cert_chain argument has been deprecated.  '
+            'Please use a lookup instead, see the documentation for examples.',
+            version='4.0.0', collection_name='community.aws')
     return cert, key, cert_chain
 
 
 def main():
+
+    global module
+
     argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(required=True),


### PR DESCRIPTION
##### SUMMARY

iam_server_certificate currently accepts file names (or content) in the cert, chain_cert and key options.  Since the module directly uses `open()`.  This will perform a 'remote' lookup with unexpected results for relative file paths.  Encourage the use of lookups so that the behaviour will at least be predictable.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_server_certificate

##### ADDITIONAL INFORMATION