### PR TITLE
sns_topic - Define shape for delivery_policy.

### DIFF
--- a/changelogs/fragments/739-sns_topic-delivery_policy-shape.yml
+++ b/changelogs/fragments/739-sns_topic-delivery_policy-shape.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- sns_topic - define suboptions for delivery_policy option (https://github.com/ansible-collections/community.aws/issues/713).

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -127,7 +127,7 @@
       delivery_policy:
         http:
           defaultHealthyRetryPolicy:
-            minDelayTarget: 20
+            minDelayTarget: "20"
             maxDelayTarget: 20
             numRetries: 3
             numMaxDelayRetries: 0
@@ -153,7 +153,7 @@
       delivery_policy:
         http:
           defaultHealthyRetryPolicy:
-            minDelayTarget: 20
+            minDelayTarget: "20"
             maxDelayTarget: 20
             numRetries: 3
             numMaxDelayRetries: 0
@@ -179,7 +179,7 @@
       delivery_policy:
         http:
           defaultHealthyRetryPolicy:
-            minDelayTarget: 40
+            minDelayTarget: "40"
             maxDelayTarget: 40
             numRetries: 6
             numMaxDelayRetries: 0


### PR DESCRIPTION
##### SUMMARY

delivery_policy was previously defined just as "dict", this meant that if someone passed in JSON or quoted the numbers, AWS would spit errors at them.

By defining the shape of delivery_policy Ansible will automatically convert `"10"` to `10`, as well as providing cleaner error messages for missing components of the policy.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

sns_topic

##### ADDITIONAL INFORMATION

obsoletes #716 