### PR TITLE
Add tests config file to specificaly state that we're not interested in python < 3.6

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+    python_requires: '>=3.6'


### PR DESCRIPTION
##### SUMMARY

With Ansible 2.12 ansible-test supports explicitly defining the python version supported by a collection

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

sanity tests

##### ADDITIONAL INFORMATION
