### PR TITLE
Using the bucket's region for the GET URL

### DIFF
--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -542,7 +542,7 @@ class Connection(ConnectionBase):
         client = session.client(
             service,
             config=Config(signature_version="s3v4",
-	    s3={'addressing_style': 'virtual'}),
+            s3={'addressing_style': 'virtual'}),
             region_name=region_name
         )
         return client

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -508,7 +508,8 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name):
         ''' Generate URL for get_object / put_object '''
-        region_name = self.get_option('region') or 'us-east-1'
+        # Create a client using the bucket's region
+        region_name = self._get_boto_client('s3').get_bucket_location(Bucket=bucket_name)['LocationConstraint']  
         client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 
@@ -540,7 +541,9 @@ class Connection(ConnectionBase):
 
         client = session.client(
             service,
-            config=Config(signature_version="s3v4")
+            config=Config(signature_version="s3v4",
+	    s3={'addressing_style': 'virtual'}),
+            region_name=region_name
         )
         return client
 


### PR DESCRIPTION
##### SUMMARY
Some S3 buckets have location constraints (any bucket from an AWS region added after 2019), and s3 clients must be created in the correct region to generate a valid presigned URL

Fixes: #705 #637 
Supercedes: #722 #669

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ssm connection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook:
```
- hosts: i-XXXXX
  gather_facts: false
  vars:
    ansible_connection: aws_ssm
    ansible_user: ssm-user
    ansible_aws_ssm_bucket_name: ansible-ssm-test-12345
    ansible_aws_ssm_region: ap-east-1
    ansible_aws_ssm_profile: primary
    ansible_aws_ssm_timeout: 300
  tasks:
    - shell: hostname
      register: hostname
    - debug: msg="{{ hostname.stdout }}"

```

Before:
```% no_proxy="*"  ansible-playbook -i ansible_plugins/ec2.yml single_host_command.yml 

PLAY [i-XXXXXX] *********************************************************************************************************************************************************************************************************************************

TASK [shell] ***********************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform linux on host i-XXXXXX is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.11/reference_appendices/interpreter_discovery.html for more information.
fatal: [i-XXXX]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "module_stderr": "", "module_stdout": "  File \"/home/ssm-user/.ansible/tmp/ansible-tmp-XXXXX-38341-125329967694532/AnsiballZ_command.py\", line 1\r\r\n    <?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\r\n    ^\r\r\nSyntaxError: invalid syntax\r\r", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************
i-XXXXXXX        : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

exit status 2

```

After:
```% no_proxy="*"  ansible-playbook -i ansible_plugins/ec2.yml single_host_command.yml

PLAY [i-XXXXXXX] *********************************************************************************************************************************************************************************************************************************

TASK [shell] ***********************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform linux on host i-XXXX is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.11/reference_appendices/interpreter_discovery.html for more information.
changed: [i-XXXX]

TASK [debug] ***********************************************************************************************************************************************************************************************************************************************
ok: [i-XXXX] => {
    "msg": "ip-XXXXXXXX.ap-east-1.compute.internal"
}

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************
i-XXXXXXX        : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```
