### PR TITLE
Bulk update AWSRetry.backoff to AWSRetry.jittered_backoff

### DIFF
--- a/changelogs/fragments/764-awsretry-backoff.yml
+++ b/changelogs/fragments/764-awsretry-backoff.yml
@@ -1,0 +1,18 @@
+minor_changes:
+- aws_config_delivery_channel - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_direct_connect_confirm_connection - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_direct_connect_connection - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_direct_connect_link_aggregation_group - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_direct_connect_virtual_interface - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_inspector_target - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_kms - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- aws_kms_info - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- cloudformation_stack_set - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- dms_endpoint - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- dms_replication_subnet_group - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- ec2_asg - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- ec2_elb_info - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- ecs_service_info - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- iam_managed_policy - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- iam_saml_federation - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).
+- rds - replaced use of deprecated backoff decorator (https://github.com/ansible-collections/community.aws/pull/764).

--- a/plugins/modules/aws_config_delivery_channel.py
+++ b/plugins/modules/aws_config_delivery_channel.py
@@ -79,7 +79,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 # this waits for an IAM role to become fully available, at the cost of
 # taking a long time to fail when the IAM role/policy really is invalid
-retry_unavailable_iam_on_put_delivery = AWSRetry.backoff(
+retry_unavailable_iam_on_put_delivery = AWSRetry.jittered_backoff(
     catch_extra_error_codes=['InsufficientDeliveryPolicyException'],
 )
 

--- a/plugins/modules/aws_direct_connect_confirm_connection.py
+++ b/plugins/modules/aws_direct_connect_confirm_connection.py
@@ -69,10 +69,10 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.direct_connect import DirectConnectError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
-retry_params = {"tries": 10, "delay": 5, "backoff": 1.2, "catch_extra_error_codes": ["DirectConnectClientException"]}
+retry_params = {"retries": 10, "delay": 5, "backoff": 1.2, "catch_extra_error_codes": ["DirectConnectClientException"]}
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def describe_connections(client, params):
     return client.describe_connections(**params)
 

--- a/plugins/modules/aws_direct_connect_link_aggregation_group.py
+++ b/plugins/modules/aws_direct_connect_link_aggregation_group.py
@@ -265,7 +265,7 @@ def delete_lag(client, lag_id):
                                  exception=e)
 
 
-@AWSRetry.backoff(tries=5, delay=2, backoff=2.0, catch_extra_error_codes=['DirectConnectClientException'])
+@AWSRetry.jittered_backoff(retries=5, delay=2, backoff=2.0, catch_extra_error_codes=['DirectConnectClientException'])
 def _update_lag(client, lag_id, lag_name, min_links):
     params = {}
     if min_links:

--- a/plugins/modules/aws_direct_connect_virtual_interface.py
+++ b/plugins/modules/aws_direct_connect_virtual_interface.py
@@ -267,7 +267,7 @@ def try_except_ClientError(failure_msg):
     def wrapper(f):
         def run_func(*args, **kwargs):
             try:
-                result = AWSRetry.backoff(tries=8, delay=5, catch_extra_error_codes=['DirectConnectClientException'])(f)(*args, **kwargs)
+                result = AWSRetry.jittered_backoff(retries=8, delay=5, catch_extra_error_codes=['DirectConnectClientException'])(f)(*args, **kwargs)
             except (ClientError, BotoCoreError) as e:
                 raise DirectConnectError(failure_msg, traceback.format_exc(), e)
             return result

--- a/plugins/modules/aws_inspector_target.py
+++ b/plugins/modules/aws_inspector_target.py
@@ -110,7 +110,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def main():
     argument_spec = dict(
         name=dict(required=True),

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -434,19 +434,19 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_iam_roles_with_backoff(connection):
     paginator = connection.get_paginator('list_roles')
     return paginator.paginate().build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_keys_with_backoff(connection):
     paginator = connection.get_paginator('list_keys')
     return paginator.paginate().build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_aliases_with_backoff(connection):
     paginator = connection.get_paginator('list_aliases')
     return paginator.paginate().build_full_result()
@@ -465,30 +465,30 @@ def get_kms_aliases_lookup(connection):
     return _aliases
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_tags_with_backoff(connection, key_id, **kwargs):
     return connection.list_resource_tags(KeyId=key_id, **kwargs)
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_grants_with_backoff(connection, key_id):
     params = dict(KeyId=key_id)
     paginator = connection.get_paginator('list_grants')
     return paginator.paginate(**params).build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_metadata_with_backoff(connection, key_id):
     return connection.describe_key(KeyId=key_id)
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def list_key_policies_with_backoff(connection, key_id):
     paginator = connection.get_paginator('list_key_policies')
     return paginator.paginate(KeyId=key_id).build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_key_policy_with_backoff(connection, key_id, policy_name):
     return connection.get_key_policy(KeyId=key_id, PolicyName=policy_name)
 

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -261,13 +261,13 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_li
 _aliases = dict()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_keys_with_backoff(connection):
     paginator = connection.get_paginator('list_keys')
     return paginator.paginate().build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_aliases_with_backoff(connection):
     paginator = connection.get_paginator('list_aliases')
     return paginator.paginate().build_full_result()
@@ -286,12 +286,12 @@ def get_kms_aliases_lookup(connection):
     return _aliases
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_tags_with_backoff(connection, key_id, **kwargs):
     return connection.list_resource_tags(KeyId=key_id, **kwargs)
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_grants_with_backoff(connection, key_id, **kwargs):
     params = dict(KeyId=key_id)
     if kwargs.get('tokens'):
@@ -300,23 +300,23 @@ def get_kms_grants_with_backoff(connection, key_id, **kwargs):
     return paginator.paginate(**params).build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_kms_metadata_with_backoff(connection, key_id):
     return connection.describe_key(KeyId=key_id)
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def list_key_policies_with_backoff(connection, key_id):
     paginator = connection.get_paginator('list_key_policies')
     return paginator.paginate(KeyId=key_id).build_full_result()
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_key_policy_with_backoff(connection, key_id, policy_name):
     return connection.get_key_policy(KeyId=key_id, PolicyName=policy_name)
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def get_enable_key_rotation_with_backoff(connection, key_id):
     try:
         current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -361,7 +361,7 @@ def compare_stack_instances(cfn, stack_set_name, accounts, regions):
     return (desired_stack_instances - existing_stack_instances), existing_stack_instances, (existing_stack_instances - desired_stack_instances)
 
 
-@AWSRetry.backoff(tries=3, delay=4)
+@AWSRetry.jittered_backoff(retries=3, delay=4)
 def stack_set_facts(cfn, stack_set_name):
     try:
         ss = cfn.describe_stack_set(StackSetName=stack_set_name)['StackSet']

--- a/plugins/modules/dms_endpoint.py
+++ b/plugins/modules/dms_endpoint.py
@@ -175,10 +175,10 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
-backoff_params = dict(tries=5, delay=1, backoff=1.5)
+backoff_params = dict(retries=5, delay=1, backoff=1.5)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_endpoints(connection, endpoint_identifier):
     """ checks if the endpoint exists """
     try:
@@ -189,7 +189,7 @@ def describe_endpoints(connection, endpoint_identifier):
         return {'Endpoints': []}
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def dms_delete_endpoint(client, **params):
     """deletes the DMS endpoint based on the EndpointArn"""
     if module.params.get('wait'):
@@ -198,19 +198,19 @@ def dms_delete_endpoint(client, **params):
         return client.delete_endpoint(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def dms_create_endpoint(client, **params):
     """ creates the DMS endpoint"""
     return client.create_endpoint(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def dms_modify_endpoint(client, **params):
     """ updates the endpoint"""
     return client.modify_endpoint(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def get_endpoint_deleted_waiter(client):
     return client.get_waiter('endpoint_deleted')
 

--- a/plugins/modules/dms_replication_subnet_group.py
+++ b/plugins/modules/dms_replication_subnet_group.py
@@ -66,10 +66,10 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
-backoff_params = dict(tries=5, delay=1, backoff=1.5)
+backoff_params = dict(retries=5, delay=1, backoff=1.5)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_subnet_group(connection, subnet_group):
     """checks if instance exists"""
     try:
@@ -80,18 +80,18 @@ def describe_subnet_group(connection, subnet_group):
         return {'ReplicationSubnetGroups': []}
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def replication_subnet_group_create(connection, **params):
     """ creates the replication subnet group """
     return connection.create_replication_subnet_group(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def replication_subnet_group_modify(connection, **modify_params):
     return connection.modify_replication_subnet_group(**modify_params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def replication_subnet_group_delete(module, connection):
     subnetid = module.params.get('identifier')
     delete_parameters = dict(ReplicationSubnetGroupIdentifier=subnetid)

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -639,21 +639,21 @@ ASG_ATTRIBUTES = ('AvailabilityZones', 'DefaultCooldown', 'DesiredCapacity',
 
 INSTANCE_ATTRIBUTES = ('instance_id', 'health_status', 'lifecycle_state', 'launch_config_name')
 
-backoff_params = dict(tries=10, delay=3, backoff=1.5)
+backoff_params = dict(retries=10, delay=3, backoff=1.5)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_autoscaling_groups(connection, group_name):
     pg = connection.get_paginator('describe_auto_scaling_groups')
     return pg.paginate(AutoScalingGroupNames=[group_name]).build_full_result().get('AutoScalingGroups', [])
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def deregister_lb_instances(connection, lb_name, instance_id):
     connection.deregister_instances_from_load_balancer(LoadBalancerName=lb_name, Instances=[dict(InstanceId=instance_id)])
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_instance_health(connection, lb_name, instances):
     params = dict(LoadBalancerName=lb_name)
     if instances:
@@ -661,28 +661,28 @@ def describe_instance_health(connection, lb_name, instances):
     return connection.describe_instance_health(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_target_health(connection, target_group_arn, instances):
     return connection.describe_target_health(TargetGroupArn=target_group_arn, Targets=instances)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def suspend_asg_processes(connection, asg_name, processes):
     connection.suspend_processes(AutoScalingGroupName=asg_name, ScalingProcesses=processes)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def resume_asg_processes(connection, asg_name, processes):
     connection.resume_processes(AutoScalingGroupName=asg_name, ScalingProcesses=processes)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_launch_configurations(connection, launch_config_name):
     pg = connection.get_paginator('describe_launch_configurations')
     return pg.paginate(LaunchConfigurationNames=[launch_config_name]).build_full_result()
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def describe_launch_templates(connection, launch_template):
     if launch_template['launch_template_id'] is not None:
         try:
@@ -698,12 +698,12 @@ def describe_launch_templates(connection, launch_template):
             module.fail_json(msg="No launch template found matching: %s" % launch_template)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def create_asg(connection, **params):
     connection.create_auto_scaling_group(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def put_notification_config(connection, asg_name, topic_arn, notification_types):
     connection.put_notification_configuration(
         AutoScalingGroupName=asg_name,
@@ -712,7 +712,7 @@ def put_notification_config(connection, asg_name, topic_arn, notification_types)
     )
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def del_notification_config(connection, asg_name, topic_arn):
     connection.delete_notification_configuration(
         AutoScalingGroupName=asg_name,
@@ -720,37 +720,37 @@ def del_notification_config(connection, asg_name, topic_arn):
     )
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def attach_load_balancers(connection, asg_name, load_balancers):
     connection.attach_load_balancers(AutoScalingGroupName=asg_name, LoadBalancerNames=load_balancers)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def detach_load_balancers(connection, asg_name, load_balancers):
     connection.detach_load_balancers(AutoScalingGroupName=asg_name, LoadBalancerNames=load_balancers)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def attach_lb_target_groups(connection, asg_name, target_group_arns):
     connection.attach_load_balancer_target_groups(AutoScalingGroupName=asg_name, TargetGroupARNs=target_group_arns)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def detach_lb_target_groups(connection, asg_name, target_group_arns):
     connection.detach_load_balancer_target_groups(AutoScalingGroupName=asg_name, TargetGroupARNs=target_group_arns)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def update_asg(connection, **params):
     connection.update_auto_scaling_group(**params)
 
 
-@AWSRetry.backoff(catch_extra_error_codes=['ScalingActivityInProgress'], **backoff_params)
+@AWSRetry.jittered_backoff(catch_extra_error_codes=['ScalingActivityInProgress'], **backoff_params)
 def delete_asg(connection, asg_name, force_delete):
     connection.delete_auto_scaling_group(AutoScalingGroupName=asg_name, ForceDelete=force_delete)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.jittered_backoff(**backoff_params)
 def terminate_asg_instance(connection, instance_id, decrement_capacity):
     connection.terminate_instance_in_auto_scaling_group(InstanceId=instance_id,
                                                         ShouldDecrementDesiredCapacity=decrement_capacity)

--- a/plugins/modules/ec2_elb_info.py
+++ b/plugins/modules/ec2_elb_info.py
@@ -109,7 +109,7 @@ class ElbInformation(object):
         elb_tags = self.connection.get_list('DescribeTags', params, [('member', Tag)])
         return dict((tag.Key, tag.Value) for tag in elb_tags if hasattr(tag, 'Key'))
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
     def _get_elb_connection(self):
         return connect_to_aws(boto.ec2.elb, self.region, **self.aws_connect_params)
 
@@ -158,7 +158,7 @@ class ElbInformation(object):
             health_check_dict['ping_path'] = path
         return health_check_dict
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
     def _get_elb_info(self, elb):
         elb_info = {
             'name': elb.name,
@@ -202,7 +202,7 @@ class ElbInformation(object):
 
     def list_elbs(self):
         elb_array, token = [], None
-        get_elb_with_backoff = AWSRetry.backoff(tries=5, delay=5, backoff=2.0)(self.connection.get_all_load_balancers)
+        get_elb_with_backoff = AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)(self.connection.get_all_load_balancers)
         while True:
             all_elbs = get_elb_with_backoff(marker=token)
             token = all_elbs.next_marker

--- a/plugins/modules/ecs_service_info.py
+++ b/plugins/modules/ecs_service_info.py
@@ -148,7 +148,7 @@ class EcsServiceManager:
         self.module = module
         self.ecs = module.client('ecs')
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
     def list_services_with_backoff(self, **kwargs):
         paginator = self.ecs.get_paginator('list_services')
         try:
@@ -156,7 +156,7 @@ class EcsServiceManager:
         except is_boto3_error_code('ClusterNotFoundException') as e:
             self.module.fail_json_aws(e, "Could not find cluster to list services")
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
     def describe_services_with_backoff(self, **kwargs):
         return self.ecs.describe_services(**kwargs)
 

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -141,7 +141,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
 def list_policies_with_backoff(iam):
     paginator = iam.get_paginator('list_policies')
     return paginator.paginate(Scope='Local').build_full_result()

--- a/plugins/modules/iam_saml_federation.py
+++ b/plugins/modules/iam_saml_federation.py
@@ -123,23 +123,23 @@ class SAMLProviderManager:
             self.module.fail_json_aws(e, msg="Unknown boto error")
 
     # use retry decorator for boto3 calls
-    @AWSRetry.backoff(tries=3, delay=5)
+    @AWSRetry.jittered_backoff(retries=3, delay=5)
     def _list_saml_providers(self):
         return self.conn.list_saml_providers()
 
-    @AWSRetry.backoff(tries=3, delay=5)
+    @AWSRetry.jittered_backoff(retries=3, delay=5)
     def _get_saml_provider(self, arn):
         return self.conn.get_saml_provider(SAMLProviderArn=arn)
 
-    @AWSRetry.backoff(tries=3, delay=5)
+    @AWSRetry.jittered_backoff(retries=3, delay=5)
     def _update_saml_provider(self, arn, metadata):
         return self.conn.update_saml_provider(SAMLProviderArn=arn, SAMLMetadataDocument=metadata)
 
-    @AWSRetry.backoff(tries=3, delay=5)
+    @AWSRetry.jittered_backoff(retries=3, delay=5)
     def _create_saml_provider(self, metadata, name):
         return self.conn.create_saml_provider(SAMLMetadataDocument=metadata, Name=name)
 
-    @AWSRetry.backoff(tries=3, delay=5)
+    @AWSRetry.jittered_backoff(retries=3, delay=5)
     def _delete_saml_provider(self, arn):
         return self.conn.delete_saml_provider(SAMLProviderArn=arn)
 

--- a/plugins/modules/rds.py
+++ b/plugins/modules/rds.py
@@ -943,13 +943,13 @@ def await_resource(conn, resource, status, module):
             if resource.name is None:
                 module.fail_json(msg="There was a problem waiting for RDS snapshot %s" % resource.snapshot)
             # Back off if we're getting throttled, since we're just waiting anyway
-            resource = AWSRetry.backoff(tries=5, delay=20, backoff=1.5)(conn.get_db_snapshot)(resource.name)
+            resource = AWSRetry.jittered_backoff(retries=5, delay=20, backoff=1.5)(conn.get_db_snapshot)(resource.name)
         else:
             # Temporary until all the rds2 commands have their responses parsed
             if resource.name is None:
                 module.fail_json(msg="There was a problem waiting for RDS instance %s" % resource.instance)
             # Back off if we're getting throttled, since we're just waiting anyway
-            resource = AWSRetry.backoff(tries=5, delay=20, backoff=1.5)(conn.get_db_instance)(resource.name)
+            resource = AWSRetry.jittered_backoff(retries=5, delay=20, backoff=1.5)(conn.get_db_instance)(resource.name)
             if resource is None:
                 break
         # Some RDS resources take much longer than others to be ready. Check


### PR DESCRIPTION
##### SUMMARY

CloudRetry.backoff has been deprecated in favour of CloudRetry{exponential,jittered}_backoff

bulk update AWSRetry.backoff usage.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_config_delivery_channel.py
plugins/modules/aws_direct_connect_confirm_connection.py
plugins/modules/aws_direct_connect_connection.py
plugins/modules/aws_direct_connect_link_aggregation_group.py
plugins/modules/aws_direct_connect_virtual_interface.py
plugins/modules/aws_inspector_target.py
plugins/modules/aws_kms.py
plugins/modules/aws_kms_info.py
plugins/modules/cloudformation_stack_set.py
plugins/modules/dms_endpoint.py
plugins/modules/dms_replication_subnet_group.py
plugins/modules/ec2_asg.py
plugins/modules/ec2_elb_info.py
plugins/modules/ecs_service_info.py
plugins/modules/iam_managed_policy.py
plugins/modules/iam_saml_federation.py
plugins/modules/rds.py

##### ADDITIONAL INFORMATION