### PR TITLE
changed `kms_master_key_id` return value from `always`

### DIFF
--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -119,7 +119,7 @@ delay_seconds:
 kms_master_key_id:
     description: The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
     type: str
-    returned: always
+    returned: if value exists
     sample: alias/MyAlias
 kms_data_key_reuse_period_seconds:
     description: The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
changed `kms_master_key_id` return value from `always`
to `if value exists`. the boto3 response for sqs_queue should
only return a `kms_master_key_id` if a value for that key
exists
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sqs_queue