### PR TITLE
added clarification on SSE and `kms_master_key_id`

### DIFF
--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -117,7 +117,7 @@ delay_seconds:
     returned: always
     sample: 0
 kms_master_key_id:
-    description: The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
+    description: The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. Specifying a valid `KmsMasterKeyId` will enable encryption automatically.
     type: str
     returned: if value exists
     sample: alias/MyAlias

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -72,7 +72,8 @@ options:
     type: dict
   kms_master_key_id:
     description:
-      - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. Specifying a valid `KmsMasterKeyId` will enable encryption automatically.
+      - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
+      - Specifying a valid `KmsMasterKeyId` will enable encryption automatically.
     type: str
   kms_data_key_reuse_period_seconds:
     description:

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -73,7 +73,7 @@ options:
   kms_master_key_id:
     description:
       - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
-      - Specifying a valid `KmsMasterKeyId` will enable encryption automatically.
+      - Specifying a valid I(kms_master_key_id) will enable encryption automatically.
     type: str
   kms_data_key_reuse_period_seconds:
     description:

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -72,7 +72,7 @@ options:
     type: dict
   kms_master_key_id:
     description:
-      - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
+      - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. Specifying a valid `KmsMasterKeyId` will enable encryption automatically.
     type: str
   kms_data_key_reuse_period_seconds:
     description:
@@ -117,7 +117,7 @@ delay_seconds:
     returned: always
     sample: 0
 kms_master_key_id:
-    description: The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. Specifying a valid `KmsMasterKeyId` will enable encryption automatically.
+    description: The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
     type: str
     returned: if value exists
     sample: alias/MyAlias


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added note about `kms_master_key_id` and how SSE is enabled automatically.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sqs_queue