### PR TITLE
Add abort multipart upload and expire obj del markers to s3 lifecycle

### DIFF
--- a/changelogs/fragments/794-s3_lifecycle_abort_expire.yml
+++ b/changelogs/fragments/794-s3_lifecycle_abort_expire.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- Add I(abort_incomplete_multipart_upload_days) and I(expire_object_delete_marker) fields to I(s3_lifecycle)
+- s3_lifecycle - Add ``abort_incomplete_multipart_upload_days`` and ``expire_object_delete_marker`` parameters (https://github.com/ansible-collections/community.aws/pull/794).

--- a/changelogs/fragments/794-s3_lifecycle_abort_expire.yml
+++ b/changelogs/fragments/794-s3_lifecycle_abort_expire.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add I(abort_incomplete_multipart_upload_days) and I(expire_object_delete_marker) fields to I(s3_lifecycle)

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -27,7 +27,7 @@ options:
     description:
       - Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload.
     type: int
-    version_added: 2.2.0
+    version_added: 3.0.0
   expiration_date:
     description:
       - Indicates the lifetime of the objects that are subject to the rule by the date they will expire.

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -27,6 +27,7 @@ options:
     description:
       - Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload.
     type: int
+    version_added: 2.2.0
   expiration_date:
     description:
       - Indicates the lifetime of the objects that are subject to the rule by the date they will expire.
@@ -45,6 +46,7 @@ options:
       - If set to C(true), the delete marker will be expired; if set to C(false) the policy takes no action.
       - This cannot be specified with C(expiration_days) or C(expiration_date).
     type: bool
+    version_added: 2.2.0
   prefix:
     description:
       - Prefix identifying one or more objects to which the rule applies.

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -27,7 +27,7 @@ options:
     description:
       - Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload.
     type: int
-    version_added: 3.0.0
+    version_added: 2.2.0
   expiration_date:
     description:
       - Indicates the lifetime of the objects that are subject to the rule by the date they will expire.

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -32,7 +32,7 @@ options:
     description:
       - Indicates the lifetime of the objects that are subject to the rule by the date they will expire.
       - The value must be ISO-8601 format, the time must be midnight and a GMT timezone must be specified.
-      - This cannot be specified with C(expire_object_delete_marker)
+      - This cannot be specified with I(expire_object_delete_marker)
     type: str
   expiration_days:
     description:

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -38,7 +38,7 @@ options:
     description:
       - Indicates the lifetime, in days, of the objects that are subject to the rule.
       - The value must be a non-zero positive integer.
-      - This cannot be specified with C(expire_object_delete_marker)
+      - This cannot be specified with I(expire_object_delete_marker)
     type: int
   expire_object_delete_marker:
     description:

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -46,7 +46,7 @@ options:
       - If set to C(true), the delete marker will be expired; if set to C(false) the policy takes no action.
       - This cannot be specified with I(expiration_days) or I(expiration_date).
     type: bool
-    version_added: 3.0.0
+    version_added: 2.2.0
   prefix:
     description:
       - Prefix identifying one or more objects to which the rule applies.

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -44,7 +44,7 @@ options:
     description:
       - Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions.
       - If set to C(true), the delete marker will be expired; if set to C(false) the policy takes no action.
-      - This cannot be specified with C(expiration_days) or C(expiration_date).
+      - This cannot be specified with I(expiration_days) or I(expiration_date).
     type: bool
     version_added: 2.2.0
   prefix:

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -46,7 +46,7 @@ options:
       - If set to C(true), the delete marker will be expired; if set to C(false) the policy takes no action.
       - This cannot be specified with I(expiration_days) or I(expiration_date).
     type: bool
-    version_added: 2.2.0
+    version_added: 3.0.0
   prefix:
     description:
       - Prefix identifying one or more objects to which the rule applies.

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -42,7 +42,7 @@ options:
   expire_object_delete_marker:
     description:
       - Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions.
-      - If set to true, the delete marker will be expired; if set to false the policy takes no action.
+      - If set to C(true), the delete marker will be expired; if set to C(false) the policy takes no action.
       - This cannot be specified with C(expiration_days) or C(expiration_date).
     type: bool
   prefix:

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -326,6 +326,54 @@
     - assert:
         that:
           - output is not changed
+          
+  # ============================================================
+    - name: Create a lifecycle policy, with abort_incomplete_multipart_upload
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        abort_incomplete_multipart_upload_days: 1
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+  # ============================================================
+    - name: Create a lifecycle policy, with abort_incomplete_multipart_upload (idempotency)
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        abort_incomplete_multipart_upload_days: 1
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+
+  # ============================================================
+    - name: Create a lifecycle policy, with expired_object_delete_marker 
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        expire_object_delete_marker: True
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+  # ============================================================
+    - name: Create a lifecycle policy, with expired_object_delete_marker  (idempotency)
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        expire_object_delete_marker: True
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
 
   # ============================================================
   # test all the examples

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -326,7 +326,7 @@
     - assert:
         that:
           - output is not changed
-          
+
   # ============================================================
     - name: Create a lifecycle policy, with abort_incomplete_multipart_upload
       s3_lifecycle:
@@ -352,7 +352,7 @@
           - output is not changed
 
   # ============================================================
-    - name: Create a lifecycle policy, with expired_object_delete_marker 
+    - name: Create a lifecycle policy, with expired_object_delete_marker
       s3_lifecycle:
         name: '{{ bucket_name }}'
         expire_object_delete_marker: True


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1247

##### SUMMARY

Fixes ~~#365~~ #796 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

s3_lifecycle

##### ADDITIONAL INFORMATION

I have not run integration tests yet because of #793.


I'm unsure about how to name and structure the new arguments.
Do I nest them to match the API, or flatten them to match existing arguments?