### PR TITLE
route53: fix empty result set

### DIFF
--- a/changelogs/fragments/798-fix-route53-empty-result.yaml
+++ b/changelogs/fragments/798-fix-route53-empty-result.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - route53 - fix empty result on none existing records (https://github.com/ansible-collections/community.aws/pull/799).
+  - route53 - return empty result for nonexistent records (https://github.com/ansible-collections/community.aws/pull/799).

--- a/changelogs/fragments/798-fix-route53-empty-result.yaml
+++ b/changelogs/fragments/798-fix-route53-empty-result.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - route53 - fix empty result on none existing records (https://github.com/ansible-collections/community.aws/pull/799).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -637,6 +637,11 @@ def main():
             ns = get_hosted_zone_nameservers(route53, zone_id)
 
         formatted_aws = format_record(aws_record, zone_in, zone_id)
+
+        if formatted_aws is None:
+            # record does not exist
+            module.exit_json(changed=False, set=[], nameservers=ns, resource_record_sets=[])
+
         rr_sets = [camel_dict_to_snake_dict(aws_record)]
         module.exit_json(changed=False, set=formatted_aws, nameservers=ns, resource_record_sets=rr_sets)
 

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -417,6 +417,20 @@
         - get_result.set.ResourceRecords[0].Value == "192.0.2.1"
         - get_result.set.Type == "A"
 
+  - name: Get a record that does not exist
+    route53:
+      state: get
+      zone: "{{ zone_two }}"
+      record: "notfound.{{ zone_two }}"
+      type: A
+      private_zone: true
+    register: get_result
+  - assert:
+      that:
+        - get_result.nameservers|length > 0
+        - get_result.set|length == 0
+        - get_result.resource_record_sets|length == 0
+
   - name: Create same A record using zone non-qualified domain
     route53:
       state: present


### PR DESCRIPTION
##### SUMMARY
Closes: #798 
Using `state: get` on none existing records results in an error.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53

##### ADDITIONAL INFORMATION

```yml
---
- hosts: localhost
  connection: local

  tasks:
    - community.aws.route53:
        state: get
        zone: xn--mitlinuxwrdasnichtpassiert-ohc.de
        record: doesnotexist.xn--mitlinuxwrdasnichtpassiert-ohc.de.
        type: A
      register: test

    - debug:
        var: test
```

results in 

```
TASK [community.aws.route53] ********************************************************************************************************************************************************************************************************
task path: /home/m/git/lekker/iac/798.yml:6
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: m
<127.0.0.1> EXEC /bin/sh -c 'echo ~m && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/m/.ansible/tmp `"&& mkdir "` echo /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765 `" && echo ansible-tmp-1636703337.6553104-21549-57181038135765="` echo /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765 `" ) && sleep 0'
Using module file /home/m/.local/lib/python3.9/site-packages/ansible_collections/community/aws/plugins/modules/route53.py
<127.0.0.1> PUT /home/m/.ansible/tmp/ansible-local-21466oog6jc4o/tmpeo_xv0k3 TO /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/ /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py", line 100, in <module>
    _ansiballz_main()
  File "/home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py", line 92, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.route53', init_globals=dict(_module_fqn='ansible_collections.community.aws.plugins.modules.route53', _modlib_path=modlib_path),
  File "/usr/lib/python3.9/runpy.py", line 210, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_community.aws.route53_payload_aekaeeo1/ansible_community.aws.route53_payload.zip/ansible_collections/community/aws/plugins/modules/route53.py", line 698, in <module>
  File "/tmp/ansible_community.aws.route53_payload_aekaeeo1/ansible_community.aws.route53_payload.zip/ansible_collections/community/aws/plugins/modules/route53.py", line 636, in main
  File "/tmp/ansible_community.aws.route53_payload_aekaeeo1/ansible_community.aws.route53_payload.zip/ansible/module_utils/common/dict_transformations.py", line 42, in camel_dict_to_snake_dict
AttributeError: 'NoneType' object has no attribute 'items'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py\", line 100, in <module>\n    _ansiballz_main()\n  File \"/home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py\", line 92, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/m/.ansible/tmp/ansible-tmp-1636703337.6553104-21549-57181038135765/AnsiballZ_route53.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.route53', init_globals=dict(_module_fqn='ansible_collections.community.aws.plugins.modules.route53', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.aws.route53_payload_aekaeeo1/ansible_community.aws.route53_payload.zip/ansible_collections/community/aws/plugins/modules/route53.py\", line 698, in <module>\n  File \"/tmp/ansible_community.aws.route53_payload_aekaeeo1/ansible_community.aws.route53_payload.zip/ansible_collections/community/aws/plugins/modules/route53.py\", line 636, in main\n  File \"/tmp/ansible_community.aws.route53_payload_aekaeeo1/ansible_community.aws.route53_payload.zip/ansible/module_utils/common/dict_transformations.py\", line 42, in camel_dict_to_snake_dict\nAttributeError: 'NoneType' object has no attribute 'items'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
