### PR TITLE
Route53: fix diff mode when state: absent

### DIFF
--- a/changelogs/fragments/802-fix-diif-mode.yml
+++ b/changelogs/fragments/802-fix-diif-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- route53 -  fix diff mode when deleting records (https://github.com/ansible-collections/community.aws/pull/801).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -692,7 +692,7 @@ def main():
         changed=True,
         diff=dict(
             before=formatted_aws,
-            after=formatted_record if command != 'delete' else {},
+            after=formatted_record if command_in != 'delete' else {},
             resource_record_sets=rr_sets,
         ),
     )

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -386,6 +386,7 @@
       that:
         - wc_a_record is not failed
         - wc_a_record is changed
+        - wc_a_record.diff.after == {}
 
   # Tests on zone two (private zone)
   - name: Create A record using zone fqdn


### PR DESCRIPTION
##### SUMMARY
Fix diff mode when `state: absend`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53
