### PR TITLE
Add wildcard to credentials file in .gitignore

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,3 @@
 output/
-integration/cloud-config-aws.ini
-integration/cloud-config-aws.yml
+integration/cloud-config-*.ini
+integration/cloud-config-*.yml


### PR DESCRIPTION
##### SUMMARY
In addition to the static cloud-config-aws.(ini|yml) files devs can create, ansible-test may also create temporary credentials files with random strings in the filename.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitignore