### PR TITLE
add bucket_region support ansible manager multiple region ec2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -733,3 +733,4 @@ New Modules
 - sqs_queue - Creates or deletes AWS SQS queues.
 - sts_assume_role - Assume a role using AWS Security Token Service and obtain temporary credentials
 - sts_session_token - Obtain a session token from the AWS Security Token Service
+

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -44,6 +44,10 @@ options:
     vars:
     - name: ansible_aws_ssm_region
     default: 'us-east-1'
+  bucket_region:
+    description: The region the S3 bucket is located.
+    vars:
+    - name: ansible_aws_ssm_bucket_region
   bucket_name:
     description: The name of the S3 bucket used for file transfers.
     vars:
@@ -92,6 +96,7 @@ EXAMPLES = r'''
   vars:
     ansible_connection: aws_ssm
     ansible_aws_ssm_bucket_name: nameofthebucket
+    ansible_aws_ssm_bucket_region: us-west-1
     ansible_aws_ssm_region: us-west-2
   tasks:
     - name: Install a Nginx Package
@@ -105,6 +110,7 @@ EXAMPLES = r'''
     ansible_connection: aws_ssm
     ansible_shell_type: powershell
     ansible_aws_ssm_bucket_name: nameofthebucket
+    ansible_aws_ssm_bucket_region: us-west-2
     ansible_aws_ssm_region: us-east-1
   tasks:
     - name: Create a Directory
@@ -130,6 +136,7 @@ EXAMPLES = r'''
   vars:
     ansible_connection: aws_ssm
     ansible_aws_ssm_bucket_name: nameofthebucket
+    ansible_aws_ssm_bucket_region: us-west-2
     ansible_aws_ssm_region: us-east-1
   tasks:
   - name: aws-cli
@@ -154,6 +161,7 @@ EXAMPLES = r'''
     ansible_connection: aws_ssm
     ansible_shell_type: powershell
     ansible_aws_ssm_bucket_name: nameofthebucket
+    ansible_aws_ssm_bucket_region: us-west-2
     ansible_aws_ssm_region: us-east-1
   tasks:
     - name: Create the directory
@@ -508,7 +516,7 @@ class Connection(ConnectionBase):
 
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name):
         ''' Generate URL for get_object / put_object '''
-        region_name = self.get_option('region') or 'us-east-1'
+        region_name = self.get_option('bucket_region') or self.get_option('region')
         client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)
         return client.generate_presigned_url(client_method, Params={'Bucket': bucket_name, 'Key': out_path}, ExpiresIn=3600, HttpMethod=http_method)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add s3 bucket_region variable support ansible manager multiple region ec2
S3 bucket region can be different from EC2 region



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ssm connection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
