### PR TITLE
[3.0.0] Bump minimal botocore version to 1.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 2.0.0 of this collection supports `boto3 >= 1.15.0` and `botocore >= 1.18.0`
+Version 3.0.0 of this collection supports `boto3 >= 1.16.0` and `botocore >= 1.19.0`
 
 ## Included content
 <!--start collection content-->

--- a/changelogs/fragments/809-botocore-1-19-0.yml
+++ b/changelogs/fragments/809-botocore-1-19-0.yml
@@ -1,0 +1,7 @@
+major_changes:
+- community.aws collection - The community.aws collection has dropped support for
+  ``botocore<1.19.0`` and ``boto3<1.16.0``. Most modules will continue to work
+  with older versions of the AWS SDK, however compatability with older versions
+  of the SDK is not guaranteed and will not be tested. When using older versions
+  of the SDK a warning will be emitted by Ansible
+  (https://github.com/ansible-collections/community.aws/pull/809).

--- a/plugins/modules/aws_s3_bucket_info.py
+++ b/plugins/modules/aws_s3_bucket_info.py
@@ -80,7 +80,6 @@ options:
       bucket_ownership_controls:
         description:
         - Retrive S3 ownership controls.
-        - Access to bucket ownership controls requires botocore>=1.18.11.
         type: bool
         default: False
       bucket_website:
@@ -594,9 +593,6 @@ def main():
     if is_old_facts:
         module.deprecate("The 'aws_s3_bucket_facts' module has been renamed to 'aws_s3_bucket_info', "
                          "and the renamed one no longer returns ansible_facts", date='2021-12-01', collection_name='community.aws')
-
-    if module.params.get("bucket_ownership_controls"):
-        module.require_botocore_at_least('1.18.11', reason='to retreive bucket ownership controls')
 
     # Get parameters
     name = module.params.get("name")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.18.0
-boto3>=1.15.0
+botocore>=1.19.0
+boto3>=1.16.0
 # Final released version
 boto>=2.49.0

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.15.0
-botocore==1.18.0
+boto3==1.16.0
+botocore==1.19.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.18.141
+awscli==1.18.160

--- a/tests/integration/targets/setup_botocore_pip/defaults/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/defaults/main.yml
@@ -1,2 +1,2 @@
-default_botocore_version: '1.18.0'
-default_boto3_version: '1.15.0'
+default_botocore_version: '1.19.0'
+default_boto3_version: '1.16.0'

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.15.0
-botocore==1.18.0
+boto3==1.16.0
+botocore==1.19.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.18.141
+awscli==1.18.160


### PR DESCRIPTION
##### SUMMARY

In preparation for release 3.0.0, bump the minimal botocore version

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
plugins/modules/aws_s3_bucket_info.py
requirements.txt
tests/integration/constraints.txt
tests/integration/targets/setup_botocore_pip/defaults/main.yml
tests/unit/constraints.txt

##### ADDITIONAL INFORMATION

Depends-On: https://github.com/ansible-collections/amazon.aws/pull/574