### PR TITLE
Disable ssm connection tests

### DIFF
--- a/tests/integration/targets/connection_aws_ssm/aliases
+++ b/tests/integration/targets/connection_aws_ssm/aliases
@@ -1,5 +1,6 @@
 # reason: slow
 # This test suite can take almost 25 minutes (on a good day)
+disabled # Test is currently broken on Deb-based systems, and dependant ../connection dir access in ansible/default-test-container
 unstable
 
 cloud/aws


### PR DESCRIPTION
##### SUMMARY
Test is currently broken on Deb-based systems.  On CentOS (using local and ansible/default-test-container) the dependent tests/integration/target/connection dir is no longer available to the test execution

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
tests/integration/targets/connection_aws_ssm
