### PR TITLE
iam_user password management support

### DIFF
--- a/changelogs/fragments/822-add-password-support-iam_user.yml
+++ b/changelogs/fragments/822-add-password-support-iam_user.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - iam_user - add password management support bringing parity with `iam` module (https://github.com/ansible-collections/community.aws/pull/822).
+  - iam_user - add boto3 waiter for iam user creation (https://github.com/ansible-collections/community.aws/pull/822).

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -258,7 +258,7 @@ def create_or_update_login_profile(connection, module):
             connection.create_login_profile(**user_params)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Unable to create user login profile")
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e: # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to update user login profile")
 
     return True

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -38,7 +38,7 @@ options:
     version_added: 2.2.0
   remove_password:
     description:
-      - When to update delete user login passwords.
+      - Option to delete user login passwords.
       - This field is mutually exclusive to I(password).
     type: 'bool'
     version_added: 2.2.0

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -258,7 +258,7 @@ def create_or_update_login_profile(connection, module):
             connection.create_login_profile(**user_params)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Unable to create user login profile")
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e: # pylint: disable=duplicate-except
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to update user login profile")
 
     return True

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -26,6 +26,7 @@ options:
       - The password to apply to the user.
     required: false
     type: str
+    version_added: 2.2.0
   update_password:
     default: always
     choices: ['always', 'on_create']
@@ -34,6 +35,7 @@ options:
       - I(update_password=always) will ensure the password is set to I(password).
       - I(update_password=on_create) will only set the password for newly created users.
     type: str
+    version_added: 2.2.0
   managed_policies:
     description:
       - A list of managed policy ARNs or friendly names to attach to the user.
@@ -73,11 +75,13 @@ options:
         for IAM user creation before returning.
     default: True
     type: bool
+    version_added: 2.2.0
   wait_timeout:
     description:
       - How long (in seconds) to wait for creation / updates to complete.
     default: 120
     type: int
+    version_added: 2.2.0
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -319,7 +319,7 @@ def create_or_update_user(connection, module):
 
         if module.params['update_password'] == "always" and module.params.get('password') is not None:
             login_profile_result = create_or_update_login_profile(connection, module)
-        elif module.params.get('remove_password') is not None:
+        elif module.params.get('remove_password'):
             login_profile_result = delete_login_profile(connection, module)
 
         changed = bool(update_result) or bool(login_profile_result)

--- a/tests/integration/targets/iam_user/defaults/main.yml
+++ b/tests/integration/targets/iam_user/defaults/main.yml
@@ -2,8 +2,10 @@
 test_group: '{{ resource_prefix }}-group'
 test_path: '/'
 test_user:  '{{ test_users[0] }}'
+test_user3:  '{{ test_users[2] }}'
 test_password: ATotallySecureUncrackablePassword1!
 test_new_password: ATotallyNewSecureUncrackablePassword1!
 test_users:
   - '{{ resource_prefix }}-user-a'
   - '{{ resource_prefix }}-user-b'
+  - '{{ resource_prefix }}-user-c'

--- a/tests/integration/targets/iam_user/defaults/main.yml
+++ b/tests/integration/targets/iam_user/defaults/main.yml
@@ -2,6 +2,8 @@
 test_group: '{{ resource_prefix }}-group'
 test_path: '/'
 test_user:  '{{ test_users[0] }}'
+test_password: ATotallySecureUncrackablePassword1!
+test_new_password: ATotallyNewSecureUncrackablePassword1!
 test_users:
   - '{{ resource_prefix }}-user-a'
   - '{{ resource_prefix }}-user-b'

--- a/tests/integration/targets/iam_user/tasks/main.yml
+++ b/tests/integration/targets/iam_user/tasks/main.yml
@@ -240,10 +240,22 @@
         - iam_user.iam_user.user.tags | length == 0
 
   ## Test user password update
+  - name: test update IAM password with on_create only
+    iam_user:
+      name: "{{ test_user }}"
+      password: "{{ test_new_password }}"
+      update_password: "on_create"
+      state: present
+    register: iam_user_update
+
+  - assert:
+      that:
+        - iam_user_update is not changed
+
   - name: update IAM password
     iam_user:
       name: "{{ test_user }}"
-      new_password: "{{ test_new_password }}"
+      password: "{{ test_new_password }}"
       state: present
     register: iam_user_update
 

--- a/tests/integration/targets/iam_user/tasks/main.yml
+++ b/tests/integration/targets/iam_user/tasks/main.yml
@@ -11,10 +11,11 @@
   block:
   - name: ensure improper usage of parameters fails gracefully
     iam_user_info:
-      path: '{{ test_path }}'
-      group: '{{ test_group }}'
+      path: "{{ test_path }}"
+      group: "{{ test_group }}"
     ignore_errors: yes
     register: iam_user_info_path_group
+
   - assert:
       that:
         - iam_user_info_path_group is failed
@@ -22,7 +23,8 @@
 
   - name: create test user (check mode)
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
+      password: "{{ test_password }}"
       state: present
     check_mode: yes
     register: iam_user
@@ -34,7 +36,8 @@
 
   - name: create test user
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
+      password: "{{ test_password }}"
       state: present
     register: iam_user
 
@@ -45,7 +48,7 @@
 
   - name: ensure test user exists (no change)
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
     register: iam_user
 
@@ -56,7 +59,8 @@
 
   - name: ensure the info used to validate other tests is valid
     set_fact:
-        test_iam_user: '{{ iam_user.iam_user.user }}'
+      test_iam_user: "{{ iam_user.iam_user.user }}"
+
   - assert:
       that:
         - 'test_iam_user.arn.startswith("arn:aws:iam")'
@@ -70,15 +74,18 @@
   - name: get info on IAM user(s)
     iam_user_info:
     register: iam_user_info
+
   - assert:
       that:
         - iam_user_info.iam_users | length != 0
 
   - name: get info on IAM user(s) with name
     iam_user_info:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
     register: iam_user_info
+
   - debug: var=iam_user_info
+
   - assert:
       that:
         - iam_user_info.iam_users | length == 1
@@ -91,9 +98,10 @@
 
   - name: get info on IAM user(s) on path
     iam_user_info:
-      path: '{{ test_path }}'
-      name: '{{ test_user }}'
+      path: "{{ test_path }}"
+      name: "{{ test_user }}"
     register: iam_user_info
+
   - assert:
       that:
         - iam_user_info.iam_users | length == 1
@@ -104,39 +112,42 @@
         - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
         - iam_user_info.iam_users[0].tags | length == 0
 
-  - name: 'Add Tag'
+  ## Test tags creation / updates
+  - name: "Add Tag"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       tags:
         TagA: ValueA
     register: iam_user
+
   - assert:
       that:
-          - iam_user is changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 1
-          - '"TagA" in iam_user.iam_user.user.tags'
-          - iam_user.iam_user.user.tags.TagA == "ValueA"
+        - iam_user is changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 1
+        - '"TagA" in iam_user.iam_user.user.tags'
+        - iam_user.iam_user.user.tags.TagA == "ValueA"
 
-  - name: 'Add Tag (no change)'
+  - name: "Add Tag (no change)"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       tags:
         TagA: ValueA
     register: iam_user
+
   - assert:
       that:
-          - iam_user is not changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 1
-          - '"TagA" in iam_user.iam_user.user.tags'
-          - iam_user.iam_user.user.tags.TagA == "ValueA"
+        - iam_user is not changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 1
+        - '"TagA" in iam_user.iam_user.user.tags'
+        - iam_user.iam_user.user.tags.TagA == "ValueA"
 
-  - name: 'Extend Tags'
+  - name: "Extend Tags"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       purge_tags: no
       tags:
@@ -144,83 +155,102 @@
         "Tag C": "Value C"
         "tag d": "value d"
     register: iam_user
+
   - assert:
       that:
-          - iam_user is changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 4
-          - '"TagA" in iam_user.iam_user.user.tags'
-          - '"tag_b" in iam_user.iam_user.user.tags'
-          - '"Tag C" in iam_user.iam_user.user.tags'
-          - '"tag d" in iam_user.iam_user.user.tags'
-          - iam_user.iam_user.user.tags.TagA == "ValueA"
-          - iam_user.iam_user.user.tags.tag_b == "value_b"
-          - iam_user.iam_user.user.tags["Tag C"] == "Value C"
-          - iam_user.iam_user.user.tags["tag d"] == "value d"
+        - iam_user is changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 4
+        - '"TagA" in iam_user.iam_user.user.tags'
+        - '"tag_b" in iam_user.iam_user.user.tags'
+        - '"Tag C" in iam_user.iam_user.user.tags'
+        - '"tag d" in iam_user.iam_user.user.tags'
+        - iam_user.iam_user.user.tags.TagA == "ValueA"
+        - iam_user.iam_user.user.tags.tag_b == "value_b"
+        - iam_user.iam_user.user.tags["Tag C"] == "Value C"
+        - iam_user.iam_user.user.tags["tag d"] == "value d"
 
-  - name: 'Create user without Tag (no change)'
+  - name: "Create user without Tag (no change)"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
     register: iam_user
+
   - assert:
       that:
-          - iam_user is not changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 4
+        - iam_user is not changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 4
 
-  - name: 'Remove all Tags (check mode)'
+  - name: "Remove all Tags (check mode)"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       tags: {}
     check_mode: yes
     register: iam_user
+
   - assert:
       that:
-          - iam_user is changed
+        - iam_user is changed
 
-  - name: 'Remove 3 Tags'
+  - name: "Remove 3 Tags"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       tags:
         TagA: ValueA
     register: iam_user
+
   - assert:
       that:
-          - iam_user is changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 1
-          - '"TagA" in iam_user.iam_user.user.tags'
-          - iam_user.iam_user.user.tags.TagA == "ValueA"
+        - iam_user is changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 1
+        - '"TagA" in iam_user.iam_user.user.tags'
+        - iam_user.iam_user.user.tags.TagA == "ValueA"
 
-  - name: 'Change Tag'
+  - name: "Change Tag"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       tags:
         TagA: AnotherValueA
     register: iam_user
+
   - assert:
       that:
-          - iam_user is changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 1
-          - '"TagA" in iam_user.iam_user.user.tags'
-          - iam_user.iam_user.user.tags.TagA == "AnotherValueA"
-  
-  - name: 'Remove All Tags'
+        - iam_user is changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 1
+        - '"TagA" in iam_user.iam_user.user.tags'
+        - iam_user.iam_user.user.tags.TagA == "AnotherValueA"
+
+  - name: "Remove All Tags"
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       tags: {}
     register: iam_user
+
   - assert:
       that:
-          - iam_user is changed
-          - iam_user.iam_user.user.user_name == test_user
-          - iam_user.iam_user.user.tags | length == 0
+        - iam_user is changed
+        - iam_user.iam_user.user.user_name == test_user
+        - iam_user.iam_user.user.tags | length == 0
+
+  ## Test user password update
+  - name: update IAM password
+    iam_user:
+      name: "{{ test_user }}"
+      new_password: "{{ test_new_password }}"
+      state: present
+    register: iam_user_update
+
+  - assert:
+      that:
+        - iam_user_update is changed
+        - iam_user_update.iam_user.user.user_name == test_user
 
   # ===========================================
   # Test Managed Policy management
@@ -232,7 +262,7 @@
   - name: attach managed policy to user (check mode)
     check_mode: yes
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/AWSDenyAll
@@ -245,7 +275,7 @@
 
   - name: attach managed policy to user
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/AWSDenyAll
@@ -258,7 +288,7 @@
 
   - name: ensure managed policy is attached to user (no change)
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/AWSDenyAll
@@ -272,7 +302,7 @@
   - name: attach different managed policy to user (check mode)
     check_mode: yes
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
@@ -286,7 +316,7 @@
 
   - name: attach different managed policy to user
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
@@ -300,7 +330,7 @@
 
   - name: Check first policy wasn't purged
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
@@ -315,7 +345,7 @@
 
   - name: Check that managed policy order doesn't matter
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/AWSDenyAll
@@ -330,7 +360,7 @@
 
   - name: Check that policy doesn't require full ARN path
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - AWSDenyAll
@@ -346,7 +376,7 @@
   - name: Remove one of the managed policies - with purge (check mode)
     check_mode: yes
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
@@ -360,7 +390,7 @@
 
   - name: Remove one of the managed policies - with purge
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
@@ -374,7 +404,7 @@
 
   - name: Check we only have the one policy attached
     iam_user:
-      name: '{{ test_user }}'
+      name: "{{ test_user }}"
       state: present
       managed_policy:
         - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
@@ -388,9 +418,9 @@
 
   - name: ensure group exists
     iam_group:
-      name: '{{ test_group }}'
+      name: "{{ test_group }}"
       users:
-        - '{{ test_user }}'
+        - "{{ test_user }}"
       state: present
     register: iam_group
 
@@ -401,8 +431,8 @@
 
   - name: get info on IAM user(s) in group
     iam_user_info:
-      group: '{{ test_group }}'
-      name: '{{ test_user }}'
+      group: "{{ test_group }}"
+      name: "{{ test_user }}"
     register: iam_user_info
 
   - assert:
@@ -417,7 +447,7 @@
 
   - name: remove user from group
     iam_group:
-      name: '{{ test_group }}'
+      name: "{{ test_group }}"
       purge_users: True
       users: []
       state: present
@@ -425,8 +455,8 @@
 
   - name: get info on IAM user(s) after removing from group
     iam_user_info:
-      group: '{{ test_group }}'
-      name: '{{ test_user }}'
+      group: "{{ test_group }}"
+      name: "{{ test_user }}"
     register: iam_user_info
 
   - name: assert empty list of users for group are returned
@@ -436,9 +466,9 @@
 
   - name: ensure ansible users exist
     iam_user:
-      name: '{{ item }}'
+      name: "{{ item }}"
       state: present
-    with_items: '{{ test_users }}'
+    with_items: "{{ test_users }}"
 
   - name: get info on multiple IAM user(s)
     iam_user_info:
@@ -449,15 +479,15 @@
 
   - name: ensure multiple user group exists with single user
     iam_group:
-      name: '{{ test_group }}'
+      name: "{{ test_group }}"
       users:
-        - '{{ test_user }}'
+        - "{{ test_user }}"
       state: present
     register: iam_group
 
   - name: get info on IAM user(s) in group
     iam_user_info:
-      group: '{{ test_group }}'
+      group: "{{ test_group }}"
     register: iam_user_info
   - assert:
       that:
@@ -465,14 +495,14 @@
 
   - name: add all users to group
     iam_group:
-      name: '{{ test_group }}'
-      users: '{{ test_users }}'
+      name: "{{ test_group }}"
+      users: "{{ test_users }}"
       state: present
     register: iam_group
 
   - name: get info on multiple IAM user(s) in group
     iam_user_info:
-      group: '{{ test_group }}'
+      group: "{{ test_group }}"
     register: iam_user_info
   - assert:
       that:
@@ -480,7 +510,7 @@
 
   - name: purge users from group
     iam_group:
-      name: '{{ test_group }}'
+      name: "{{ test_group }}"
       purge_users: True
       users: []
       state: present
@@ -488,7 +518,7 @@
 
   - name: ensure info is empty for empty group
     iam_user_info:
-      group: '{{ test_group }}'
+      group: "{{ test_group }}"
     register: iam_user_info
   - assert:
       that:
@@ -496,7 +526,7 @@
 
   - name: get info on IAM user(s) after removing from group
     iam_user_info:
-      group: '{{ test_group }}'
+      group: "{{ test_group }}"
     register: iam_user_info
 
   - name: assert empty list of users for group are returned
@@ -506,7 +536,7 @@
 
   - name: remove group
     iam_group:
-      name: '{{ test_group }}'
+      name: "{{ test_group }}"
       state: absent
     register: iam_group
 
@@ -535,7 +565,7 @@
 
   - name: get info on IAM user(s) after deleting
     iam_user_info:
-      group: '{{ test_user }}'
+      group: "{{ test_user }}"
     ignore_errors: yes
     register: iam_user_info
 
@@ -558,15 +588,15 @@
         - not iam_user.changed
 
   always:
-  - name: remove group
-    iam_group:
-      name: '{{ test_group }}'
-      state: absent
-    ignore_errors: yes
+    - name: remove group
+      iam_group:
+        name: "{{ test_group }}"
+        state: absent
+      ignore_errors: yes
 
-  - name: remove ansible users
-    iam_user:
-      name: '{{ item }}'
-      state: absent
-    with_items: '{{ test_users }}'
-    ignore_errors: yes
+    - name: remove ansible users
+      iam_user:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ test_users }}"
+      ignore_errors: yes

--- a/tests/integration/targets/iam_user/tasks/main.yml
+++ b/tests/integration/targets/iam_user/tasks/main.yml
@@ -24,7 +24,6 @@
   - name: create test user (check mode)
     iam_user:
       name: "{{ test_user }}"
-      password: "{{ test_password }}"
       state: present
     check_mode: yes
     register: iam_user
@@ -37,7 +36,6 @@
   - name: create test user
     iam_user:
       name: "{{ test_user }}"
-      password: "{{ test_password }}"
       state: present
     register: iam_user
 
@@ -95,6 +93,31 @@
         - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
         - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
         - iam_user_info.iam_users[0].tags | length == 0
+
+  - name: create test user with password (check mode)
+    iam_user:
+      name: "{{ test_user3 }}"
+      password: "{{ test_password }}"
+      state: present
+    check_mode: yes
+    register: iam_user
+
+  - name: assert that the second user would be created
+    assert:
+      that:
+        - iam_user is changed
+
+  - name: create second test user with password
+    iam_user:
+      name: "{{ test_user3 }}"
+      password: "{{ test_password }}"
+      state: present
+    register: iam_user
+
+  - name: assert that the second user is created
+    assert:
+      that:
+        - iam_user is changed
 
   - name: get info on IAM user(s) on path
     iam_user_info:
@@ -242,7 +265,7 @@
   ## Test user password update
   - name: test update IAM password with on_create only
     iam_user:
-      name: "{{ test_user }}"
+      name: "{{ test_user3 }}"
       password: "{{ test_new_password }}"
       update_password: "on_create"
       state: present
@@ -254,7 +277,7 @@
 
   - name: update IAM password
     iam_user:
-      name: "{{ test_user }}"
+      name: "{{ test_user3 }}"
       password: "{{ test_new_password }}"
       state: present
     register: iam_user_update
@@ -262,7 +285,7 @@
   - assert:
       that:
         - iam_user_update is changed
-        - iam_user_update.iam_user.user.user_name == test_user
+        - iam_user_update.iam_user.user.user_name == test_user3
 
   # ===========================================
   # Test Managed Policy management
@@ -598,6 +621,18 @@
     assert:
       that:
         - not iam_user.changed
+
+  ## Test user password removal
+  - name: Delete IAM password
+    iam_user:
+      name: "{{ test_user3 }}"
+      remove_password: yes
+      state: present
+    register: iam_user_password_removal
+
+  - assert:
+      that:
+        - iam_user_password_removal is changed
 
   always:
     - name: remove group


### PR DESCRIPTION
##### SUMMARY
The `iam` module currently supports password management for IAM users, but the newer  `iam_user` module does not currently. This PR adds the password management functionality to bring parity with the old module.

To ensure the IAM user is properly created before adding a login profile, the waiter for the IAM creation has also been added.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iam_user

##### ADDITIONAL INFORMATION
The added functionality uses the `create_login_profile` and `update_login_profile` methods:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.create_login_profile
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.update_login_profile

**Local integration tests run:**
```
ansible-test integration --docker centos8 -vv iam_user --allow-unsupported
...
PLAY RECAP *********************************************************************
testhost                   : ok=92   changed=24   unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   

AWS ACTIONS: ['iam:AddUserToGroup', 'iam:AttachUserPolicy', 'iam:CreateGroup', 'iam:CreateLoginProfile', 'iam:CreateUser', 'iam:DeleteGroup', 'iam:DeleteLoginProfile', 'iam:DeleteUser', 'iam:DetachUserPolicy', 'iam:GetGroup', 'iam:GetUser', 'iam:ListAccessKeys', 'iam:ListAttachedGroupPolicies', 'iam:ListAttachedUserPolicies', 'iam:ListGroupsForUser', 'iam:ListMFADevices', 'iam:ListPolicies', 'iam:ListSSHPublicKeys', 'iam:ListServiceSpecificCredentials', 'iam:ListSigningCertificates', 'iam:ListUserPolicies', 'iam:ListUsers', 'iam:RemoveUserFromGroup', 'iam:TagUser', 'iam:UntagUser', 'iam:UpdateLoginProfile']
```


