### PR TITLE
Respect wait parameter in elb_instance when adding/removing instances

### DIFF
--- a/changelogs/fragments/825-fix-elb-wait.yml
+++ b/changelogs/fragments/825-fix-elb-wait.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - elb_instance - `wait` parameter is no longer ignored (https://github.com/ansible-collections/community.aws/pull/826)

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -144,8 +144,9 @@ class ElbManager:
             # already OutOfService is being deregistered.
             self.changed = True
 
-        for lb in self.lbs:
-            self._await_elb_instance_state(lb, 'Deregistered', timeout)
+        if wait:
+            for lb in self.lbs:
+                self._await_elb_instance_state(lb, 'Deregistered', timeout)
 
     def register(self, wait, enable_availability_zone, timeout):
         """Register the instance for all ELBs and wait for the ELB
@@ -176,8 +177,9 @@ class ElbManager:
 
             self.changed = True
 
-        for lb in self.lbs:
-            self._await_elb_instance_state(lb, 'InService', timeout)
+        if wait:
+            for lb in self.lbs:
+                self._await_elb_instance_state(lb, 'InService', timeout)
 
     @AWSRetry.jittered_backoff()
     def _describe_elbs(self, **params):


### PR DESCRIPTION
##### SUMMARY
The wait parameter is currently ignored when registering or
deregistering an instance with an ELB. Looks like this was lost in the
boto3 migration: 96f151853500887ae9cac90c8c60f372a856ccdc

Related: #825

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
elb_instance

##### ADDITIONAL INFORMATION
See #825 
