### PR TITLE
Allow to provide instance requirements options to ASG module

### DIFF
--- a/changelogs/fragments/831-ec2_asg.yml
+++ b/changelogs/fragments/831-ec2_asg.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - ec2_asg - Allow defining instance requirements in the mixed instances policy for flexible instance picking by AWS
+  - ec2_asg - Allow defining instance requirements in the mixed instances policy for flexible instance picking by AWS (https://github.com/ansible-collections/community.aws/pull/831).
 breaking_changes:
-  - ec2_asg - The return value of mixed_instances_policy does now return the actual mixed instance policy instead of just a list of instance types (that might not always defined in such a policy)
+  - ec2_asg - The return value of mixed_instances_policy does now return the actual mixed instance policy instead of just a list of instance types (that might not always defined in such a policy) (https://github.com/ansible-collections/community.aws/pull/831).

--- a/changelogs/fragments/831-ec2_asg.yml
+++ b/changelogs/fragments/831-ec2_asg.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - ec2_asg - Allow defining instance requirements in the mixed instances policy for flexible instance picking by AWS
+breaking_changes:
+  - ec2_asg - The return value of mixed_instances_policy does now return the actual mixed instance policy instead of just a list of instance types (that might not always defined in such a policy)

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -92,7 +92,7 @@ options:
         - A set of params describing the specs instances should have
         type: dict
         required: false
-        version_added: 3.2.0
+        version_added: 4.0.0
       instance_types:
         description:
           - A list of instance_types.

--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -89,7 +89,7 @@ options:
     suboptions:
       instance_requirements:
         description:
-        - A set of params decribing the specs instances should have
+        - A set of params describing the specs instances should have
         type: dict
         required: false
         version_added: 3.2.0

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/meta/main.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# meta file for ec2_asg
+
+dependencies:
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: "1.23.27"

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/meta/main.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/meta/main.yml
@@ -4,4 +4,5 @@
 dependencies:
   - role: setup_botocore_pip
     vars:
+      boto3_version: "1.20.27"
       botocore_version: "1.23.27"

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -431,6 +431,7 @@
       ec2_launch_template:
         template_name: "{{ resource_prefix }}-lt"
         image_id: "{{ ec2_ami_image }}"
+        instance_type: t3.micro
         credit_specification:
           cpu_credits: standard
         network_interfaces:

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -529,15 +529,13 @@
           instance_requirements:
             v_cpu_count: { min: 2, max: 8 }
             memory_mi_b: { min: 1024, max: 4096 }
-          instances_distribution:
-            on_demand_percentage_above_base_capacity: 0
         wait_for_instances: yes
       register: output
 
     - assert:
         that:
+          - output is changed
           - "output.mixed_instances_policy.launch_template.overrides[0].instance_requirements == { memory_mi_b: { min: 1024, max: 4096 }, v_cpu_count: { min: 2, max: 8 } }"
-          - "output.mixed_instances_policy.instances_distribution.on_demand_percentage_above_base_capacity == 0"
 
     # ============================================================
 

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -431,7 +431,6 @@
       ec2_launch_template:
         template_name: "{{ resource_prefix }}-lt"
         image_id: "{{ ec2_ami_image }}"
-        instance_type: t3.micro
         credit_specification:
           cpu_credits: standard
         network_interfaces:
@@ -529,6 +528,11 @@
           instance_requirements:
             v_cpu_count: { min: 2, max: 8 }
             memory_mi_b: { min: 1024, max: 4096 }
+          instances_distribution:
+            on_demand_allocation_strategy: lowest-price
+            on_demand_percentage_above_base_capacity: 0
+            spot_allocation_strategy: lowest-price
+            spot_instance_pools: 15 # only available when spot_allocation_strategy is 'lowest-price
         wait_for_instances: yes
       register: output
 
@@ -536,6 +540,9 @@
         that:
           - output is changed
           - "output.mixed_instances_policy.launch_template.overrides[0].instance_requirements == { memory_mi_b: { min: 1024, max: 4096 }, v_cpu_count: { min: 2, max: 8 } }"
+          - "output.mixed_instances_policy.instances_distribution.on_demand_percentage_above_base_capacity == 0"
+          - "output.mixed_instances_policy.instances_distribution.spot_allocation_strategy == 'lowest-price'"
+
 
     # ============================================================
 

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -484,9 +484,9 @@
 
     - assert:
         that:
-          - "output.mixed_instances_policy | length == 2"
-          - "output.mixed_instances_policy[0] == 't3.micro'"
-          - "output.mixed_instances_policy[1] == 't2.nano'"
+          - "output.mixed_instances_policy.launch_template.overrides | length == 2"
+          - "output.mixed_instances_policy.launch_template.overrides[0].instance_type == 't3.micro'"
+          - "output.mixed_instances_policy.launch_template.overrides[1].instance_type == 't2.nano'"
 
     - name: update autoscaling group with mixed-instances policy with instances_distribution
       ec2_asg:
@@ -511,7 +511,7 @@
     - assert:
         that:
           - "output.mixed_instances_policy.launch_template.overrides[0].instance_type == 't3.micro'"
-          - "output.mixed_instances_policy.launch_template.overrides[1].instance_type == 't3a.micro'"
+          - "output.mixed_instances_policy.launch_template.overrides[1].instance_type == 't2.nano'"
           - "output.mixed_instances_policy.instances_distribution.on_demand_percentage_above_base_capacity == 0"
           - "output.mixed_instances_policy.instances_distribution.spot_allocation_strategy == 'capacity-optimized'"
 

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -511,10 +511,36 @@
 
     - assert:
         that:
-          - "output.mixed_instances_policy_full['launch_template']['overrides'][0]['instance_type'] == 't3.micro'"
-          - "output.mixed_instances_policy_full['launch_template']['overrides'][1]['instance_type'] == 't2.nano'"
-          - "output.mixed_instances_policy_full['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0"
-          - "output.mixed_instances_policy_full['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'"
+          - "output.mixed_instances_policy['launch_template']['overrides'][0]['instance_type'] == 't3.micro'"
+          - "output.mixed_instances_policy['launch_template']['overrides'][1]['instance_type'] == 't3a.micro'"
+          - "output.mixed_instances_policy['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0"
+          - "output.mixed_instances_policy['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'"
+
+    - name: update autoscaling group with mixed-instances policy with instances_requirements
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        mixed_instances_policy:
+          instance_requirements:
+            v_cpu_count: { min: 2, max: 8 }
+            memory_mi_b: { min: 1024, max: 4096 }
+          instances_distribution:
+            on_demand_percentage_above_base_capacity: 0
+            spot_allocation_strategy: capacity-optimized
+        wait_for_instances: yes
+      register: output
+
+    - assert:
+        that:
+          - "output.mixed_instances_policy['launch_template']['overrides'][0]['instance_requirements'] == { memory_mi_b: { min: 1024, max: 4096 }, v_cpu_count: { min: 2, max: 8 } }"
+          - "output.mixed_instances_policy['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0"
+          - "output.mixed_instances_policy['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'"
 
     # ============================================================
 

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -22,7 +22,6 @@
         that:
           - "result.msg == 'missing required arguments: name'"
 
-
     - name: ensure launch configs exist
       ec2_lc:
         name: "{{ item }}"
@@ -511,10 +510,10 @@
 
     - assert:
         that:
-          - "output.mixed_instances_policy['launch_template']['overrides'][0]['instance_type'] == 't3.micro'"
-          - "output.mixed_instances_policy['launch_template']['overrides'][1]['instance_type'] == 't3a.micro'"
-          - "output.mixed_instances_policy['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0"
-          - "output.mixed_instances_policy['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'"
+          - "output.mixed_instances_policy.launch_template.overrides[0].instance_type == 't3.micro'"
+          - "output.mixed_instances_policy.launch_template.overrides[1].instance_type == 't3a.micro'"
+          - "output.mixed_instances_policy.instances_distribution.on_demand_percentage_above_base_capacity == 0"
+          - "output.mixed_instances_policy.instances_distribution.spot_allocation_strategy == 'capacity-optimized'"
 
     - name: update autoscaling group with mixed-instances policy with instances_requirements
       ec2_asg:
@@ -538,9 +537,9 @@
 
     - assert:
         that:
-          - "output.mixed_instances_policy['launch_template']['overrides'][0]['instance_requirements'] == { memory_mi_b: { min: 1024, max: 4096 }, v_cpu_count: { min: 2, max: 8 } }"
-          - "output.mixed_instances_policy['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0"
-          - "output.mixed_instances_policy['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'"
+          - "output.mixed_instances_policy.launch_template.overrides[0].instance_requirements == { memory_mi_b: { min: 1024, max: 4096 }, v_cpu_count: { min: 2, max: 8 } }"
+          - "output.mixed_instances_policy.instances_distribution.on_demand_percentage_above_base_capacity == 0"
+          - "output.mixed_instances_policy.instances_distribution.spot_allocation_strategy == 'capacity-optimized'"
 
     # ============================================================
 

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -531,7 +531,6 @@
             memory_mi_b: { min: 1024, max: 4096 }
           instances_distribution:
             on_demand_percentage_above_base_capacity: 0
-            spot_allocation_strategy: capacity-optimized
         wait_for_instances: yes
       register: output
 
@@ -539,7 +538,6 @@
         that:
           - "output.mixed_instances_policy.launch_template.overrides[0].instance_requirements == { memory_mi_b: { min: 1024, max: 4096 }, v_cpu_count: { min: 2, max: 8 } }"
           - "output.mixed_instances_policy.instances_distribution.on_demand_percentage_above_base_capacity == 0"
-          - "output.mixed_instances_policy.instances_distribution.spot_allocation_strategy == 'capacity-optimized'"
 
     # ============================================================
 

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/main.yml
@@ -18,23 +18,32 @@
   collections:
     - community.aws
   block:
-    - debug:
-        msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"
-    - include_tasks: '{{ inventory_hostname }}.yml'
-    - debug:
-        msg: "{{ inventory_hostname }} finish: {{ lookup('pipe','date') }}"
-
-  always:
-    - set_fact:
-        _role_complete: True
-    - vars:
-        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
-        hosts_in_play: '{{ ansible_play_hosts_all | length }}'
-      debug:
-        msg: "{{ completed_hosts }} of {{ hosts_in_play }} complete"
-    - include_tasks: env_cleanup.yml
+    - name: Run tests in virtualenv to newer botocore version
       vars:
-        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
-        hosts_in_play: '{{ ansible_play_hosts_all | length }}'
-      when:
-      - completed_hosts == hosts_in_play
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+      block:
+
+        - debug:
+            msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"
+
+        - include_tasks: '{{ inventory_hostname }}.yml'
+
+        - debug:
+            msg: "{{ inventory_hostname }} finish: {{ lookup('pipe','date') }}"
+
+      always:
+        - set_fact:
+            _role_complete: True
+
+        - vars:
+            completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+            hosts_in_play: '{{ ansible_play_hosts_all | length }}'
+          debug:
+            msg: "{{ completed_hosts }} of {{ hosts_in_play }} complete"
+
+        - include_tasks: env_cleanup.yml
+          vars:
+            completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+            hosts_in_play: '{{ ansible_play_hosts_all | length }}'
+          when:
+            - completed_hosts == hosts_in_play


### PR DESCRIPTION
... to let AWS pick instance types based on machine specs.

##### SUMMARY
Just allows to pass through more arguments in the `mixed_instances_policy` section, namely the one for specifying instance requirements (instead of providing specific instance types).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_asg
