### PR TITLE
Make deprecated updates in dynamodbo_table module fail

### DIFF
--- a/changelogs/fragments/837-make-deprecated-dynamodb_table-updates-fail.yml.yml
+++ b/changelogs/fragments/837-make-deprecated-dynamodb_table-updates-fail.yml.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+- Deprecated updates currently ignored for primary keys and global_all indexes will now result in a failure.
+  (https://github.com/ansible-collections/community.aws/pull/837).

--- a/changelogs/fragments/837-make-deprecated-dynamodb_table-updates-fail.yml.yml
+++ b/changelogs/fragments/837-make-deprecated-dynamodb_table-updates-fail.yml.yml
@@ -1,3 +1,3 @@
 breaking_changes:
-- Deprecated updates currently ignored for primary keys and global_all indexes will now result in a failure.
+- dynamodb_table - deprecated updates currently ignored for primary keys and global_all indexes will now result in a failure.
   (https://github.com/ansible-collections/community.aws/pull/837).

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -854,8 +854,7 @@ def _update_tags(current_table):
 def update_table(current_table):
     primary_index_changes = _primary_index_changes(current_table)
     if primary_index_changes:
-        module.fail_json("DynamoDB does not support updating the Primary keys on a table. "
-                        "Changed paramters are {0}".format(primary_index_changes))
+        module.fail_json("DynamoDB does not support updating the Primary keys on a table. Changed paramters are: {0}".format(primary_index_changes))
 
     changed = False
     changed |= _update_table(current_table)

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -678,12 +678,9 @@ def _generate_index(index, include_throughput=True):
         projection['NonKeyAttributes'] = non_key_attributes
     else:
         if non_key_attributes:
-            module.deprecate(
+            module.fail_json(
                 "DynamoDB does not support specifying non-key-attributes ('includes') for "
-                "indexes of type 'all'.  Attempts to set this attributes are currently "
-                "ignored, but in future will result in a failure.  "
-                "Index name: {0}".format(index['name']),
-                version='3.0.0', collection_name='community.aws')
+                "indexes of type 'all'. Index name: {0}".format(index['name']))
 
     idx = dict(
         IndexName=index['name'],
@@ -857,11 +854,8 @@ def _update_tags(current_table):
 def update_table(current_table):
     primary_index_changes = _primary_index_changes(current_table)
     if primary_index_changes:
-        module.deprecate("DynamoDB does not support updating the Primary keys on a table.  "
-                         "Attempts to change the keys are currently ignored, but in future will "
-                         "result in a failure.  "
-                         "Changed paramters are {0}".format(primary_index_changes),
-                         version='3.0.0', collection_name='community.aws')
+        module.fail_json("DynamoDB does not support updating the Primary keys on a table. "
+                        "Changed paramters are {0}".format(primary_index_changes))
 
     changed = False
     changed |= _update_table(current_table)

--- a/tests/integration/targets/dynamodb_table/defaults/main.yml
+++ b/tests/integration/targets/dynamodb_table/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 table_name: "{{ resource_prefix }}"
 table_name_on_demand: "{{ resource_prefix }}-pay-per-request"
+table_name_on_demand_complex: "{{ resource_prefix }}-pay-per-request-complex"
 
 table_index: "id"
 table_index_type: "NUMBER"
@@ -22,13 +23,23 @@ indexes:
     type: global_all
     hash_key_name: foo
     range_key_name: bar
-    includes:
-      - another_field
-      - another_field2
     read_capacity: 5
     write_capacity: 5
 
 indexes_pay_per_request:
+  - name: NamedIndex
+    type: global_include
+    hash_key_name: idx
+    range_key_name: create_time
+    includes:
+      - other_field
+      - other_field2
+  - name: AnotherIndex
+    type: global_all
+    hash_key_name: foo
+    range_key_name: bar
+
+indexes_pay_per_request_bad:
   - name: NamedIndex
     type: global_include
     hash_key_name: idx

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -7,12 +7,11 @@
 #
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-
   - include: "test_pay_per_request.yml"
 
   # ==============================================
@@ -20,205 +19,205 @@
   - name: Create table - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
     register: create_table
     check_mode: True
 
   - name: Check results - Create table - check_mode
     assert:
       that:
-      - create_table is successful
-      - create_table is changed
+        - create_table is successful
+        - create_table is changed
 
   - name: Create table
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
     register: create_table
 
   - name: Check results - Create table
     assert:
       that:
-      - create_table is successful
-      - create_table is changed
-      - '"hash_key_name" in create_table'
-      - '"hash_key_type" in create_table'
-      - '"indexes" in create_table'
-      - '"range_key_name" in create_table'
-      - '"range_key_type" in create_table'
-      - '"read_capacity" in create_table'
-      - '"region" in create_table'
-      - '"table_name" in create_table'
-      - '"table_status" in create_table'
-      - '"tags" in create_table'
-      - '"write_capacity" in create_table'
-      - create_table.hash_key_name == table_index
-      - create_table.hash_key_type == table_index_type
-      - create_table.indexes | length == 0
-      - create_table.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - create_table.range_key_type is none
-      - create_table.read_capacity == 1
-      - create_table.table_name == table_name
-      - create_table.write_capacity == 1
+        - create_table is successful
+        - create_table is changed
+        - '"hash_key_name" in create_table'
+        - '"hash_key_type" in create_table'
+        - '"indexes" in create_table'
+        - '"range_key_name" in create_table'
+        - '"range_key_type" in create_table'
+        - '"read_capacity" in create_table'
+        - '"region" in create_table'
+        - '"table_name" in create_table'
+        - '"table_status" in create_table'
+        - '"tags" in create_table'
+        - '"write_capacity" in create_table'
+        - create_table.hash_key_name == table_index
+        - create_table.hash_key_type == table_index_type
+        - create_table.indexes | length == 0
+        - create_table.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - create_table.range_key_type is none
+        - create_table.read_capacity == 1
+        - create_table.table_name == table_name
+        - create_table.write_capacity == 1
 
   - name: Create table - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
     register: create_table
     check_mode: True
 
   - name: Check results - Create table - idempotent - check_mode
     assert:
       that:
-      - create_table is successful
-      - create_table is not changed
+        - create_table is successful
+        - create_table is not changed
 
   - name: Create table - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
     register: create_table
 
   - name: Check results - Create table - idempotent
     assert:
       that:
-      - create_table is successful
-      - create_table is not changed
-      - '"hash_key_name" in create_table'
-      - '"hash_key_type" in create_table'
-      - '"indexes" in create_table'
-      - '"range_key_name" in create_table'
-      - '"range_key_type" in create_table'
-      - '"read_capacity" in create_table'
-      - '"region" in create_table'
-      - '"table_name" in create_table'
-      - '"table_status" in create_table'
-      - '"tags" in create_table'
-      - '"write_capacity" in create_table'
-      - create_table.hash_key_name == table_index
-      - create_table.hash_key_type == table_index_type
-      - create_table.indexes | length == 0
-      - create_table.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - create_table.range_key_type is none
-      - create_table.read_capacity == 1
-      - create_table.table_name == table_name
-      - create_table.write_capacity == 1
+        - create_table is successful
+        - create_table is not changed
+        - '"hash_key_name" in create_table'
+        - '"hash_key_type" in create_table'
+        - '"indexes" in create_table'
+        - '"range_key_name" in create_table'
+        - '"range_key_type" in create_table'
+        - '"read_capacity" in create_table'
+        - '"region" in create_table'
+        - '"table_name" in create_table'
+        - '"table_status" in create_table'
+        - '"tags" in create_table'
+        - '"write_capacity" in create_table'
+        - create_table.hash_key_name == table_index
+        - create_table.hash_key_type == table_index_type
+        - create_table.indexes | length == 0
+        - create_table.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - create_table.range_key_type is none
+        - create_table.read_capacity == 1
+        - create_table.table_name == table_name
+        - create_table.write_capacity == 1
 
   # ==============================================
 
   - name: Tag table - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      tags: '{{ tags_default }}'
+      name: "{{ table_name }}"
+      tags: "{{ tags_default }}"
     register: tag_table
     check_mode: True
 
   - name: Check results - Tag table - check_mode
     assert:
       that:
-      - tag_table is successful
-      - tag_table is changed
+        - tag_table is successful
+        - tag_table is changed
 
   - name: Tag table
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      tags: '{{ tags_default }}'
+      name: "{{ table_name }}"
+      tags: "{{ tags_default }}"
     register: tag_table
 
   - name: Check results - Tag table
     assert:
       that:
-      - tag_table is successful
-      - tag_table is changed
-      - '"hash_key_name" in tag_table'
-      - '"hash_key_type" in tag_table'
-      - '"indexes" in tag_table'
-      - '"range_key_name" in tag_table'
-      - '"range_key_type" in tag_table'
-      - '"read_capacity" in tag_table'
-      - '"region" in tag_table'
-      - '"table_name" in tag_table'
-      - '"table_status" in tag_table'
-      - '"tags" in tag_table'
-      - '"write_capacity" in tag_table'
-      - tag_table.hash_key_name == table_index
-      - tag_table.hash_key_type == table_index_type
-      - tag_table.indexes | length == 0
-      - tag_table.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - tag_table.range_key_type is none
-      - tag_table.read_capacity == 1
-      - tag_table.table_name == table_name
-      - tag_table.write_capacity == 1
-      - tag_table.tags == tags_default
+        - tag_table is successful
+        - tag_table is changed
+        - '"hash_key_name" in tag_table'
+        - '"hash_key_type" in tag_table'
+        - '"indexes" in tag_table'
+        - '"range_key_name" in tag_table'
+        - '"range_key_type" in tag_table'
+        - '"read_capacity" in tag_table'
+        - '"region" in tag_table'
+        - '"table_name" in tag_table'
+        - '"table_status" in tag_table'
+        - '"tags" in tag_table'
+        - '"write_capacity" in tag_table'
+        - tag_table.hash_key_name == table_index
+        - tag_table.hash_key_type == table_index_type
+        - tag_table.indexes | length == 0
+        - tag_table.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - tag_table.range_key_type is none
+        - tag_table.read_capacity == 1
+        - tag_table.table_name == table_name
+        - tag_table.write_capacity == 1
+        - tag_table.tags == tags_default
 
   - name: Tag table - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      tags: '{{ tags_default }}'
+      name: "{{ table_name }}"
+      tags: "{{ tags_default }}"
     register: tag_table
     check_mode: True
 
   - name: Check results - Tag table - idempotent - check_mode
     assert:
       that:
-      - tag_table is successful
-      - tag_table is not changed
+        - tag_table is successful
+        - tag_table is not changed
 
   - name: Tag table - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      tags: '{{ tags_default }}'
+      name: "{{ table_name }}"
+      tags: "{{ tags_default }}"
     register: tag_table
 
   - name: Check results - Tag table - idempotent
     assert:
       that:
-      - tag_table is successful
-      - tag_table is not changed
-      - '"hash_key_name" in tag_table'
-      - '"hash_key_type" in tag_table'
-      - '"indexes" in tag_table'
-      - '"range_key_name" in tag_table'
-      - '"range_key_type" in tag_table'
-      - '"read_capacity" in tag_table'
-      - '"region" in tag_table'
-      - '"table_name" in tag_table'
-      - '"table_status" in tag_table'
-      - '"tags" in tag_table'
-      - '"write_capacity" in tag_table'
-      - tag_table.hash_key_name == table_index
-      - tag_table.hash_key_type == table_index_type
-      - tag_table.indexes | length == 0
-      - tag_table.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - tag_table.range_key_type is none
-      - tag_table.read_capacity == 1
-      - tag_table.table_name == table_name
-      - tag_table.write_capacity == 1
-      - tag_table.tags == tags_default
+        - tag_table is successful
+        - tag_table is not changed
+        - '"hash_key_name" in tag_table'
+        - '"hash_key_type" in tag_table'
+        - '"indexes" in tag_table'
+        - '"range_key_name" in tag_table'
+        - '"range_key_type" in tag_table'
+        - '"read_capacity" in tag_table'
+        - '"region" in tag_table'
+        - '"table_name" in tag_table'
+        - '"table_status" in tag_table'
+        - '"tags" in tag_table'
+        - '"write_capacity" in tag_table'
+        - tag_table.hash_key_name == table_index
+        - tag_table.hash_key_type == table_index_type
+        - tag_table.indexes | length == 0
+        - tag_table.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - tag_table.range_key_type is none
+        - tag_table.read_capacity == 1
+        - tag_table.table_name == table_name
+        - tag_table.write_capacity == 1
+        - tag_table.tags == tags_default
 
   # ==============================================
 
   - name: Update table read capacity - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       read_capacity: 3
     register: update_read
     check_mode: True
@@ -226,47 +225,47 @@
   - name: Check results - Update table read capacity - check_mode
     assert:
       that:
-      - update_read is successful
-      - update_read is changed
+        - update_read is successful
+        - update_read is changed
 
   - name: Update table read capacity
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       read_capacity: 3
     register: update_read
 
   - name: Check results - Update table read capacity
     assert:
       that:
-      - update_read is successful
-      - update_read is changed
-      - '"hash_key_name" in update_read'
-      - '"hash_key_type" in update_read'
-      - '"indexes" in update_read'
-      - '"range_key_name" in update_read'
-      - '"range_key_type" in update_read'
-      - '"read_capacity" in update_read'
-      - '"region" in update_read'
-      - '"table_name" in update_read'
-      - '"table_status" in update_read'
-      - '"tags" in update_read'
-      - '"write_capacity" in update_read'
-      - update_read.hash_key_name == table_index
-      - update_read.hash_key_type == table_index_type
-      - update_read.indexes | length == 0
-      - update_read.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - update_read.range_key_type is none
-      - update_read.read_capacity == 3
-      - update_read.table_name == table_name
-      - update_read.write_capacity == 1
-      - update_read.tags == tags_default
+        - update_read is successful
+        - update_read is changed
+        - '"hash_key_name" in update_read'
+        - '"hash_key_type" in update_read'
+        - '"indexes" in update_read'
+        - '"range_key_name" in update_read'
+        - '"range_key_type" in update_read'
+        - '"read_capacity" in update_read'
+        - '"region" in update_read'
+        - '"table_name" in update_read'
+        - '"table_status" in update_read'
+        - '"tags" in update_read'
+        - '"write_capacity" in update_read'
+        - update_read.hash_key_name == table_index
+        - update_read.hash_key_type == table_index_type
+        - update_read.indexes | length == 0
+        - update_read.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - update_read.range_key_type is none
+        - update_read.read_capacity == 3
+        - update_read.table_name == table_name
+        - update_read.write_capacity == 1
+        - update_read.tags == tags_default
 
   - name: Update table read capacity - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       read_capacity: 3
     register: update_read
     check_mode: True
@@ -274,49 +273,49 @@
   - name: Check results - Update table read capacity - idempotent - check_mode
     assert:
       that:
-      - update_read is successful
-      - update_read is not changed
+        - update_read is successful
+        - update_read is not changed
 
   - name: Update table read capacity - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       read_capacity: 3
     register: update_read
 
   - name: Check results - Update table read capacity - idempotent
     assert:
       that:
-      - update_read is successful
-      - update_read is not changed
-      - '"hash_key_name" in update_read'
-      - '"hash_key_type" in update_read'
-      - '"indexes" in update_read'
-      - '"range_key_name" in update_read'
-      - '"range_key_type" in update_read'
-      - '"read_capacity" in update_read'
-      - '"region" in update_read'
-      - '"table_name" in update_read'
-      - '"table_status" in update_read'
-      - '"tags" in update_read'
-      - '"write_capacity" in update_read'
-      - update_read.hash_key_name == table_index
-      - update_read.hash_key_type == table_index_type
-      - update_read.indexes | length == 0
-      - update_read.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - update_read.range_key_type is none
-      - update_read.read_capacity == 3
-      - update_read.table_name == table_name
-      - update_read.write_capacity == 1
-      - update_read.tags == tags_default
+        - update_read is successful
+        - update_read is not changed
+        - '"hash_key_name" in update_read'
+        - '"hash_key_type" in update_read'
+        - '"indexes" in update_read'
+        - '"range_key_name" in update_read'
+        - '"range_key_type" in update_read'
+        - '"read_capacity" in update_read'
+        - '"region" in update_read'
+        - '"table_name" in update_read'
+        - '"table_status" in update_read'
+        - '"tags" in update_read'
+        - '"write_capacity" in update_read'
+        - update_read.hash_key_name == table_index
+        - update_read.hash_key_type == table_index_type
+        - update_read.indexes | length == 0
+        - update_read.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - update_read.range_key_type is none
+        - update_read.read_capacity == 3
+        - update_read.table_name == table_name
+        - update_read.write_capacity == 1
+        - update_read.tags == tags_default
 
   # ==============================================
 
   - name: Update table write capacity - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       write_capacity: 3
     register: update_write
     check_mode: True
@@ -324,47 +323,47 @@
   - name: Check results - Update table write capacity - check_mode
     assert:
       that:
-      - update_write is successful
-      - update_write is changed
+        - update_write is successful
+        - update_write is changed
 
   - name: Update table write capacity
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       write_capacity: 3
     register: update_write
 
   - name: Check results - Update table write capacity
     assert:
       that:
-      - update_write is successful
-      - update_write is changed
-      - '"hash_key_name" in update_write'
-      - '"hash_key_type" in update_write'
-      - '"indexes" in update_write'
-      - '"range_key_name" in update_write'
-      - '"range_key_type" in update_write'
-      - '"read_capacity" in update_write'
-      - '"region" in update_write'
-      - '"table_name" in update_write'
-      - '"table_status" in update_write'
-      - '"tags" in update_write'
-      - '"write_capacity" in update_write'
-      - update_write.hash_key_name == table_index
-      - update_write.hash_key_type == table_index_type
-      - update_write.indexes | length == 0
-      - update_write.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - update_write.range_key_type is none
-      - update_write.read_capacity == 3
-      - update_write.table_name == table_name
-      - update_write.write_capacity == 3
-      - update_write.tags == tags_default
+        - update_write is successful
+        - update_write is changed
+        - '"hash_key_name" in update_write'
+        - '"hash_key_type" in update_write'
+        - '"indexes" in update_write'
+        - '"range_key_name" in update_write'
+        - '"range_key_type" in update_write'
+        - '"read_capacity" in update_write'
+        - '"region" in update_write'
+        - '"table_name" in update_write'
+        - '"table_status" in update_write'
+        - '"tags" in update_write'
+        - '"write_capacity" in update_write'
+        - update_write.hash_key_name == table_index
+        - update_write.hash_key_type == table_index_type
+        - update_write.indexes | length == 0
+        - update_write.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - update_write.range_key_type is none
+        - update_write.read_capacity == 3
+        - update_write.table_name == table_name
+        - update_write.write_capacity == 3
+        - update_write.tags == tags_default
 
   - name: Update table write capacity - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       write_capacity: 3
     register: update_write
     check_mode: True
@@ -372,466 +371,380 @@
   - name: Check results - Update table write capacity - idempotent - check_mode
     assert:
       that:
-      - update_write is successful
-      - update_write is not changed
+        - update_write is successful
+        - update_write is not changed
 
   - name: Update table write capacity - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
       write_capacity: 3
     register: update_write
 
   - name: Check results - Update table write capacity - idempotent
     assert:
       that:
-      - update_write is successful
-      - update_write is not changed
-      - '"hash_key_name" in update_write'
-      - '"hash_key_type" in update_write'
-      - '"indexes" in update_write'
-      - '"range_key_name" in update_write'
-      - '"range_key_type" in update_write'
-      - '"read_capacity" in update_write'
-      - '"region" in update_write'
-      - '"table_name" in update_write'
-      - '"table_status" in update_write'
-      - '"tags" in update_write'
-      - '"write_capacity" in update_write'
-      - update_write.hash_key_name == table_index
-      - update_write.hash_key_type == table_index_type
-      - update_write.indexes | length == 0
-      - update_write.range_key_name is none
-      # We used to return "STRING" even if there wasn't a key
-      - update_write.range_key_type is none
-      - update_write.read_capacity == 3
-      - update_write.table_name == table_name
-      - update_write.write_capacity == 3
-      - update_write.tags == tags_default
+        - update_write is successful
+        - update_write is not changed
+        - '"hash_key_name" in update_write'
+        - '"hash_key_type" in update_write'
+        - '"indexes" in update_write'
+        - '"range_key_name" in update_write'
+        - '"range_key_type" in update_write'
+        - '"read_capacity" in update_write'
+        - '"region" in update_write'
+        - '"table_name" in update_write'
+        - '"table_status" in update_write'
+        - '"tags" in update_write'
+        - '"write_capacity" in update_write'
+        - update_write.hash_key_name == table_index
+        - update_write.hash_key_type == table_index_type
+        - update_write.indexes | length == 0
+        - update_write.range_key_name is none
+        # We used to return "STRING" even if there wasn't a key
+        - update_write.range_key_type is none
+        - update_write.read_capacity == 3
+        - update_write.table_name == table_name
+        - update_write.write_capacity == 3
+        - update_write.tags == tags_default
 
   # ==============================================
-  # Updating the indexes used to simply be ignored
-  # We've deprecated accepting this, but dropping
-  # support would be a breaking change.
+  # Attempting to update the primary indexes now will result in an expected failure.
 
-  - name: Update table add range index - check_mode
+  - name: Update table add range index - test failure
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
-    register: update_range_index
-    check_mode: True
-
-  - name: Check results - Update table add range index - check_mode
-    assert:
-      that:
-      - update_range_index is successful
-      # - update_range_index is changed
-
-  - name: Update table add range index
-    dynamodb_table:
-      state: present
-      name: '{{ table_name }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
+      name: "{{ table_name }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+    ignore_errors: yes
     register: update_range_index
 
   - name: Check results - Update table add range index
     assert:
       that:
-      - update_range_index is successful
-      # - update_range_index is changed
-      - '"hash_key_name" in update_range_index'
-      - '"hash_key_type" in update_range_index'
-      - '"indexes" in update_range_index'
-      - '"range_key_name" in update_range_index'
-      - '"range_key_type" in update_range_index'
-      - '"read_capacity" in update_range_index'
-      - '"region" in update_range_index'
-      - '"table_name" in update_range_index'
-      - '"table_status" in update_range_index'
-      - '"tags" in update_range_index'
-      - '"write_capacity" in update_range_index'
-      - update_range_index.hash_key_name == table_index
-      - update_range_index.hash_key_type == table_index_type
-      - update_range_index.indexes | length == 0
-      # - update_range_index.range_key_name == range_index
-      # - update_range_index.range_key_type == range_index_type
-      - update_range_index.read_capacity == 3
-      - update_range_index.table_name == table_name
-      - update_range_index.write_capacity == 3
-      - update_range_index.tags == tags_default
-
-  - name: Update table add range index - idempotent - check_mode
-    dynamodb_table:
-      state: present
-      name: '{{ table_name }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
-    register: update_range_index
-    check_mode: True
-
-  - name: Check results - Update table add range index - idempotent - check_mode
-    assert:
-      that:
-      - update_range_index is successful
-      # - update_range_index is not changed
-
-  - name: Update table add range index - idempotent
-    dynamodb_table:
-      state: present
-      name: '{{ table_name }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
-    register: update_range_index
-
-  - name: Check results - Update table add range index - idempotent
-    assert:
-      that:
-      - update_range_index is successful
-      # - update_range_index is not changed
-      - '"hash_key_name" in update_range_index'
-      - '"hash_key_type" in update_range_index'
-      - '"indexes" in update_range_index'
-      - '"range_key_name" in update_range_index'
-      - '"range_key_type" in update_range_index'
-      - '"read_capacity" in update_range_index'
-      - '"region" in update_range_index'
-      - '"table_name" in update_range_index'
-      - '"table_status" in update_range_index'
-      - '"tags" in update_range_index'
-      - '"write_capacity" in update_range_index'
-      - update_range_index.hash_key_name == table_index
-      - update_range_index.hash_key_type == table_index_type
-      - update_range_index.indexes | length == 0
-      # - update_range_index.range_key_name == range_index
-      # - update_range_index.range_key_type == range_index_type
-      - update_range_index.read_capacity == 3
-      - update_range_index.table_name == table_name
-      - update_range_index.write_capacity == 3
-      - update_range_index.tags == tags_default
+        - update_range_index is failed
 
   # ==============================================
 
   - name: Update table add indexes - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ indexes }}'
+      name: "{{ table_name }}"
+      indexes: "{{ indexes }}"
     register: update_indexes
     check_mode: True
 
   - name: Check results - Update table add indexes - check_mode
     assert:
       that:
-      - update_indexes is successful
-      - update_indexes is changed
+        - update_indexes is successful
+        - update_indexes is changed
 
   - name: Update table add indexes
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ indexes }}'
+      name: "{{ table_name }}"
+      indexes: "{{ indexes }}"
     register: update_indexes
 
   - name: Check results - Update table add indexes
     assert:
       that:
-      - update_indexes is successful
-      - update_indexes is changed
-      - '"hash_key_name" in update_indexes'
-      - '"hash_key_type" in update_indexes'
-      - '"indexes" in update_indexes'
-      - '"range_key_name" in update_indexes'
-      - '"range_key_type" in update_indexes'
-      - '"read_capacity" in update_indexes'
-      - '"region" in update_indexes'
-      - '"table_name" in update_indexes'
-      - '"table_status" in update_indexes'
-      - '"tags" in update_indexes'
-      - '"write_capacity" in update_indexes'
-      - update_indexes.hash_key_name == table_index
-      - update_indexes.hash_key_type == table_index_type
-      - update_indexes.indexes | length == 2
-      # - update_indexes.range_key_name == range_index
-      # - update_indexes.range_key_type == range_index_type
-      - update_indexes.read_capacity == 3
-      - update_indexes.table_name == table_name
-      - update_indexes.write_capacity == 3
-      - update_indexes.tags == tags_default
+        - update_indexes is successful
+        - update_indexes is changed
+        - '"hash_key_name" in update_indexes'
+        - '"hash_key_type" in update_indexes'
+        - '"indexes" in update_indexes'
+        - '"range_key_name" in update_indexes'
+        - '"range_key_type" in update_indexes'
+        - '"read_capacity" in update_indexes'
+        - '"region" in update_indexes'
+        - '"table_name" in update_indexes'
+        - '"table_status" in update_indexes'
+        - '"tags" in update_indexes'
+        - '"write_capacity" in update_indexes'
+        - update_indexes.hash_key_name == table_index
+        - update_indexes.hash_key_type == table_index_type
+        - update_indexes.indexes | length == 2
+        # - update_indexes.range_key_name == range_index
+        # - update_indexes.range_key_type == range_index_type
+        - update_indexes.read_capacity == 3
+        - update_indexes.table_name == table_name
+        - update_indexes.write_capacity == 3
+        - update_indexes.tags == tags_default
 
   - name: Update table add indexes - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ indexes }}'
+      name: "{{ table_name }}"
+      indexes: "{{ indexes }}"
     register: update_indexes
     check_mode: True
 
   - name: Check results - Update table add indexes - idempotent - check_mode
     assert:
       that:
-      - update_indexes is successful
-      - update_indexes is not changed
+        - update_indexes is successful
+        - update_indexes is not changed
 
   - name: Update table add indexes - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ indexes }}'
+      name: "{{ table_name }}"
+      indexes: "{{ indexes }}"
     register: update_indexes
 
   - name: Check results - Update table add indexes - idempotent
     assert:
       that:
-      - update_indexes is successful
-      - update_indexes is not changed
-      - '"hash_key_name" in update_indexes'
-      - '"hash_key_type" in update_indexes'
-      - '"indexes" in update_indexes'
-      - '"range_key_name" in update_indexes'
-      - '"range_key_type" in update_indexes'
-      - '"read_capacity" in update_indexes'
-      - '"region" in update_indexes'
-      - '"table_name" in update_indexes'
-      - '"table_status" in update_indexes'
-      - '"tags" in update_indexes'
-      - '"write_capacity" in update_indexes'
-      - update_indexes.hash_key_name == table_index
-      - update_indexes.hash_key_type == table_index_type
-      - update_indexes.indexes | length == 2
-      # - update_indexes.range_key_name == range_index
-      # - update_indexes.range_key_type == range_index_type
-      - update_indexes.read_capacity == 3
-      - update_indexes.table_name == table_name
-      - update_indexes.write_capacity == 3
-      - update_indexes.tags == tags_default
+        - update_indexes is successful
+        - update_indexes is not changed
+        - '"hash_key_name" in update_indexes'
+        - '"hash_key_type" in update_indexes'
+        - '"indexes" in update_indexes'
+        - '"range_key_name" in update_indexes'
+        - '"range_key_type" in update_indexes'
+        - '"read_capacity" in update_indexes'
+        - '"region" in update_indexes'
+        - '"table_name" in update_indexes'
+        - '"table_status" in update_indexes'
+        - '"tags" in update_indexes'
+        - '"write_capacity" in update_indexes'
+        - update_indexes.hash_key_name == table_index
+        - update_indexes.hash_key_type == table_index_type
+        - update_indexes.indexes | length == 2
+        # - update_indexes.range_key_name == range_index
+        # - update_indexes.range_key_type == range_index_type
+        - update_indexes.read_capacity == 3
+        - update_indexes.table_name == table_name
+        - update_indexes.write_capacity == 3
+        - update_indexes.tags == tags_default
 
   # ==============================================
 
   - name: Delete table - check_mode
     dynamodb_table:
       state: absent
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
     register: delete_table
     check_mode: True
 
   - name: Check results - Delete table - check_mode
     assert:
       that:
-      - delete_table is successful
-      - delete_table is changed
+        - delete_table is successful
+        - delete_table is changed
 
   - name: Delete table
     dynamodb_table:
       state: absent
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
     register: delete_table
 
   - name: Check results - Delete table
     assert:
       that:
-      - delete_table is successful
-      - delete_table is changed
+        - delete_table is successful
+        - delete_table is changed
 
   - name: Delete table - idempotent - check_mode
     dynamodb_table:
       state: absent
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
     register: delete_table
     check_mode: True
 
   - name: Check results - Delete table - idempotent - check_mode
     assert:
       that:
-      - delete_table is successful
-      - delete_table is not changed
+        - delete_table is successful
+        - delete_table is not changed
 
   - name: Delete table - idempotent
     dynamodb_table:
       state: absent
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
     register: delete_table
 
   - name: Check results - Delete table - idempotent
     assert:
       that:
-      - delete_table is successful
-      - delete_table is not changed
+        - delete_table is successful
+        - delete_table is not changed
 
   # ==============================================
 
   - name: Create complex table - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
-      tags: '{{ tags_default }}'
-      indexes: '{{ indexes }}'
+      tags: "{{ tags_default }}"
+      indexes: "{{ indexes }}"
     register: create_complex_table
     check_mode: True
 
   - name: Check results - Create complex table - check_mode
     assert:
       that:
-      - create_complex_table is successful
-      - create_complex_table is changed
+        - create_complex_table is successful
+        - create_complex_table is changed
 
   - name: Create complex table
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
-      tags: '{{ tags_default }}'
-      indexes: '{{ indexes }}'
+      tags: "{{ tags_default }}"
+      indexes: "{{ indexes }}"
     register: create_complex_table
 
   - name: Check results - Create complex table
     assert:
       that:
-      - create_complex_table is successful
-      - create_complex_table is changed
-      - '"hash_key_name" in create_complex_table'
-      - '"hash_key_type" in create_complex_table'
-      - '"indexes" in create_complex_table'
-      - '"range_key_name" in create_complex_table'
-      - '"range_key_type" in create_complex_table'
-      - '"read_capacity" in create_complex_table'
-      - '"region" in create_complex_table'
-      - '"table_name" in create_complex_table'
-      - '"table_status" in create_complex_table'
-      - '"tags" in create_complex_table'
-      - '"write_capacity" in create_complex_table'
-      - create_complex_table.hash_key_name == table_index
-      - create_complex_table.hash_key_type == table_index_type
-      - create_complex_table.indexes | length == 2
-      - create_complex_table.range_key_name == range_index
-      - create_complex_table.range_key_type == range_index_type
-      - create_complex_table.read_capacity == 3
-      - create_complex_table.table_name == table_name
-      - create_complex_table.write_capacity == 3
-      - create_complex_table.tags == tags_default
+        - create_complex_table is successful
+        - create_complex_table is changed
+        - '"hash_key_name" in create_complex_table'
+        - '"hash_key_type" in create_complex_table'
+        - '"indexes" in create_complex_table'
+        - '"range_key_name" in create_complex_table'
+        - '"range_key_type" in create_complex_table'
+        - '"read_capacity" in create_complex_table'
+        - '"region" in create_complex_table'
+        - '"table_name" in create_complex_table'
+        - '"table_status" in create_complex_table'
+        - '"tags" in create_complex_table'
+        - '"write_capacity" in create_complex_table'
+        - create_complex_table.hash_key_name == table_index
+        - create_complex_table.hash_key_type == table_index_type
+        - create_complex_table.indexes | length == 2
+        - create_complex_table.range_key_name == range_index
+        - create_complex_table.range_key_type == range_index_type
+        - create_complex_table.read_capacity == 3
+        - create_complex_table.table_name == table_name
+        - create_complex_table.write_capacity == 3
+        - create_complex_table.tags == tags_default
 
   - name: Create complex table - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
-      tags: '{{ tags_default }}'
-      indexes: '{{ indexes }}'
+      tags: "{{ tags_default }}"
+      indexes: "{{ indexes }}"
     register: create_complex_table
     check_mode: True
 
   - name: Check results - Create complex table - idempotent - check_mode
     assert:
       that:
-      - create_complex_table is successful
-      - create_complex_table is not changed
+        - create_complex_table is successful
+        - create_complex_table is not changed
 
   - name: Create complex table - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      hash_key_name: '{{ table_index }}'
-      hash_key_type: '{{ table_index_type }}'
-      range_key_name: '{{ range_index }}'
-      range_key_type: '{{ range_index_type }}'
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
-      tags: '{{ tags_default }}'
-      indexes: '{{ indexes }}'
+      tags: "{{ tags_default }}"
+      indexes: "{{ indexes }}"
     register: create_complex_table
 
   - name: Check results - Create complex table - idempotent
     assert:
       that:
-      - create_complex_table is successful
-      - create_complex_table is not changed
-      - '"hash_key_name" in create_complex_table'
-      - '"hash_key_type" in create_complex_table'
-      - '"indexes" in create_complex_table'
-      - '"range_key_name" in create_complex_table'
-      - '"range_key_type" in create_complex_table'
-      - '"read_capacity" in create_complex_table'
-      - '"region" in create_complex_table'
-      - '"table_name" in create_complex_table'
-      - '"table_status" in create_complex_table'
-      - '"tags" in create_complex_table'
-      - '"write_capacity" in create_complex_table'
-      - create_complex_table.hash_key_name == table_index
-      - create_complex_table.hash_key_type == table_index_type
-      - create_complex_table.indexes | length == 2
-      - create_complex_table.range_key_name == range_index
-      - create_complex_table.range_key_type == range_index_type
-      - create_complex_table.read_capacity == 3
-      - create_complex_table.table_name == table_name
-      - create_complex_table.write_capacity == 3
-      - create_complex_table.tags == tags_default
+        - create_complex_table is successful
+        - create_complex_table is not changed
+        - '"hash_key_name" in create_complex_table'
+        - '"hash_key_type" in create_complex_table'
+        - '"indexes" in create_complex_table'
+        - '"range_key_name" in create_complex_table'
+        - '"range_key_type" in create_complex_table'
+        - '"read_capacity" in create_complex_table'
+        - '"region" in create_complex_table'
+        - '"table_name" in create_complex_table'
+        - '"table_status" in create_complex_table'
+        - '"tags" in create_complex_table'
+        - '"write_capacity" in create_complex_table'
+        - create_complex_table.hash_key_name == table_index
+        - create_complex_table.hash_key_type == table_index_type
+        - create_complex_table.indexes | length == 2
+        - create_complex_table.range_key_name == range_index
+        - create_complex_table.range_key_type == range_index_type
+        - create_complex_table.read_capacity == 3
+        - create_complex_table.table_name == table_name
+        - create_complex_table.write_capacity == 3
+        - create_complex_table.tags == tags_default
 
   # ==============================================
 
   - name: Update table update index - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ index_updated }}'
+      name: "{{ table_name }}"
+      indexes: "{{ index_updated }}"
     register: update_index
     check_mode: True
 
   - name: Check results - Update table update index - check_mode
     assert:
       that:
-      - update_index is successful
-      - update_index is changed
+        - update_index is successful
+        - update_index is changed
 
   - name: Update table update index
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ index_updated }}'
+      name: "{{ table_name }}"
+      indexes: "{{ index_updated }}"
     register: update_index
 
   - name: Check results - Update table update index
     assert:
       that:
-      - update_index is successful
-      - update_index is changed
-      - '"hash_key_name" in update_index'
-      - '"hash_key_type" in update_index'
-      - '"indexes" in update_index'
-      - '"range_key_name" in update_index'
-      - '"range_key_type" in update_index'
-      - '"read_capacity" in update_index'
-      - '"region" in update_index'
-      - '"table_name" in update_index'
-      - '"table_status" in update_index'
-      - '"tags" in update_index'
-      - '"write_capacity" in update_index'
-      - update_index.hash_key_name == table_index
-      - update_index.hash_key_type == table_index_type
-      - update_index.indexes | length == 2
-      - update_index.range_key_name == range_index
-      - update_index.range_key_type == range_index_type
-      - update_index.read_capacity == 3
-      - update_index.table_name == table_name
-      - update_index.write_capacity == 3
-      - update_index.tags == tags_default
+        - update_index is successful
+        - update_index is changed
+        - '"hash_key_name" in update_index'
+        - '"hash_key_type" in update_index'
+        - '"indexes" in update_index'
+        - '"range_key_name" in update_index'
+        - '"range_key_type" in update_index'
+        - '"read_capacity" in update_index'
+        - '"region" in update_index'
+        - '"table_name" in update_index'
+        - '"table_status" in update_index'
+        - '"tags" in update_index'
+        - '"write_capacity" in update_index'
+        - update_index.hash_key_name == table_index
+        - update_index.hash_key_type == table_index_type
+        - update_index.indexes | length == 2
+        - update_index.range_key_name == range_index
+        - update_index.range_key_type == range_index_type
+        - update_index.read_capacity == 3
+        - update_index.table_name == table_name
+        - update_index.write_capacity == 3
+        - update_index.tags == tags_default
 
   - name: Pause to allow index to finish updating
     pause:
@@ -840,73 +753,86 @@
   - name: Update table update index - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ index_updated }}'
+      name: "{{ table_name }}"
+      indexes: "{{ index_updated }}"
     register: update_index
     check_mode: True
 
   - name: Check results - Update table update index - idempotent - check_mode
     assert:
       that:
-      - update_index is successful
-      - update_index is not changed
+        - update_index is successful
+        - update_index is not changed
 
   - name: Update table update index - idempotent
     dynamodb_table:
       state: present
-      name: '{{ table_name }}'
-      indexes: '{{ index_updated }}'
+      name: "{{ table_name }}"
+      indexes: "{{ index_updated }}"
     register: update_index
 
   - name: Check results - Update table update index - idempotent
     assert:
       that:
-      - update_index is successful
-      - update_index is not changed
-      - '"hash_key_name" in update_index'
-      - '"hash_key_type" in update_index'
-      - '"indexes" in update_index'
-      - '"range_key_name" in update_index'
-      - '"range_key_type" in update_index'
-      - '"read_capacity" in update_index'
-      - '"region" in update_index'
-      - '"table_name" in update_index'
-      - '"table_status" in update_index'
-      - '"tags" in update_index'
-      - '"write_capacity" in update_index'
-      - update_index.hash_key_name == table_index
-      - update_index.hash_key_type == table_index_type
-      - update_index.indexes | length == 2
-      - update_index.range_key_name == range_index
-      - update_index.range_key_type == range_index_type
-      - update_index.read_capacity == 3
-      - update_index.table_name == table_name
-      - update_index.write_capacity == 3
-      - update_index.tags == tags_default
+        - update_index is successful
+        - update_index is not changed
+        - '"hash_key_name" in update_index'
+        - '"hash_key_type" in update_index'
+        - '"indexes" in update_index'
+        - '"range_key_name" in update_index'
+        - '"range_key_type" in update_index'
+        - '"read_capacity" in update_index'
+        - '"region" in update_index'
+        - '"table_name" in update_index'
+        - '"table_status" in update_index'
+        - '"tags" in update_index'
+        - '"write_capacity" in update_index'
+        - update_index.hash_key_name == table_index
+        - update_index.hash_key_type == table_index_type
+        - update_index.indexes | length == 2
+        - update_index.range_key_name == range_index
+        - update_index.range_key_type == range_index_type
+        - update_index.read_capacity == 3
+        - update_index.table_name == table_name
+        - update_index.write_capacity == 3
+        - update_index.tags == tags_default
 
   # ==============================================
 
   - name: Delete table
     dynamodb_table:
       state: absent
-      name: '{{ table_name }}'
+      name: "{{ table_name }}"
     register: delete_table
 
   - name: Check results - Delete table
     assert:
       that:
-      - delete_table is successful
-      - delete_table is changed
+        - delete_table is successful
+        - delete_table is changed
 
   always:
+    ################################################
+    # TEARDOWN STARTS HERE
+    ################################################
 
-  ################################################
-  # TEARDOWN STARTS HERE
-  ################################################
+    - name: Delete provisoned table
+      dynamodb_table:
+        state: absent
+        name: "{{ table_name }}"
+        wait: false
+      register: delete_table
 
-  - name: Clean up table
-    dynamodb_table:
-      state: absent
-      name: '{{ table_name }}'
-      wait: false
-    register: delete_table
+    - name: Delete on-demand table
+      dynamodb_table:
+        state: absent
+        name: "{{ table_name_on_demand }}"
+        wait: false
+      register: delete_table
+
+    - name: Delete complex on-demand table
+      dynamodb_table:
+        state: absent
+        name: "{{ table_name_on_demand_complex }}"
+        wait: false
+      register: delete_table

--- a/tests/integration/targets/dynamodb_table/tasks/test_pay_per_request.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/test_pay_per_request.yml
@@ -31,12 +31,29 @@
       - create_table is changed
       - create_table.billing_mode == "PAY_PER_REQUEST"
 
+- name: Create table - pay-per-request - check failure
+  dynamodb_table:
+    state: present
+    name: "{{ table_name_on_demand }}"
+    hash_key_name: "{{ table_index }}"
+    hash_key_type: "{{ table_index_type }}"
+    range_key_name: "{{ range_index }}"
+    range_key_type: "{{ range_index_type }}"
+    billing_mode: PAY_PER_REQUEST
+  ignore_errors: yes
+  register: create_table_bad
+
+- name: Check results - Create table
+  assert:
+    that:
+      - create_table_bad is failed
+
 # ==============================================
 
 - name: Create complex table - check_mode
   dynamodb_table:
     state: present
-    name: "{{ table_name_on_demand }}"
+    name: "{{ table_name_on_demand_complex }}"
     hash_key_name: "{{ table_index }}"
     hash_key_type: "{{ table_index_type }}"
     range_key_name: "{{ range_index }}"
@@ -53,10 +70,27 @@
       - create_complex_table is successful
       - create_complex_table is changed
 
+- name: Create complex table - check failure on index
+  dynamodb_table:
+    state: present
+    name: "{{ table_name_on_demand_complex }}"
+    hash_key_name: "{{ table_index }}"
+    hash_key_type: "{{ table_index_type }}"
+    billing_mode: PAY_PER_REQUEST
+    tags: "{{ tags_default }}"
+    indexes: "{{ indexes_pay_per_request_bad }}"
+  ignore_errors: yes
+  register: create_complex_table_bad
+
+- name: Check results - Create complex table
+  assert:
+    that:
+      - create_complex_table_bad is failure
+
 - name: Create complex table
   dynamodb_table:
     state: present
-    name: "{{ table_name_on_demand }}"
+    name: "{{ table_name_on_demand_complex }}"
     hash_key_name: "{{ table_index }}"
     hash_key_type: "{{ table_index_type }}"
     billing_mode: PAY_PER_REQUEST
@@ -82,13 +116,13 @@
       - create_complex_table.hash_key_name == table_index
       - create_complex_table.hash_key_type == table_index_type
       - create_complex_table.indexes | length == 2
-      - create_complex_table.table_name == table_name_on_demand
+      - create_complex_table.table_name == table_name_on_demand_complex
       - create_complex_table.tags == tags_default
 
 - name: Update complex table billing_mode
   dynamodb_table:
     state: present
-    name: "{{ table_name_on_demand }}"
+    name: "{{ table_name_on_demand_complex }}"
     hash_key_name: "{{ table_index }}"
     hash_key_type: "{{ table_index_type }}"
     billing_mode: PROVISIONED
@@ -105,10 +139,3 @@
       - convert_complex_table is changed
       - '"billing_mode" in convert_complex_table'
       - convert_complex_table.billing_mode == "PROVISIONED"
-
-- name: Delete table
-  dynamodb_table:
-    state: absent
-    name: "{{ table_name_on_demand }}"
-    wait: false
-  register: delete_table


### PR DESCRIPTION
##### SUMMARY
Make deprecated primary key updates and `all` type index includes update fail in `dynamodb_table` module for `3.0.0`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dynamodb_table

##### ADDITIONAL INFORMATION
Both parts were previously deprecated and are currently ignored, this PR actually makes those ignore updates fail on attempts to pass the bad config.
