### PR TITLE
Make deprecated keys_attr param ignored in aws_kms_info

### DIFF
--- a/changelogs/fragments/838-ignore-deprecated-param-aws_kms_info.yml
+++ b/changelogs/fragments/838-ignore-deprecated-param-aws_kms_info.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Deprecated ``keys_attr`` field in aws_kms_info is now ignored (https://github.com/ansible-collections/community.aws/pull/838).

--- a/changelogs/fragments/838-ignore-deprecated-param-aws_kms_info.yml
+++ b/changelogs/fragments/838-ignore-deprecated-param-aws_kms_info.yml
@@ -1,2 +1,2 @@
 breaking_changes:
-  - Deprecated ``keys_attr`` field in aws_kms_info is now ignored (https://github.com/ansible-collections/community.aws/pull/838).
+  - aws_kms_info - Deprecated ``keys_attr`` field is now ignored (https://github.com/ansible-collections/community.aws/pull/838).

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -470,10 +470,9 @@ def main():
     # We originally returned "keys"
     if module.params['keys_attr']:
         module.deprecate("Returning results in the 'keys' attribute conflicts with the builtin keys() method on "
-                         "dicts and as such is deprecated.  Please use the kms_keys attribute.  This warning can be "
+                         "dicts and as such is deprecated and is now ignored. Please use the kms_keys attribute. This warning can be "
                          "silenced by setting keys_attr to False.",
                          version='3.0.0', collection_name='community.aws')
-        ret_params.update(dict(keys=filtered_keys))
     module.exit_json(**ret_params)
 
 


### PR DESCRIPTION
##### SUMMARY
Make deprecated `keys_attr` param ignored in `aws_kms_info` as planned for `3.0.0`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_kms_info

##### ADDITIONAL INFORMATION

