### PR TITLE
Support changing of launch type

### DIFF
--- a/changelogs/fragments/840-ecs_taskdefinition-fix-task-definition-comparison.yml
+++ b/changelogs/fragments/840-ecs_taskdefinition-fix-task-definition-comparison.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ecs_taskdefinition - include launch_type comparison when comparing task definitions (https://github.com/ansible-collections/community.aws/pull/840)

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -931,7 +931,7 @@ def main():
                 if requested_task_role_arn != td.get('taskRoleArn', ""):
                     return None
 
-                if requested_launch_type not in td.get('requiresCompatibilities', []):
+                if requested_launch_type != None and requested_launch_type not in td.get('compatibilities', []):
                     return None
 
                 existing_volumes = td.get('volumes', []) or []

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -931,7 +931,7 @@ def main():
                 if requested_task_role_arn != td.get('taskRoleArn', ""):
                     return None
 
-                if requested_launch_type != None and requested_launch_type not in td.get('compatibilities', []):
+                if requested_launch_type is not None and requested_launch_type not in td.get('compatibilities', []):
                     return None
 
                 existing_volumes = td.get('volumes', []) or []

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -924,11 +924,14 @@ def main():
 
                 return True
 
-            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, existing_task_definition):
+            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_launch_type, existing_task_definition):
                 if td['status'] != "ACTIVE":
                     return None
 
                 if requested_task_role_arn != td.get('taskRoleArn', ""):
+                    return None
+
+                if requested_launch_type not in td.get('requiresCompatibilities', []):
                     return None
 
                 existing_volumes = td.get('volumes', []) or []
@@ -973,7 +976,7 @@ def main():
                 requested_volumes = module.params['volumes'] or []
                 requested_containers = module.params['containers'] or []
                 requested_task_role_arn = module.params['task_role_arn']
-                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, td)
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_launch_type td)
 
                 if existing:
                     break

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -976,7 +976,8 @@ def main():
                 requested_volumes = module.params['volumes'] or []
                 requested_containers = module.params['containers'] or []
                 requested_task_role_arn = module.params['task_role_arn']
-                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_launch_type td)
+                requested_launch_type = module.params['launch_type']
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_launch_type, td)
 
                 if existing:
                     break

--- a/tests/integration/targets/ecs_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/full_test.yml
@@ -674,6 +674,29 @@
       ecs_taskdefinition_info:
         task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_fargate_task_definition.taskdefinition.revision }}"
 
+    - name: create EC2 VPC-networked task definition with CPU or Memory and execution role
+      ecs_taskdefinition:
+        containers: "{{ ecs_fargate_task_containers }}"
+        family: "{{ ecs_task_name }}-vpc"
+        network_mode: awsvpc
+        launch_type: EC2
+        cpu: 512
+        memory: 1024
+        execution_role_arn: "{{ iam_execution_role.arn }}"
+        state: present
+      vars:
+        ecs_task_host_port: 8080
+      register: ecs_ec2_task_definition
+
+    - name: obtain ECS task definition facts
+      ecs_taskdefinition_info:
+        task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_ec2_task_definition.taskdefinition.revision }}"
+
+    - name: check that changing task definiton launch type created a new task definition revision
+      assert:
+        that:
+          - ecs_fargate_task_definition.taskdefinition.revision != ecs_ec2_task_definition.taskdefinition.revision
+
     - name: create fargate ECS service without network config (expected to fail)
       ecs_service:
         state: present


### PR DESCRIPTION
##### SUMMARY

When changing the `launch_type` parameter for an `ecs_taskdefition` there was no change reported by the module. This adds a check to see if `launch_type` in the `ecs_taskdefinition` has changed. If there is a change detected the module reports back there is not a matching task definition and creates a new one.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ecs_taskdefinition
