### PR TITLE
increase length clientRequestToken for 33char min

### DIFF
--- a/plugins/modules/aws_eks_cluster.py
+++ b/plugins/modules/aws_eks_cluster.py
@@ -204,7 +204,7 @@ def ensure_present(client, module):
                       resourcesVpcConfig=dict(
                           subnetIds=subnets,
                           securityGroupIds=groups),
-                      clientRequestToken='ansible-create-%s' % name)
+                      clientRequestToken='ansible-eks-cluster-automation-create-%s' % name)
         if module.params['version']:
             params['version'] = module.params['version']
         cluster = client.create_cluster(**params)['cluster']


### PR DESCRIPTION

With the old string of 'ansible-create-%s', anyone who uses this module to create a cluster with a name < 18 characters will encounter an InvalidParameterError

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AWS Updated this parameter to require a minimum of 33 chars.

Unaware of existing issue for this, I encountered it today and couldnt find much online.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
aws_eks_cluster.py module 

##### ADDITIONAL INFORMATION
Without this fix, any cluster created using this module, with a cluster name < 18 characters, will encounter the following error:
"Couldn't create cluster <cluster_name>: An error occurred (InvalidParameterException) when calling the CreateCluster operation: The client request token parameter must be between 33 and 126 characters."
