### PR TITLE
Remove unsed imports

### DIFF
--- a/plugins/modules/aws_glue_job.py
+++ b/plugins/modules/aws_glue_job.py
@@ -245,9 +245,7 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_aws_account_info
 

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -241,7 +241,6 @@ result:
     type: dict
 '''
 
-from functools import partial
 import traceback
 
 try:

--- a/plugins/modules/rds_option_group_info.py
+++ b/plugins/modules/rds_option_group_info.py
@@ -244,7 +244,6 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1285
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1286
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1287

##### SUMMARY

My local tests are flagging that we've picked up some unused imports again.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_glue_job
cloudfront_info
rds_option_group_info


##### ADDITIONAL INFORMATION
