### PR TITLE
Remove duplicate botocore requirement from aws_msk_config docs

### DIFF
--- a/plugins/modules/aws_msk_config.py
+++ b/plugins/modules/aws_msk_config.py
@@ -12,9 +12,6 @@ DOCUMENTATION = r"""
 module: aws_msk_config
 short_description: Manage Amazon MSK cluster configurations.
 version_added: "2.0.0"
-requirements:
-    - botocore >= 1.17.48
-    - boto3
 description:
     - Create, delete and modify Amazon MSK (Managed Streaming for Apache Kafka) cluster configurations.
 author:


### PR DESCRIPTION
##### SUMMARY

Module doc has a botocore requirement line, and the aws doc fragment also has a requirement line.  The collection requirement is higher than the module requirement so this is redundant.

##### ISSUE TYPE
- Docs Pull Request
- 
##### COMPONENT NAME
aws_msk_config


This has been duplicated in the docs for some time so IMO we don't need to merge this before 3.0.0 releases; that way we don't have to regenerate the docs for the release.  We can backport after the release.