### PR TITLE
docs fix. clean up duplicated and unspecific requirements

### DIFF
--- a/changelogs/fragments/863-requirements-doc-fix.yml
+++ b/changelogs/fragments/863-requirements-doc-fix.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - aws_msk_config - remove duplicated and unspecific requirements (https://github.com/ansible-collections/community.aws/pull/863).
+  - ecs_taskdefinition - remove duplicated and unspecific requirements (https://github.com/ansible-collections/community.aws/pull/863).

--- a/plugins/modules/aws_msk_config.py
+++ b/plugins/modules/aws_msk_config.py
@@ -12,8 +12,6 @@ DOCUMENTATION = r"""
 module: aws_msk_config
 short_description: Manage Amazon MSK cluster configurations.
 version_added: "2.0.0"
-requirements:
-    - botocore >= 1.17.48
 description:
     - Create, delete and modify Amazon MSK (Managed Streaming for Apache Kafka) cluster configurations.
 author:

--- a/plugins/modules/aws_msk_config.py
+++ b/plugins/modules/aws_msk_config.py
@@ -14,7 +14,6 @@ short_description: Manage Amazon MSK cluster configurations.
 version_added: "2.0.0"
 requirements:
     - botocore >= 1.17.48
-    - boto3
 description:
     - Create, delete and modify Amazon MSK (Managed Streaming for Apache Kafka) cluster configurations.
 author:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -16,7 +16,6 @@ description:
 author:
     - Mark Chance (@Java1Guy)
     - Alina Buzachis (@alinabuzachis)
-requirements: [ json, botocore, boto3 ]
 options:
     state:
         description:


### PR DESCRIPTION
##### SUMMARY
* remove unspecific/duplicated requirements

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* aws_msk_config
* ecs_taskdefinition

##### ADDITIONAL INFORMATION
I don't see the `json` library is explicit used in `aws_msk_config`. Furthermore it's standard python library.
