### PR TITLE
Add support for tagging certificates. Fix deprecated tasks in aws_acm integration tests

### DIFF
--- a/changelogs/fragments/870-aws_acm_certificate_tags.yml
+++ b/changelogs/fragments/870-aws_acm_certificate_tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_acm - Add ``tags`` and ``purge_tags`` parameters to tag certificates in ACM (https://github.com/ansible-collections/community.aws/pull/780).

--- a/changelogs/fragments/870-aws_acm_certificate_tags.yml
+++ b/changelogs/fragments/870-aws_acm_certificate_tags.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- aws_acm - Add ``tags`` and ``purge_tags`` parameters to tag certificates in ACM (https://github.com/ansible-collections/community.aws/pull/780).
+- aws_acm - Add ``tags`` and ``purge_tags`` parameters to tag certificates in ACM (https://github.com/ansible-collections/community.aws/pull/870).

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -157,6 +157,17 @@ options:
     choices: [present, absent]
     default: present
     type: str
+
+  tags:
+    description:
+      - tags dict to apply to a snapshot.
+    type: dict
+  purge_tags:
+    description:
+      - whether to remove tags not present in the C(tags) parameter.
+    default: True
+    type: bool
+
 author:
   - Matthew Davis (@matt-telstra) on behalf of Telstra Corporation Limited
 extends_documentation_fragment:

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -175,7 +175,7 @@ options:
   purge_tags:
     description:
       - whether to remove tags not present in the C(tags) parameter.
-    default: True
+    default: false
     type: bool
 
 author:

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -529,14 +529,14 @@ def main():
         if sum([(module.params[a] is not None) for a in absent_args]) < 1:
             for a in absent_args:
                 module.debug("%s is %s" % (a, module.params[a]))
-            module.fail_json(msg="If 'state' is specified as 'present' then at least one of 'name_tag', certificate_arn' or 'domain_name' must be specified")
+            module.fail_json(msg="If 'state' is specified as 'present' then at least one of 'name_tag', 'certificate_arn' or 'domain_name' must be specified")
     else:  # absent
         # exactly one of these should be specified
         absent_args = ['certificate_arn', 'domain_name', 'name_tag']
         if sum([(module.params[a] is not None) for a in absent_args]) != 1:
             for a in absent_args:
                 module.debug("%s is %s" % (a, module.params[a]))
-            module.fail_json(msg="If 'state' is specified as 'absent' then exactly one of 'name_tag', certificate_arn' or 'domain_name' must be specified")
+            module.fail_json(msg="If 'state' is specified as 'absent' then exactly one of 'name_tag', 'certificate_arn' or 'domain_name' must be specified")
 
     filter_tags = None
     desired_tags = None

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -173,7 +173,7 @@ options:
         If the 'Name' tag in I(tags) is not set and I(name_tag) is set,
         the I(name_tag) value is copied to I(tags).
     type: dict
-    version_added: 3.1.0
+    version_added: 3.2.0
 
   purge_tags:
     description:

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -229,6 +229,14 @@ EXAMPLES = '''
     state: absent
     region: ap-southeast-2
 
+- name: add tags to an existing certificate with a particular ARN
+  community.aws.aws_acm:
+    certificate_arn: "arn:aws:acm:ap-southeast-2:123456789012:certificate/01234567-abcd-abcd-abcd-012345678901"
+    tags:
+      Name: my_certificate
+      Application: search
+      Environment: development
+    purge_tags: true
 '''
 
 RETURN = '''

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -180,7 +180,7 @@ options:
       - whether to remove tags not present in the C(tags) parameter.
     default: false
     type: bool
-    version_added: 3.1.0
+    version_added: 3.2.0
 
 author:
   - Matthew Davis (@matt-telstra) on behalf of Telstra Corporation Limited

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -173,12 +173,14 @@ options:
         If the 'Name' tag in I(tags) is not set and I(name_tag) is set,
         the I(name_tag) value is copied to I(tags).
     type: dict
+    version_added: 3.1.0
 
   purge_tags:
     description:
       - whether to remove tags not present in the C(tags) parameter.
     default: false
     type: bool
+    version_added: 3.1.0
 
 author:
   - Matthew Davis (@matt-telstra) on behalf of Telstra Corporation Limited

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -425,7 +425,7 @@ def update_imported_certificate(client, module, acm, old_cert, desired_tags):
     else:
         absent_args = ['certificate', 'name_tag', 'private_key']
         if sum([(module.params[a] is not None) for a in absent_args]) < 3:
-            module.fail_json(msg="When importing a certificate, all of 'name_tag', certificate' and 'private_key' must be specified")
+            module.fail_json(msg="When importing a certificate, all of 'name_tag', 'certificate' and 'private_key' must be specified")
         module.debug("Existing certificate in ACM is different, overwriting")
         changed = True
         if module.check_mode:
@@ -453,7 +453,7 @@ def import_certificate(client, module, acm, desired_tags):
     absent_args = ['certificate', 'name_tag', 'private_key']
     cert_arn = None
     if sum([(module.params[a] is not None) for a in absent_args]) < 3:
-        module.fail_json(msg="When importing a new certificate, all of 'name_tag', certificate' and 'private_key' must be specified")
+        module.fail_json(msg="When importing a new certificate, all of 'name_tag', 'certificate' and 'private_key' must be specified")
     module.debug("No certificate in ACM. Creating new one.")
     changed = True
     if module.check_mode:

--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -79,15 +79,17 @@ options:
   certificate:
     description:
       - The body of the PEM encoded public certificate.
-      - Required when I(state) is not C(absent).
+      - Required when I(state) is not C(absent) and the certificate does not exist.
       - >
         If your certificate is in a file,
         use C(lookup('file', 'path/to/cert.pem')).
     type: str
   certificate_arn:
     description:
-      - The ARN of a certificate in ACM to delete
-      - Ignored when I(state=present).
+      - The ARN of a certificate in ACM to modify or delete.
+      - >
+        If I(state=present), the certificate with the specified ARN can be updated.
+        For example, this can be used to add/remove tags to an existing certificate.
       - >
         If I(state=absent), you must provide one of
         I(certificate_arn), I(domain_name) or I(name_tag).
@@ -142,7 +144,7 @@ options:
   private_key:
     description:
       - The body of the PEM encoded private key.
-      - Required when I(state=present).
+      - Required when I(state=present) and the certificate does not exist.
       - Ignored when I(state=absent).
       - >
         If your private key is in a file,
@@ -163,7 +165,7 @@ options:
 
   tags:
     description:
-      - Tags to apply to certificates imported in AWS Certificate Manager.
+      - Tags to apply to certificates imported in ACM.
       - >
         If both I(name_tag) and the 'Name' tag in I(tags) are set,
         the values must be the same.

--- a/tests/integration/targets/aws_acm/aliases
+++ b/tests/integration/targets/aws_acm/aliases
@@ -1,5 +1,5 @@
 # https://github.com/ansible/ansible/issues/67788
-unstable
+# unstable
 
 cloud/aws
 

--- a/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
+++ b/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
@@ -68,7 +68,7 @@
       common_name: '{{ item.domain }}'
   - name: Generate a Self Signed OpenSSL certificate for own certs
     with_items: '{{ local_certs }}'
-    community.crypto.openssl_certificate:
+    community.crypto.x509_certificate:
       provider: selfsigned
       path: '{{ item.cert }}'
       csr_path: '{{ item.csr }}'
@@ -392,7 +392,7 @@
       common_name: '{{ chained_cert.domain }}'
   - name: Sign new certs with cert 0 and 1
     with_items: '{{ chained_cert.chains }}'
-    community.crypto.openssl_certificate:
+    community.crypto.x509_certificate:
       provider: ownca
       path: '{{ item.cert }}'
       csr_path: '{{ item.csr }}'

--- a/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
+++ b/tests/integration/targets/aws_acm/tasks/full_acm_test.yml
@@ -73,8 +73,7 @@
       path: '{{ item.cert }}'
       csr_path: '{{ item.csr }}'
       privatekey_path: '{{ item.priv_key }}'
-      signature_algorithms:
-      - sha256WithRSAEncryption
+      selfsigned_digest: sha256
   - name: upload certificate with check mode
     aws_acm:
       name_tag: '{{ item.name }}'
@@ -398,8 +397,7 @@
       csr_path: '{{ item.csr }}'
       ownca_path: '{{ local_certs[item.ca].cert }}'
       ownca_privatekey_path: '{{ local_certs[item.ca].priv_key }}'
-      signature_algorithms:
-      - sha256WithRSAEncryption
+      selfsigned_digest: sha256
   - name: check files exist (for next task)
     file:
       path: '{{ item }}'

--- a/tests/integration/targets/aws_acm/tasks/main.yml
+++ b/tests/integration/targets/aws_acm/tasks/main.yml
@@ -59,12 +59,36 @@
       csr_path: '{{ item.csr }}'
       privatekey_path: '{{ item.priv_key }}'
       selfsigned_digest: sha256
+  - name: try to upload certificate, but name_tag conflicts with tags.Name
+    vars:
+      local_cert: '{{ local_certs[0] }}'
+    aws_acm:
+      name_tag: '{{ local_cert.name }}'
+      certificate: '{{ lookup(''file'', local_cert.cert ) }}'
+      private_key: '{{ lookup(''file'', local_cert.priv_key ) }}'
+      state: present
+      tags:
+        Name: '{{ local_cert.name }}-other'
+        Application: search
+        Environment: development
+    register: result
+    ignore_errors: true
+  - name: assert failure when name_tag conflicts with tags.Name
+    assert:
+      that:
+          - 'result.failed'
+          - '"conflicts with value of" in result.msg'
   - name: upload certificates first time
     aws_acm:
       name_tag: '{{ item.name }}'
       certificate: '{{ lookup(''file'', item.cert ) }}'
       private_key: '{{ lookup(''file'', item.priv_key ) }}'
       state: present
+      # Add tags
+      tags:
+        Application: search
+        Environment: development
+      purge_tags: false
     register: upload
     with_items: '{{ local_certs }}'
     until: upload is succeeded
@@ -94,7 +118,11 @@
       - fetch_after_up_result.certificates[0].domain_name == original_cert.domain
       - (fetch_after_up_result.certificates[0].certificate | replace( ' ', '' ) | replace( '\n', '')) == (lookup( 'file', original_cert.cert ) | replace( ' ', '' ) | replace( '\n', '' ))
       - '''Name'' in fetch_after_up_result.certificates[0].tags'
+      - '''Application'' in fetch_after_up_result.certificates[0].tags'
+      - '''Environment'' in fetch_after_up_result.certificates[0].tags'
       - fetch_after_up_result.certificates[0].tags['Name'] == original_cert.name
+      - fetch_after_up_result.certificates[0].tags['Application'] == 'search'
+      - fetch_after_up_result.certificates[0].tags['Environment'] == 'development'
     with_items: '{{ fetch_after_up.results }}'
     vars:
       fetch_after_up_result: '{{ item }}'

--- a/tests/integration/targets/aws_acm/tasks/main.yml
+++ b/tests/integration/targets/aws_acm/tasks/main.yml
@@ -53,7 +53,7 @@
       common_name: '{{ item.domain }}'
   - name: Generate a Self Signed OpenSSL certificate for own certs
     with_items: '{{ local_certs }}'
-    community.crypto.openssl_certificate:
+    community.crypto.x509_certificate:
       provider: selfsigned
       path: '{{ item.cert }}'
       csr_path: '{{ item.csr }}'
@@ -293,7 +293,7 @@
       common_name: '{{ chained_cert.domain }}'
   - name: Sign new certs with cert 0 and 1
     with_items: '{{ chained_cert.chains }}'
-    community.crypto.openssl_certificate:
+    community.crypto.x509_certificate:
       provider: ownca
       path: '{{ item.cert }}'
       csr_path: '{{ item.csr }}'

--- a/tests/integration/targets/aws_acm/tasks/main.yml
+++ b/tests/integration/targets/aws_acm/tasks/main.yml
@@ -11,7 +11,16 @@
   # are from which test
   - set_fact:
       aws_acm_test_uuid: "{{ (10**9) | random }}"
-
+  - name: attempt to delete cert without specifying required parameter
+    aws_acm:
+      state: absent
+    register: result
+    ignore_errors: true
+  - name: assert failure when name_tag conflicts with tags.Name
+    assert:
+      that:
+          - 'result.failed'
+          - '"If ''state'' is specified as ''absent'' then exactly one of ''name_tag''" in result.msg'
   - name: list certs
     aws_acm_info: null
     register: list_all
@@ -181,6 +190,68 @@
     register: upload2
     with_items: '{{ local_certs }}'
     failed_when: upload2.changed
+  - name: change tags of existing certificate
+    aws_acm:
+      # When applying tags to an existing certificate, it is sufficient to specify the 'certificate_arn'.
+      # Previously, the 'aws_acm' module was requiring the 'certificate', 'name_tag' and 'domain_name'
+      # attributes.
+      certificate_arn: '{{ certificate_arn }}'
+      tags:
+        Name: '{{ name_tag }}'
+        Application: search
+        Environment: staging
+        Owner: Bob
+    register: certificate_with_tags
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+      domain_name: '{{ upload2.results[0].certificate.domain_name }}'
+  - name: check fetched data of cert we just uploaded
+    vars:
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+      domain_name: '{{ upload2.results[0].certificate.domain_name }}'
+      name_tag: '{{ upload2.results[0].item.name }}'
+    assert:
+      that:
+      - certificate_with_tags.certificate.arn == certificate_arn
+      - certificate_with_tags.certificate.tags | length == 4
+      - '''Name'' in certificate_with_tags.certificate.tags'
+      - '''Application'' in certificate_with_tags.certificate.tags'
+      - '''Environment'' in certificate_with_tags.certificate.tags'
+      - '''Owner'' in certificate_with_tags.certificate.tags'
+      - certificate_with_tags.certificate.tags['Name'] == name_tag
+      - certificate_with_tags.certificate.tags['Application'] == 'search'
+      - certificate_with_tags.certificate.tags['Environment'] == 'staging'
+      - certificate_with_tags.certificate.tags['Owner'] == 'Bob'
+  - name: change tags of existing certificate, purge tags
+    aws_acm:
+      certificate_arn: '{{ certificate_arn }}'
+      tags:
+        Name: '{{ name_tag }}'
+        Application: search
+        Environment: staging
+      # 'Owner' tag should be removed because 'purge_tags: true'
+      purge_tags: true
+    register: certificate_with_tags
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+      domain_name: '{{ upload2.results[0].certificate.domain_name }}'
+  - name: check fetched data of cert we just uploaded
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+      domain_name: '{{ upload2.results[0].certificate.domain_name }}'
+    assert:
+      that:
+      - certificate_with_tags.certificate.arn == certificate_arn
+      - certificate_with_tags.certificate.tags | length == 3
+      - '''Name'' in certificate_with_tags.certificate.tags'
+      - '''Application'' in certificate_with_tags.certificate.tags'
+      - '''Environment'' in certificate_with_tags.certificate.tags'
+      - certificate_with_tags.certificate.tags['Name'] == name_tag
+      - certificate_with_tags.certificate.tags['Application'] == 'search'
+      - certificate_with_tags.certificate.tags['Environment'] == 'staging'
   - name: update first cert with body of the second, first time
     aws_acm:
       state: present

--- a/tests/integration/targets/aws_acm/tasks/main.yml
+++ b/tests/integration/targets/aws_acm/tasks/main.yml
@@ -190,7 +190,24 @@
     register: upload2
     with_items: '{{ local_certs }}'
     failed_when: upload2.changed
-  - name: change tags of existing certificate
+  - name: change tags of existing certificate, check mode
+    aws_acm:
+      certificate_arn: '{{ certificate_arn }}'
+      tags:
+        Name: '{{ name_tag }}'
+        Application: search
+        Environment: staging
+        Owner: Bob
+    register: certificate_with_tags
+    check_mode: true
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+      domain_name: '{{ upload2.results[0].certificate.domain_name }}'
+  - assert:
+      that:
+      - certificate_with_tags.changed
+  - name: change tags of existing certificate, changes expected
     aws_acm:
       # When applying tags to an existing certificate, it is sufficient to specify the 'certificate_arn'.
       # Previously, the 'aws_acm' module was requiring the 'certificate', 'name_tag' and 'domain_name'
@@ -206,6 +223,64 @@
       name_tag: '{{ upload2.results[0].item.name }}'
       certificate_arn: '{{ upload2.results[0].certificate.arn }}'
       domain_name: '{{ upload2.results[0].certificate.domain_name }}'
+  - name: assert certificate tags
+    assert:
+      that:
+      - certificate_with_tags.certificate.tags | length == 4
+      - '''Name'' in certificate_with_tags.certificate.tags'
+      - '''Application'' in certificate_with_tags.certificate.tags'
+      - '''Environment'' in certificate_with_tags.certificate.tags'
+      - '''Owner'' in certificate_with_tags.certificate.tags'
+      - certificate_with_tags.certificate.tags['Name'] == name_tag
+      - certificate_with_tags.certificate.tags['Application'] == 'search'
+      - certificate_with_tags.certificate.tags['Environment'] == 'staging'
+      - certificate_with_tags.certificate.tags['Owner'] == 'Bob'
+      - certificate_with_tags.changed
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+  - name: change tags of existing certificate, check mode again
+    aws_acm:
+      certificate_arn: '{{ certificate_arn }}'
+      tags:
+        Name: '{{ name_tag }}'
+        Application: search
+        Environment: staging
+        Owner: Bob
+    register: certificate_with_tags
+    check_mode: true
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+  - assert:
+      that:
+      - not certificate_with_tags.changed
+  - name: change tags of existing certificate, no change expected
+    aws_acm:
+      certificate_arn: '{{ certificate_arn }}'
+      tags:
+        Name: '{{ name_tag }}'
+        Application: search
+        Environment: staging
+        Owner: Bob
+    register: certificate_with_tags
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
+      certificate_arn: '{{ upload2.results[0].certificate.arn }}'
+  - name: assert certificate tags
+    assert:
+      that:
+      - certificate_with_tags.certificate.tags | length == 4
+      - '''Name'' in certificate_with_tags.certificate.tags'
+      - '''Application'' in certificate_with_tags.certificate.tags'
+      - '''Environment'' in certificate_with_tags.certificate.tags'
+      - '''Owner'' in certificate_with_tags.certificate.tags'
+      - certificate_with_tags.certificate.tags['Name'] == name_tag
+      - certificate_with_tags.certificate.tags['Application'] == 'search'
+      - certificate_with_tags.certificate.tags['Environment'] == 'staging'
+      - certificate_with_tags.certificate.tags['Owner'] == 'Bob'
+      - not certificate_with_tags.changed
+    vars:
+      name_tag: '{{ upload2.results[0].item.name }}'
   - name: check fetched data of cert we just uploaded
     vars:
       certificate_arn: '{{ upload2.results[0].certificate.arn }}'

--- a/tests/integration/targets/aws_acm/tasks/main.yml
+++ b/tests/integration/targets/aws_acm/tasks/main.yml
@@ -58,8 +58,7 @@
       path: '{{ item.cert }}'
       csr_path: '{{ item.csr }}'
       privatekey_path: '{{ item.priv_key }}'
-      signature_algorithms:
-      - sha256WithRSAEncryption
+      selfsigned_digest: sha256
   - name: upload certificates first time
     aws_acm:
       name_tag: '{{ item.name }}'
@@ -299,8 +298,7 @@
       csr_path: '{{ item.csr }}'
       ownca_path: '{{ local_certs[item.ca].cert }}'
       ownca_privatekey_path: '{{ local_certs[item.ca].priv_key }}'
-      signature_algorithms:
-      - sha256WithRSAEncryption
+      selfsigned_digest: sha256
   - name: check files exist (for next task)
     file:
       path: '{{ item }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for configuring arbitrary tags when importing a certificate using the `aws_acm` module. Previously, it was only possible to set the 'Name' tag.

Additionally, this PR fixes issues with the `aws_acm` integration tests.  The integration tests were using deprecated tasks or attributes, such as `openssl_certificate`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

aws_acm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Changes to the `aws_acm.py` module:
1. Add new `tags` and `purge_tags` attributes.
2. The `certificate_arn` attribute is now allowed when `state='present'`. A playbook should be allowed to modify an existing certificate entry by providing the ARN. For example, a play may want to add, modify, remove tags on an existing certificate.
3. The `aws_acm` module returns the updated tags. See example below.
4. Refactor `aws_acm.py` to improve code reuse and make it possible to set arbitrary tags. This should also help to 1) improve readability. 2) prepare for #869 which I am planning to work on next.

Backwards-compatibility is retained, even though it might make sense to normalize some of the attributes.

Example return value:
```
"certificate": {
            "arn": "arn:aws:acm:us-west-1:account:certificate/f85abf9d-4bda-4dcc-98c3-770664a68243",
            "domain_name": "acm1.949058644.ansible.com",
            "tags": {
                "Application": "search",
                "Environment": "development",
                "Name": "ansible-test-78006277-398b5796f999_949058644_1"
            }
        }
```

**Integration tests:**
1. The `openssl_certificate` task is deprecated. Migrate to `x509_certificate`.
2. The `signature_algorithms` attribute is no longer supported by the new `x509_certificate` task. Using `selfsigned_digest` instead.
3. The integration tests for the `aws_acm` module pass locally.
4. I see https://github.com/ansible/ansible/issues/67788 has been closed, but tests/integration/targets/aws_acm/aliases still has `unstable`. I am not sure what to do about it. I was able to run the tests in my local workspace after making the above changes.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
