### PR TITLE
wafv2_web_acl_info doc fix

### DIFF
--- a/plugins/modules/wafv2_web_acl_info.py
+++ b/plugins/modules/wafv2_web_acl_info.py
@@ -15,21 +15,21 @@ short_description: wafv2_web_acl
 description:
   - Info about web acl
 options:
-    name:
-      description:
-        - The name of the web acl.
-      required: true
-      type: str
-    scope:
-      description:
-        - Scope of wafv2 web acl.
-      required: true
-      choices: ["CLOUDFRONT","REGIONAL"]
-      type: str
+  name:
+    description:
+      - The name of the web acl.
+    required: true
+    type: str
+  scope:
+    description:
+      - Scope of wafv2 web acl.
+    required: true
+    choices: ["CLOUDFRONT", "REGIONAL"]
+    type: str
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+  - amazon.aws.aws
+  - amazon.aws.ec2
 
 '''
 


### PR DESCRIPTION
##### SUMMARY

```
  10:5      error    wrong indentation: expected 2 but found 4  (indentation)
  19:30     error    too few spaces after comma  (commas)
  23:1      error    wrong indentation: expected 2 but found 0  (indentation)
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
wafv2_web_acl_info
