### PR TITLE
s3_lifecycle: incr version_added

### DIFF
--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -27,7 +27,7 @@ options:
     description:
       - Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload.
     type: int
-    version_added: 2.2.0
+    version_added: 3.1.0
   expiration_date:
     description:
       - Indicates the lifetime of the objects that are subject to the rule by the date they will expire.
@@ -46,7 +46,7 @@ options:
       - If set to C(true), the delete marker will be expired; if set to C(false) the policy takes no action.
       - This cannot be specified with I(expiration_days) or I(expiration_date).
     type: bool
-    version_added: 2.2.0
+    version_added: 3.1.0
   prefix:
     description:
       - Prefix identifying one or more objects to which the rule applies.


### PR DESCRIPTION
##### SUMMARY

Since 3.0.0 is already inceased, we've missed the train to backport a new feature for 2.2.0

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
s3_lifecycle

##### ADDITIONAL INFORMATION

It was not merge due the CI change to softwareproject. After CI pass, 3.0.0 was already released.   
Backport a new feature to 2.2.0 would suggest that the feature is also available in 3.0.0

https://github.com/ansible-collections/community.aws/pull/794/