### PR TITLE
Add dynamodb table class support

### DIFF
--- a/changelogs/fragments/880-add-table-class-param.yml
+++ b/changelogs/fragments/880-add-table-class-param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dynamodb_table - the ``table_class`` parameter has been added (https://github.com/ansible-collections/community.aws/pull/880).

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -123,7 +123,8 @@ options:
     elements: dict
   table_class:
     description:
-      - The class of the table
+      - The class of the table.
+      - Requires at least botocore version 1.23.18.
     choices: ['STANDARD', 'STANDARD_INFREQUENT_ACCESS']
     type: str
     version_added: 3.1.0
@@ -212,6 +213,11 @@ table_status:
     returned: success
     type: str
     sample: ACTIVE
+table_class:
+    description: The current table class.
+    returned: when state present
+    type: str
+    sample: STANDARD_INFREQUENT_ACCESS
 '''
 
 try:
@@ -1020,8 +1026,7 @@ def main():
     client = module.client('dynamodb', retry_decorator=retry_decorator)
 
     if module.params.get('table_class'):
-        if not module.botocore_at_least("1.23.18"):
-            module.fail_json(msg='botocore version >= 1.23.18 is required setting table_class')
+        module.require_botocore_at_least('1.23.18', reason='to set table_class')
 
     current_table = get_dynamodb_table()
     changed = False

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -459,6 +459,9 @@ def get_dynamodb_table():
     table['size'] = table['table_size_bytes']
     table['tags'] = tags
 
+    if 'table_class_summary' in table:
+        table['table_class'] = table['table_class_summary']['table_class']
+
     # billing_mode_summary doesn't always seem to be set but is always set for PAY_PER_REQUEST
     # and when updating the billing_mode
     if 'billing_mode_summary' in table:

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -208,16 +208,49 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+table:
+  description: The returned table params from the describe API call.
+  returned: success
+  type: complex
+  contains: {}
+  sample: {
+    "arn": "arn:aws:dynamodb:us-east-1:721066863947:table/ansible-test-table",
+    "attribute_definitions": [
+        {
+            "attribute_name": "id",
+            "attribute_type": "N"
+        }
+    ],
+    "billing_mode": "PROVISIONED",
+    "creation_date_time": "2022-02-04T13:36:01.578000+00:00",
+    "id": "533b45fe-0870-4b66-9b00-d2afcfe96f19",
+    "item_count": 0,
+    "key_schema": [
+        {
+            "attribute_name": "id",
+            "key_type": "HASH"
+        }
+    ],
+    "name": "ansible-test-14482047-alinas-mbp",
+    "provisioned_throughput": {
+        "number_of_decreases_today": 0,
+        "read_capacity_units": 1,
+        "write_capacity_units": 1
+    },
+    "size": 0,
+    "status": "ACTIVE",
+    "table_arn": "arn:aws:dynamodb:us-east-1:721066863947:table/ansible-test-table",
+    "table_id": "533b45fe-0870-4b66-9b00-d2afcfe96f19",
+    "table_name": "ansible-test-table",
+    "table_size_bytes": 0,
+    "table_status": "ACTIVE",
+    "tags": {}
+  }
 table_status:
-    description: The current status of the table.
-    returned: success
-    type: str
-    sample: ACTIVE
-table_class:
-    description: The current table class.
-    returned: when state present
-    type: str
-    sample: STANDARD_INFREQUENT_ACCESS
+  description: The current status of the table.
+  returned: success
+  type: str
+  sample: ACTIVE
 '''
 
 try:

--- a/tests/integration/targets/dynamodb_table/meta/main.yml
+++ b/tests/integration/targets/dynamodb_table/meta/main.yml
@@ -1,2 +1,4 @@
 dependencies:
-  - prepare_tests
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: "1.23.18"

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -574,7 +574,6 @@
         - delete_table is not changed
 
   # ==============================================
-
   - name: Create complex table - check_mode
     dynamodb_table:
       state: present
@@ -589,6 +588,8 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     check_mode: True
 
   - name: Check results - Create complex table - check_mode
@@ -611,6 +612,8 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - name: Check results - Create complex table
     assert:
@@ -653,6 +656,8 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     check_mode: True
 
   - name: Check results - Create complex table - idempotent - check_mode
@@ -675,6 +680,8 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - name: Check results - Create complex table - idempotent
     assert:
@@ -712,6 +719,8 @@
       name: "{{ table_name }}"
       table_class: "STANDARD"
     register: update_class
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     check_mode: True
 
   - name: Check results - Update table class - check_mode
@@ -725,6 +734,8 @@
       state: present
       name: "{{ table_name }}"
       table_class: "STANDARD"
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     register: update_class
 
   - name: Check results - Update table class

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -585,6 +585,7 @@
       range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
+      table_class: "STANDARD_INFREQUENT_ACCESS"
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
@@ -606,6 +607,7 @@
       range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
+      table_class: "STANDARD_INFREQUENT_ACCESS"
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
@@ -633,6 +635,7 @@
         - create_complex_table.range_key_type == range_index_type
         - create_complex_table.read_capacity == 3
         - create_complex_table.table_name == table_name
+        - create_complex_table.table_class == "STANDARD_INFREQUENT_ACCESS"
         - create_complex_table.write_capacity == 3
         - create_complex_table.tags == tags_default
 
@@ -646,6 +649,7 @@
       range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
+      table_class: "STANDARD_INFREQUENT_ACCESS"
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
@@ -667,6 +671,7 @@
       range_key_type: "{{ range_index_type }}"
       read_capacity: 3
       write_capacity: 3
+      table_class: "STANDARD_INFREQUENT_ACCESS"
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
@@ -694,10 +699,44 @@
         - create_complex_table.range_key_type == range_index_type
         - create_complex_table.read_capacity == 3
         - create_complex_table.table_name == table_name
+        - create_complex_table.table_class == "STANDARD_INFREQUENT_ACCESS"
         - create_complex_table.write_capacity == 3
         - create_complex_table.tags == tags_default
 
   # ==============================================
+  # Update table class on exisiting table
+
+  - name: Update table class - check_mode
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      table_class: "STANDARD"
+    register: update_class
+    check_mode: True
+
+  - name: Check results - Update table class - check_mode
+    assert:
+      that:
+        - update_class is successful
+        - update_class is changed
+
+  - name: Update table class
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      table_class: "STANDARD"
+    register: update_class
+
+  - name: Check results - Update table class
+    assert:
+      that:
+        - update_class is successful
+        - update_class is changed
+        - update_class.table_name == table_name
+        - update_class.table_class == "STANDARD"
+
+  # ==============================================
+  # Update table index on exisiting table
 
   - name: Update table update index - check_mode
     dynamodb_table:


### PR DESCRIPTION
##### SUMMARY
Add support for defining a `TableClass` on DynamoDB tables.

`TableClass` was introduced as part of `botocore` version `1.23.18`
https://github.com/boto/botocore/blob/develop/CHANGELOG.rst#12318

Fixes: https://github.com/ansible-collections/community.aws/issues/829

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dynamodb_table

##### ADDITIONAL INFORMATION
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.create_table
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.update_table
