### PR TITLE
Fix cloudfront_distribution s3_origin_access_identity_enabled bug

### DIFF
--- a/changelogs/fragments/881-cloudfront-bug.yml
+++ b/changelogs/fragments/881-cloudfront-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudfront_distribution - Dont pass ``s3_origin_access_identity_enabled`` to API request (https://github.com/ansible-collections/community.aws/pull/881).


### PR DESCRIPTION
##### SUMMARY
If `s3_origin_access_identity_enabled` is set to `True` but no `s3_origin_config` then a default origin config is applied however it also picks up `s3_origin_access_identity_enabled` as `S3OriginAccessIdentityEnabled` and passes it to the API request which is not a valid option to be passed and then fails validation.

Fixes: https://github.com/ansible-collections/community.aws/issues/749

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ADDITIONAL INFORMATION
The option mention is not valid for the API request:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#CloudFront.Client.create_distribution
