### PR TITLE
migrate from ansible.netcommon to ansible.utils

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,7 @@ mock
 pytest-xdist
 # We should avoid these two modules with py3
 pytest-mock
-# Needed for ansible.netcommon.ipaddr in tests
+# Needed for ansible.utils.ipaddr in tests
 netaddr
 # Sometimes needed where we don't have features we need in modules
 awscli

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,7 +3,7 @@ boto
 boto3
 botocore
 
-# netaddr is needed for ansible.netcommon.ipv6
+# netaddr is needed for ansible.utils.ipv6
 netaddr
 virtualenv
 # Sometimes needed where we don't have features we need in modules

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -108,7 +108,7 @@
       that:
       - eip is defined
       - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.netcommon.ipaddr )
+      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
 
@@ -160,7 +160,7 @@
       that:
       - eip is defined
       - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.netcommon.ipaddr )
+      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
@@ -175,7 +175,7 @@
       that:
       - reallocate_eip is defined
       - reallocate_eip is not changed
-      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.netcommon.ipaddr )
+      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr )
       - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
@@ -202,7 +202,7 @@
       that:
       - eip is defined
       - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.netcommon.ipaddr )
+      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
@@ -217,7 +217,7 @@
       that:
       - reallocate_eip is defined
       - reallocate_eip is not changed
-      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.netcommon.ipaddr )
+      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr )
       - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
@@ -244,7 +244,7 @@
       that:
       - eip is defined
       - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.netcommon.ipaddr )
+      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
@@ -260,7 +260,7 @@
       that:
       - no_tagged_eip is defined
       - no_tagged_eip is changed
-      - no_tagged_eip.public_ip is defined and ( no_tagged_eip.public_ip | ansible.netcommon.ipaddr )
+      - no_tagged_eip.public_ip is defined and ( no_tagged_eip.public_ip | ansible.utils.ipaddr )
       - no_tagged_eip.allocation_id is defined and no_tagged_eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 2  == ( eip_info.addresses | length )
 
@@ -283,7 +283,7 @@
       that:
       - reallocate_eip is defined
       - reallocate_eip is not changed
-      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.netcommon.ipaddr )
+      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr )
       - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 2  == ( eip_info.addresses | length )
 
@@ -300,7 +300,7 @@
       that:
       - backend_eip is defined
       - backend_eip is changed
-      - backend_eip.public_ip is defined and ( backend_eip.public_ip | ansible.netcommon.ipaddr )
+      - backend_eip.public_ip is defined and ( backend_eip.public_ip | ansible.utils.ipaddr )
       - backend_eip.allocation_id is defined and backend_eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 3  == ( eip_info.addresses | length )
 
@@ -378,7 +378,7 @@
       that:
       - eip is defined
       - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.netcommon.ipaddr )
+      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
@@ -413,7 +413,7 @@
       - eip_info.addresses[0].public_ip == eip.public_ip
       - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
       - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.netcommon.ipaddr )
+      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
       - eip_info.addresses[0].network_interface_owner_id == caller_info.account
 
   - name: Re-Attach EIP to ENI A (no change)
@@ -437,7 +437,7 @@
       - eip_info.addresses[0].public_ip == eip.public_ip
       - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
       - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.netcommon.ipaddr )
+      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
   - name: Attach EIP to ENI B (should fail, already associated)
     ec2_eip:
@@ -459,7 +459,7 @@
       - eip_info.addresses[0].public_ip == eip.public_ip
       - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
       - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.netcommon.ipaddr )
+      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
   - name: Attach EIP to ENI B
     ec2_eip:
@@ -483,7 +483,7 @@
       - eip_info.addresses[0].public_ip == eip.public_ip
       - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
       - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.netcommon.ipaddr )
+      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
   - name: Detach EIP from ENI B, without enabling release on disassociation
     ec2_eip:
@@ -667,7 +667,7 @@
       that:
       - eip is defined
       - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.netcommon.ipaddr )
+      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a maintenance task to migrate from ansible.netcommon to ansible.utils. I was trying to fix an issue in that module, but I was told the functions have moved to ansible.utils. See https://github.com/ansible-collections/ansible.netcommon/pull/362#issuecomment-1020049600

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Existing integration tests that use the ansible.netcommon module. No module uses netcommon, only integration tests.


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
