### PR TITLE
Format extends_documentation_fragment such that it's consistent across all modules

### DIFF
--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -160,9 +160,8 @@ options:
 author:
   - Matthew Davis (@matt-telstra) on behalf of Telstra Corporation Limited
 extends_documentation_fragment:
-  - amazon.aws.aws
-  - amazon.aws.ec2
-
+- amazon.aws.aws
+- amazon.aws.ec2
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_msk_cluster.py
+++ b/plugins/modules/aws_msk_cluster.py
@@ -207,8 +207,8 @@ options:
         default: true
         type: bool
 extends_documentation_fragment:
-    - amazon.aws.aws
-    - amazon.aws.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 notes:
     - All operations are time consuming, for example create takes 20-30 minutes,
       update kafka version -- more than one hour, update configuration -- 10-15 minutes;

--- a/plugins/modules/aws_msk_config.py
+++ b/plugins/modules/aws_msk_config.py
@@ -40,8 +40,8 @@ options:
         type: list
         elements: str
 extends_documentation_fragment:
-    - amazon.aws.aws
-    - amazon.aws.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/elasticache_subnet_group.py
+++ b/plugins/modules/elasticache_subnet_group.py
@@ -40,8 +40,8 @@ options:
 author:
   - "Tim Mahoney (@timmahoney)"
 extends_documentation_fragment:
-  - amazon.aws.aws
-  - amazon.aws.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/redshift.py
+++ b/plugins/modules/redshift.py
@@ -180,8 +180,8 @@ options:
     default: 'yes'
     version_added: "1.3.0"
 extends_documentation_fragment:
-  - amazon.aws.aws
-  - amazon.aws.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/wafv2_web_acl_info.py
+++ b/plugins/modules/wafv2_web_acl_info.py
@@ -28,9 +28,8 @@ options:
     type: str
 
 extends_documentation_fragment:
-  - amazon.aws.aws
-  - amazon.aws.ec2
-
+- amazon.aws.aws
+- amazon.aws.ec2
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Format `extends_documentation_fragment` such that it's consistent across all modules. I'm still getting ansible-doc failures in PRs. Even if the job is non-voting, it's still causing confusion because e-mail notifications indicate CI failures.

```yaml
extends_documentation_fragment:
- amazon.aws.aws
- amazon.aws.ec2
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
