### PR TITLE
Fix unit tests which broke due to things being moved about in amazon.aws

### DIFF
--- a/tests/unit/plugins/modules/test_aws_api_gateway.py
+++ b/tests/unit/plugins/modules/test_aws_api_gateway.py
@@ -11,8 +11,8 @@ __metaclass__ = type
 import sys
 import pytest
 
-from ansible_collections.amazon.aws.plugins.module_utils import core
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils import modules as aws_modules
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
 from ansible_collections.community.aws.tests.unit.plugins.modules.utils import set_module_args
 
 import ansible_collections.community.aws.plugins.modules.aws_api_gateway as agw
@@ -41,8 +41,10 @@ def test_upload_api(monkeypatch):
     def return_fake_connection(*args, **kwargs):
         return FakeConnection()
 
-    monkeypatch.setattr(core, "boto3_conn", return_fake_connection)
-    monkeypatch.setattr(core.AnsibleAWSModule, "exit_json", fake_exit_json)
+    # Because it's imported into the aws_modules namespace we need to override
+    # it there, even though the function itself lives in module_utils.botocore
+    monkeypatch.setattr(aws_modules, "boto3_conn", return_fake_connection)
+    monkeypatch.setattr(aws_modules.AnsibleAWSModule, "exit_json", fake_exit_json)
 
     set_module_args({
         "api_id": "fred",

--- a/tests/unit/plugins/modules/test_ec2_vpc_vpn.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_vpn.py
@@ -11,8 +11,8 @@ import pytest
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep  # pylint: disable=unused-import
 
-import ansible_collections.amazon.aws.plugins.module_utils.core as aws_core
-import ansible_collections.amazon.aws.plugins.module_utils.ec2 as aws_ec2
+import ansible_collections.amazon.aws.plugins.module_utils.modules as aws_modules
+import ansible_collections.amazon.aws.plugins.module_utils.retries as aws_retries
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
@@ -82,8 +82,8 @@ def get_dependencies():
 
 def setup_mod_conn(placeboify, params):
     conn = placeboify.client('ec2')
-    retry_decorator = aws_ec2.AWSRetry.jittered_backoff()
-    wrapped_conn = aws_core._RetryingBotoClientWrapper(conn, retry_decorator)
+    retry_decorator = aws_retries.AWSRetry.jittered_backoff()
+    wrapped_conn = aws_modules._RetryingBotoClientWrapper(conn, retry_decorator)
     m = FakeModule(**params)
     return m, wrapped_conn
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1324

##### SUMMARY

https://github.com/ansible-collections/amazon.aws/pull/649 moved a few things around, including a "private" wrapper class.

The shuffles broke part of the monkey patching in some unit tests, and the private wrapper class wasn't made available in the old location (it's private, using it might result in things breaking)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/unit/plugins/modules/test_aws_api_gateway.py
tests/unit/plugins/modules/test_ec2_vpc_vpn.py

##### ADDITIONAL INFORMATION

CC @marknet15 