### PR TITLE
ec2_launch_template: implement missing metadata options

### DIFF
--- a/changelogs/fragments/917-add-launch-template-metadata-parameters.yml
+++ b/changelogs/fragments/917-add-launch-template-metadata-parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_launch_tempalte - Add metadata options parameter ``http_protocol_ipv6`` and ``instance_metadata_tags`` (https://github.com/ansible-collections/community.aws/pull/917).

--- a/changelogs/fragments/917-add-launch-template-metadata-parameters.yml
+++ b/changelogs/fragments/917-add-launch-template-metadata-parameters.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- ec2_launch_tempalte - Add metadata options parameter ``http_protocol_ipv6`` and ``instance_metadata_tags`` (https://github.com/ansible-collections/community.aws/pull/917).
+- ec2_launch_template - Add metadata options parameter ``http_protocol_ipv6`` and ``instance_metadata_tags`` (https://github.com/ansible-collections/community.aws/pull/917).

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -535,15 +535,19 @@ def create_or_update(module, template_options):
 
     if lt_data.get('MetadataOptions'):
         if not module.boto3_at_least('1.20.30'):
-            # warning if enabled is requested, because disabled is the API default value.
+            # fail only if enabled is requested
             if lt_data['MetadataOptions'].get('InstanceMetadataTags') == 'enabled':
-                module.warn('Metadata option "instance_metadata_tags" is ignored, because it requires boto3 >= 1.20.30.')
+                module.require_boto3_at_least('1.20.30', reason='to set instance_metadata_tags')
+            # pop if it's not requested to keep backwards compatibility.
+            # otherwise the modules failes because parameters are set due default values
             lt_data['MetadataOptions'].pop('InstanceMetadataTags')
 
         if not module.boto3_at_least('1.18.29'):
-            # warning if enabled is requested, because disabled is the API default value.
+            # fail only if enabled is requested
             if lt_data['MetadataOptions'].get('HttpProtocolIpv6') == 'enabled':
-                module.warn('Metadata option "http_protocol_ipv6" is ignored, because it requires boto3 >= 1.18.29.')
+                module.require_boto3_at_least('1.18.29', reason='to set http_protocol_ipv6')
+            # pop if it's not requested to keep backwards compatibility.
+            # otherwise the modules failes because parameters are set due default values
             lt_data['MetadataOptions'].pop('HttpProtocolIpv6')
 
     if not (template or template_versions):

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -526,6 +526,9 @@ def delete_template(module):
 
 
 def create_or_update(module, template_options):
+    if not module.boto3_at_least('1.20.46'):
+        template_options['metadata_options']['options'].pop('instance_metadata_tags')
+
     ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff(catch_extra_error_codes=['InvalidLaunchTemplateId.NotFound']))
     template, template_versions = existing_templates(module)
     out = {}

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -535,8 +535,15 @@ def create_or_update(module, template_options):
 
     if lt_data.get('MetadataOptions'):
         if not module.boto3_at_least('1.20.30'):
+            # warning if enabled is requested, because disabled is the API default value.
+            if lt_data['MetadataOptions'].get('InstanceMetadataTags') == 'enabled':
+                module.warn('Metadata option "instance_metadata_tags" is ignored, because it requires boto3 >= 1.20.30.')
             lt_data['MetadataOptions'].pop('InstanceMetadataTags')
+
         if not module.boto3_at_least('1.18.29'):
+            # warning if enabled is requested, because disabled is the API default value.
+            if lt_data['MetadataOptions'].get('HttpProtocolIpv6') == 'enabled':
+                module.warn('Metadata option "http_protocol_ipv6" is ignored, because it requires boto3 >= 1.18.29.')
             lt_data['MetadataOptions'].pop('HttpProtocolIpv6')
 
     if not (template or template_versions):

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -533,10 +533,11 @@ def create_or_update(module, template_options):
     lt_data = params_to_launch_data(module, dict((k, v) for k, v in module.params.items() if k in template_options))
     lt_data = scrub_none_parameters(lt_data, descend_into_lists=True)
 
-    if not module.boto3_at_least('1.20.30'):
-        lt_data['MetadataOptions'].pop('InstanceMetadataTags')
-    if not module.boto3_at_least('1.18.29'):
-        lt_data['MetadataOptions'].pop('HttpProtocolIpv6')
+    if lt_data.get('MetadataOptions'):
+        if not module.boto3_at_least('1.20.30'):
+            lt_data['MetadataOptions'].pop('InstanceMetadataTags')
+        if not module.boto3_at_least('1.18.29'):
+            lt_data['MetadataOptions'].pop('HttpProtocolIpv6')
 
     if not (template or template_versions):
         # create a full new one

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -353,6 +353,21 @@ options:
           The state of token usage for your instance metadata requests.
         choices: [optional, required]
         default: 'optional'
+      http_protocol_ipv6:
+        version_added: 3.1.0
+        type: str
+        description: >
+          - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
+        choices: [enabled, disabled]
+        default: 'disabled'
+      instance_metadata_tags:
+        version_added: 3.1.0
+        type: str
+        description:
+          - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
+          - Requires boto3 >= 1.20.46
+        choices: [enabled, disabled]
+        default: 'disabled'
 '''
 
 EXAMPLES = '''
@@ -671,7 +686,9 @@ def main():
             options=dict(
                 http_endpoint=dict(choices=['enabled', 'disabled'], default='enabled'),
                 http_put_response_hop_limit=dict(type='int', default=1),
-                http_tokens=dict(choices=['optional', 'required'], default='optional')
+                http_tokens=dict(choices=['optional', 'required'], default='optional'),
+                http_protocol_ipv6=dict(choices=['disabled', 'enabled'], default='disabled'),
+                instance_metadata_tags=dict(choices=['disabled', 'enabled'], default='disabled'),
             )
         ),
         network_interfaces=dict(

--- a/tests/integration/targets/ec2_launch_template/meta/main.yml
+++ b/tests/integration/targets/ec2_launch_template/meta/main.yml
@@ -2,3 +2,6 @@ dependencies:
   - prepare_tests
   - setup_ec2
   - setup_remote_tmp_dir
+  - role: setup_botocore_pip
+    vars:
+      boto3_version: "1.20.30"

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -12,7 +12,7 @@
         state: present
       register: metadata_options_launch_template
       ignore_errors: yes
-    - name: instance with metadata_options created with the right options
+    - name: verify fail with usefull error message
       assert:
         that:
           - metadata_options_launch_template.failed

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -17,7 +17,7 @@
           - metadata_options_launch_template is changed
           - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
           - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
-          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_protocol_ipv6 == 'enabled'"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_protocol_ipv6 is not defined"
           - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.instance_metadata_tags is not defined"
   always:
     - name: delete the template
@@ -40,7 +40,7 @@
         virtualenv_interpreter: "{{ virtualenv }}/bin/python"
     - pip:
         name:
-          - 'boto3>=1.20.46'
+          - 'boto3>=1.20.30'
         virtualenv: '{{ virtualenv }}'
         virtualenv_command: '{{ virtualenv_command }}'
         virtualenv_site_packages: no

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -30,48 +30,33 @@
       ignore_errors: true
 
 - name: test with boto3 version that supports instance_metadata_tags
+  vars:
+    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   block:
-    - pip:
-        name: virtualenv
-    - set_fact:
-        virtualenv: "{{ remote_tmp_dir }}/virtualenv"
-        virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
-    - set_fact:
-        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
-    - pip:
-        name:
-          - 'boto3>=1.20.30'
-        virtualenv: '{{ virtualenv }}'
-        virtualenv_command: '{{ virtualenv_command }}'
-        virtualenv_site_packages: no
-    - name: Wrap test in virtualenv
-      vars:
-        ansible_python_interpreter: "{{ virtualenv }}/bin/python"
-      block:
-        - name: metadata_options
-          ec2_launch_template:
-            name: "{{ resource_prefix }}-test-metadata"
-            metadata_options:
-              http_put_response_hop_limit: 1
-              http_tokens: required
-              http_protocol_ipv6: enabled
-              instance_metadata_tags: enabled
-            state: present
-          register: metadata_options_launch_template
-        - name: instance with metadata_options created with the right options
-          assert:
-            that:
-              - metadata_options_launch_template is changed
-              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
-              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
-              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_protocol_ipv6 == 'enabled'"
-              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.instance_metadata_tags == 'enabled'"
-      always:
-        - name: delete the template
-          ec2_launch_template:
-            name: "{{ resource_prefix }}-test-metadata"
-            state: absent
-          register: del_lt
-          retries: 10
-          until: del_lt is not failed
-          ignore_errors: true
+    - name: metadata_options
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-metadata"
+        metadata_options:
+          http_put_response_hop_limit: 1
+          http_tokens: required
+          http_protocol_ipv6: enabled
+          instance_metadata_tags: enabled
+        state: present
+      register: metadata_options_launch_template
+    - name: instance with metadata_options created with the right options
+      assert:
+        that:
+          - metadata_options_launch_template is changed
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_protocol_ipv6 == 'enabled'"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.instance_metadata_tags == 'enabled'"
+  always:
+    - name: delete the template
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-metadata"
+        state: absent
+      register: del_lt
+      retries: 10
+      until: del_lt is not failed
+      ignore_errors: true

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -1,5 +1,35 @@
 ---
-- name: Test community.aws.aws_s3_bucket_info
+- name: test with older boto3 version that does not support instance_metadata_tags
+  block:
+    - name: metadata_options
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-metadata"
+        metadata_options:
+          http_put_response_hop_limit: 1
+          http_tokens: required
+          http_protocol_ipv6: enabled
+          instance_metadata_tags: enabled
+        state: present
+      register: metadata_options_launch_template
+    - name: instance with metadata_options created with the right options
+      assert:
+        that:
+          - metadata_options_launch_template is changed
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_protocol_ipv6 == 'enabled'"
+          - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.instance_metadata_tags is not defined"
+  always:
+    - name: delete the template
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-metadata"
+        state: absent
+      register: del_lt
+      retries: 10
+      until: del_lt is not failed
+      ignore_errors: true
+
+- name: test with boto3 version that supports instance_metadata_tags
   block:
     - pip:
         name: virtualenv

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -1,7 +1,7 @@
 ---
 - name: test with older boto3 version that does not support instance_metadata_tags
   block:
-    - name: metadata_options
+    - name: fail metadata_options
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-metadata"
         metadata_options:
@@ -9,6 +9,22 @@
           http_tokens: required
           http_protocol_ipv6: enabled
           instance_metadata_tags: enabled
+        state: present
+      register: metadata_options_launch_template
+      ignore_errors: yes
+    - name: instance with metadata_options created with the right options
+      assert:
+        that:
+          - metadata_options_launch_template.failed
+          - metadata_options_launch_template is not changed
+          - "'This is required to set instance_metadata_tags' in metadata_options_launch_template.msg"
+
+    - name: success metadata_options
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-test-metadata"
+        metadata_options:
+          http_put_response_hop_limit: 1
+          http_tokens: required
         state: present
       register: metadata_options_launch_template
     - name: instance with metadata_options created with the right options

--- a/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/instance-metadata.yml
@@ -1,24 +1,47 @@
-- block:
-  - name: metadata_options
-    ec2_launch_template:
-      name: "{{ resource_prefix }}-test-metadata"
-      metadata_options:
-        http_put_response_hop_limit: 1
-        http_tokens: required
-      state: present
-    register: metadata_options_launch_template
-  - name: instance with metadata_options created with the right options
-    assert:
-      that:
-        - metadata_options_launch_template is changed
-        - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
-        - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
-  always:
-  - name: delete the template
-    ec2_launch_template:
-      name: "{{ resource_prefix }}-test-metadata"
-      state: absent
-    register: del_lt
-    retries: 10
-    until: del_lt is not failed
-    ignore_errors: true
+---
+- name: Test community.aws.aws_s3_bucket_info
+  block:
+    - pip:
+        name: virtualenv
+    - set_fact:
+        virtualenv: "{{ remote_tmp_dir }}/virtualenv"
+        virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
+    - set_fact:
+        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
+    - pip:
+        name:
+          - 'boto3>=1.20.46'
+        virtualenv: '{{ virtualenv }}'
+        virtualenv_command: '{{ virtualenv_command }}'
+        virtualenv_site_packages: no
+    - name: Wrap test in virtualenv
+      vars:
+        ansible_python_interpreter: "{{ virtualenv }}/bin/python"
+      block:
+        - name: metadata_options
+          ec2_launch_template:
+            name: "{{ resource_prefix }}-test-metadata"
+            metadata_options:
+              http_put_response_hop_limit: 1
+              http_tokens: required
+              http_protocol_ipv6: enabled
+              instance_metadata_tags: enabled
+            state: present
+          register: metadata_options_launch_template
+        - name: instance with metadata_options created with the right options
+          assert:
+            that:
+              - metadata_options_launch_template is changed
+              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_put_response_hop_limit == 1"
+              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_tokens == 'required'"
+              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.http_protocol_ipv6 == 'enabled'"
+              - "metadata_options_launch_template.latest_template.launch_template_data.metadata_options.instance_metadata_tags == 'enabled'"
+      always:
+        - name: delete the template
+          ec2_launch_template:
+            name: "{{ resource_prefix }}-test-metadata"
+            state: absent
+          register: del_lt
+          retries: 10
+          until: del_lt is not failed
+          ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
Add missing metadata options
* `instance_metadata_tags`
* `http_protocol_ipv6`

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ec2_launch_template
