### PR TITLE
Always return lists in cloudfront_info where it returns a list already…

### DIFF
--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -327,7 +327,9 @@ class CloudFrontServiceManager:
 
             if len(origin_access_identity_list['Items']) > 0:
                 return origin_access_identity_list['Items']
-            return {}
+            else:
+                return []
+
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error listing cloud front origin access identities")
 
@@ -339,7 +341,7 @@ class CloudFrontServiceManager:
             if len(distribution_list['Items']) > 0:
                 distribution_list = distribution_list['Items']
             else:
-                return {}
+                return []
 
             if not keyed:
                 return distribution_list
@@ -355,7 +357,8 @@ class CloudFrontServiceManager:
             if len(distribution_list['Items']) > 0:
                 distribution_list = distribution_list['Items']
             else:
-                return {}
+                return []
+
             return self.keyed_list_helper(distribution_list)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error listing distributions by web acl id")
@@ -367,7 +370,9 @@ class CloudFrontServiceManager:
 
             if len(invalidation_list['Items']) > 0:
                 return invalidation_list['Items']
-            return {}
+            else:
+                return []
+
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error listing invalidations")
 
@@ -379,7 +384,7 @@ class CloudFrontServiceManager:
             if len(streaming_distribution_list['Items']) > 0:
                 streaming_distribution_list = streaming_distribution_list['Items']
             else:
-                return {}
+                return []
 
             if not keyed:
                 return streaming_distribution_list

--- a/plugins/modules/cloudfront_info.py
+++ b/plugins/modules/cloudfront_info.py
@@ -325,10 +325,7 @@ class CloudFrontServiceManager:
             results = self._paginated_result('list_cloud_front_origin_access_identities')
             origin_access_identity_list = results.get('CloudFrontOriginAccessIdentityList', {'Items': []})
 
-            if len(origin_access_identity_list['Items']) > 0:
-                return origin_access_identity_list['Items']
-            else:
-                return []
+            return origin_access_identity_list['Items']
 
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error listing cloud front origin access identities")

--- a/tests/integration/targets/cloudfront_distribution/aliases
+++ b/tests/integration/targets/cloudfront_distribution/aliases
@@ -2,3 +2,4 @@
 disabled
 
 cloud/aws
+cloudfront_info

--- a/tests/integration/targets/cloudfront_distribution/tasks/cloudfront_info.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/cloudfront_info.yml
@@ -1,0 +1,35 @@
+---
+
+block:
+  - name: Create a Cloudfront distribution for testing cloudfront_info module against
+    cloudfront_distribution:
+      origins:
+      - domain_name: "{{ cloudfront_hostname }}-origin.info.example.com"
+        id: "{{ cloudfront_hostname }}-origin.info.example.com"
+      default_cache_behavior:
+        target_origin_id: "{{ cloudfront_hostname }}-origin.info.example.com"
+      state: present
+      wait: yes
+      purge_origins: yes
+    register: cloudfront_test_distribution
+
+  - name: Use cloudfront_info module to retrieve CF distribution details
+    cloudfront_info:
+      distribution: true
+      distribution_id: "{{ cloudfront_test_distribution.id }}"
+    register: cloudfront_info_results
+
+  - name: Ensure cloudfront_info returned results
+    assert:
+      that:
+        - cloudfront_info_results.result is defined
+        - cloudfront_info_results.distribution is defined
+        - cloudfront_info_results.result.id == cloudfront_test_distribution.id
+
+always:
+
+  - name: clean up cloudfront distribution
+    cloudfront_distribution:
+      distribution_id: "{{ cloudfront_test_distribution.id }}"
+      enabled: no
+      state: absent

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -501,3 +501,5 @@
       enabled: no
       wait: yes
       state: absent
+
+- include: ./cloudfront_info.yml


### PR DESCRIPTION
…when length is > 0. So it should also return same type in other case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_info.py

##### ADDITIONAL INFORMATION
Fixes problems when running against empty lists. Check this old PR for reference https://github.com/ansible-collections/community.aws/pull/293
