### PR TITLE
rename cloudwatchevent_rule module to eventbridge_rule

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -52,7 +52,6 @@ action_groups:
   - cloudfront_invalidation
   - cloudfront_origin_access_identity
   - cloudtrail
-  - cloudwatchevent_rule
   - cloudwatchlogs_log_group
   - cloudwatchlogs_log_group_info
   - cloudwatchlogs_log_group_metric_filter
@@ -123,6 +122,7 @@ action_groups:
   - elb_target_group
   - elb_target_group_info
   - elb_target_info
+  - eventbridge_rule
   - execute_lambda
   - iam_access_key
   - iam_access_key_info

--- a/plugins/modules/eventbridge_rule.py
+++ b/plugins/modules/eventbridge_rule.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: cloudwatchevent_rule
+module: eventbridge_rule
 version_added: 1.0.0
 short_description: Manage CloudWatch Event rules and targets
 description:
@@ -105,7 +105,7 @@ options:
 '''
 
 EXAMPLES = r'''
-- community.aws.cloudwatchevent_rule:
+- community.aws.eventbridge_rule:
     name: MyCronTask
     schedule_expression: "cron(0 20 * * ? *)"
     description: Run my scheduled task
@@ -113,7 +113,7 @@ EXAMPLES = r'''
       - id: MyTargetId
         arn: arn:aws:lambda:us-east-1:123456789012:function:MyFunction
 
-- community.aws.cloudwatchevent_rule:
+- community.aws.eventbridge_rule:
     name: MyDisabledCronTask
     schedule_expression: "rate(5 minutes)"
     description: Run my disabled scheduled task
@@ -123,7 +123,7 @@ EXAMPLES = r'''
         arn: arn:aws:lambda:us-east-1:123456789012:function:MyFunction
         input: '{"foo": "bar"}'
 
-- community.aws.cloudwatchevent_rule:
+- community.aws.eventbridge_rule:
     name: MyCronTask
     state: absent
 '''

--- a/plugins/modules/eventbridge_rule.py
+++ b/plugins/modules/eventbridge_rule.py
@@ -10,9 +10,9 @@ DOCUMENTATION = r'''
 ---
 module: eventbridge_rule
 version_added: 1.0.0
-short_description: Manage CloudWatch Event rules and targets
+short_description: Manage EventBridge Event rules and targets
 description:
-  - This module creates and manages CloudWatch event rules and targets.
+  - This module creates and manages EventBridge event rules and targets.
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -130,7 +130,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 rule:
-    description: CloudWatch Event rule data.
+    description: EventBridge Event rule data.
     returned: success
     type: dict
     sample:
@@ -140,7 +140,7 @@ rule:
       schedule_expression: 'cron(0 20 * * ? *)'
       state: 'ENABLED'
 targets:
-    description: CloudWatch Event target(s) assigned to the rule.
+    description: EventBridge Event target(s) assigned to the rule.
     returned: success
     type: list
     sample: "[{ 'arn': 'arn:aws:lambda:us-east-1:123456789012:function:MyFunction', 'id': 'MyTargetId' }]"
@@ -157,7 +157,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 
-class CloudWatchEventRule(object):
+class EventBridgeEventRule(object):
     def __init__(self, module, name, client, schedule_expression=None,
                  event_pattern=None, description=None, role_arn=None):
         self.name = name
@@ -303,7 +303,7 @@ class CloudWatchEventRule(object):
         return camel_dict_to_snake_dict(dict)
 
 
-class CloudWatchEventRuleManager(object):
+class EventBridgeEventRuleManager(object):
     RULE_FIELDS = ['name', 'event_pattern', 'schedule_expression', 'description', 'role_arn']
 
     def __init__(self, rule, targets):
@@ -428,14 +428,14 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
 
     rule_data = dict(
-        [(rf, module.params.get(rf)) for rf in CloudWatchEventRuleManager.RULE_FIELDS]
+        [(rf, module.params.get(rf)) for rf in EventBridgeEventRuleManager.RULE_FIELDS]
     )
     targets = module.params.get('targets')
     state = module.params.get('state')
     client = module.client('events')
 
-    cwe_rule = CloudWatchEventRule(module, client=client, **rule_data)
-    cwe_rule_manager = CloudWatchEventRuleManager(cwe_rule, targets)
+    cwe_rule = EventBridgeEventRule(module, client=client, **rule_data)
+    cwe_rule_manager = EventBridgeEventRuleManager(cwe_rule, targets)
 
     if state == 'present':
         cwe_rule_manager.ensure_present()


### PR DESCRIPTION
##### SUMMARY
I think the module handles EventBridge Rules and it is not related to CloudWatch 🤷🏼 

Ah, looks like there is some history [here](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html):
> Note
> EventBridge was formerly called Amazon CloudWatch Events. The default event bus and the rules you created in CloudWatch Events also display in the EventBridge console. EventBridge uses the same CloudWatch Events API, so your code that uses the CloudWatch Events API stays the same. New features added to EventBridge are not added to CloudWatch Events.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
 eventbridge_rule

##### ADDITIONAL INFORMATION
It is a simple change:
```
mv plugins/modules/cloudwatchevent_rule.py plugins/modules/eventbridge_rule.py
sed -i 's/cloudwatchevent_rule/eventbridge_rule/' plugins/modules/eventbridge_rule.py
sed -i 's/CloudWatch/EventBridge/' plugins/modules/eventbridge_rule.py
```

That's probably a breaking change that will impact lots of people so... feel free to decline the PR.