### PR TITLE
fix for ssm gather fact failure

### DIFF
--- a/changelogs/113-aws-ssm-fails-gather-facts
+++ b/changelogs/113-aws-ssm-fails-gather-facts
@@ -1,2 +1,0 @@
-bugfixes:
-  - aws_ssm - fix fact gather failues on Windows (https://github.com/ansible-collections/community.aws/issues/113)

--- a/changelogs/113-aws-ssm-fails-gather-facts
+++ b/changelogs/113-aws-ssm-fails-gather-facts
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - fix fact gather failues on Windows (https://github.com/ansible-collections/community.aws/issues/113)

--- a/changelogs/fragments/113-aws-ssm-fails-gather-facts.yml
+++ b/changelogs/fragments/113-aws-ssm-fails-gather-facts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - fix fact gather failures on Windows (https://github.com/ansible-collections/community.aws/issues/113).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -238,7 +238,7 @@ def _ssm_retry(func):
 
             try:
                 return_tuple = func(self, *args, **kwargs)
-                display.vvv(return_tuple, host=self.host)
+                display.vvvv(return_tuple, host=self.host)
                 break
 
             except (AnsibleConnectionFailure, Exception) as e:
@@ -386,7 +386,7 @@ class Connection(ConnectionBase):
 
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        display.vvv(u"EXEC {0}".format(to_text(cmd)), host=self.host)
+        display.vvvv(u"EXEC {0}".format(to_text(cmd)), host=self.host)
 
         session = self._session
 
@@ -407,7 +407,6 @@ class Connection(ConnectionBase):
 
         # Read stdout between the markers
         stdout = ''
-        win_line = ''
         begin = False
         stop_time = int(round(time.time())) + self.get_option('ssm_timeout')
         while session.poll() is None:
@@ -424,22 +423,26 @@ class Connection(ConnectionBase):
                 display.vvvv(u"EXEC remaining: {0}".format(remaining), host=self.host)
                 continue
 
-            if not begin and self.is_windows:
-                win_line = win_line + line
-                line = win_line
-
-            if mark_start in line:
+            stdout = stdout + line
+            if begin or mark_begin in stdout:
                 begin = True
-                if not line.startswith(mark_start):
-                    stdout = ''
-                continue
-            if begin:
-                if mark_end in line:
-                    display.vvvv(u"POST_PROCESS: {0}".format(to_text(stdout)), host=self.host)
-                    returncode, stdout = self._post_process(stdout, mark_begin)
-                    break
+                if mark_end in stdout:
+                    if "LASTEXITCODE" in stdout or "$?" in stdout:
+                        # This is windows and $LASTCODE was in line  or this is Linux and $? is in line
+                        # which means this is not the output of command, clear stdout and keep waiting for output
+                        stdout = ''
+                        continue
+                    else:
+                        # Line contains mark_start and ends with mark_end and has valid exitcode.  Send to post_process
+                        display.vvvv(u"POST_PROCESS: {0}".format(to_text(stdout)), host=self.host)
+                        (returncode, stdout) = self._post_process(stdout, mark_begin)
+                        break
                 else:
-                    stdout = stdout + line
+                    # mark_end not found, keep adding lines until it's found
+                    continue
+            else:
+                # Mark_begin not found, keep adding lines until it's found
+                continue
 
         stderr = self._flush_stderr(session)
 
@@ -542,7 +545,7 @@ class Connection(ConnectionBase):
         if self.is_windows:
             if not cmd.startswith(" ".join(_common_args) + " -EncodedCommand"):
                 cmd = self._shell._encode_script(cmd, preserve_rc=True)
-            cmd = cmd + "; echo " + mark_start + "\necho " + mark_end + "\n"
+            cmd = cmd + "; echo " + mark_start + "; echo " + mark_end + "\n"
         else:
             if sudoable:
                 cmd = "sudo " + cmd
@@ -558,31 +561,28 @@ class Connection(ConnectionBase):
     def _post_process(self, stdout, mark_begin):
         ''' extract command status and strip unwanted lines '''
 
-        if self.is_windows:
-            # Value of $LASTEXITCODE will be the line after the mark
-            trailer = stdout[stdout.rfind(mark_begin):]
-            last_exit_code = trailer.splitlines()[1]
-            if last_exit_code.isdigit:
-                returncode = int(last_exit_code)
-            else:
-                returncode = -1
-            # output to keep will be before the mark
-            stdout = stdout[:stdout.rfind(mark_begin)]
+        # Value of $LASTEXITCODE will be the line after the mark
+        trailer = stdout[stdout.rfind(mark_begin):]
+        last_exit_code = list(filter(None, trailer.splitlines()))[-2]  # Filter out empty lines and the 2nd one is the exit code
 
-            # If it looks like JSON remove any newlines
-            if stdout.startswith('{'):
-                stdout = stdout.replace('\n', '')
-
-            return (returncode, stdout)
+        if last_exit_code.isdigit():
+            returncode = int(last_exit_code)
         else:
-            # Get command return code
-            returncode = int(stdout.splitlines()[-2])
-
+            returncode = -1
+        # output to keep will be before the mark
+        if self.is_windows:
+            stdout = stdout[:stdout.rfind(mark_begin)]
+        else:
             # Throw away ending lines
             for x in range(0, 3):
                 stdout = stdout[:stdout.rfind('\n')]
 
-            return (returncode, stdout)
+        # If it looks like JSON remove any newlines
+        if stdout.startswith('{'):
+            stdout = stdout.replace('\n', '')
+            stdout = stdout.replace('\r', '')
+        display.vvvv(u"_post_process: stdout: {0}".format(to_text(stdout)), host=self.host)
+        return (returncode, stdout)
 
     def _filter_ansi(self, line):
         ''' remove any ANSI terminal control codes '''
@@ -612,7 +612,7 @@ class Connection(ConnectionBase):
             if poll_stderr.poll(1):
                 line = subprocess.stderr.readline()
                 display.vvvv(u"stderr line: {0}".format(to_text(line)), host=self.host)
-                stderr = stderr + line
+                stderr = stderr + str(line.decode())
             else:
                 break
 
@@ -630,6 +630,7 @@ class Connection(ConnectionBase):
 
         client = self._get_boto_client('s3', region_name=bucket_region_name, profile_name=profile_name)
         params = {'Bucket': bucket_name, 'Key': out_path}
+
         if extra_args is not None:
             params.update(extra_args)
         return client.generate_presigned_url(client_method, Params=params, ExpiresIn=3600, HttpMethod=http_method)
@@ -727,7 +728,7 @@ class Connection(ConnectionBase):
 
         super(Connection, self).put_file(in_path, out_path)
 
-        display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self.host)
+        display.vvvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self.host)
         if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_native(in_path)))
 
@@ -738,7 +739,7 @@ class Connection(ConnectionBase):
 
         super(Connection, self).fetch_file(in_path, out_path)
 
-        display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
+        display.vvvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
         return self._file_transport_command(in_path, out_path, 'get')
 
     def close(self):

--- a/tests/integration/targets/connection_aws_ssm_windows/aliases
+++ b/tests/integration/targets/connection_aws_ssm_windows/aliases
@@ -1,5 +1,4 @@
 time=10m
 
-unstable
 cloud/aws
 connection_aws_ssm


### PR DESCRIPTION
Depends-On:  https://github.com/ansible/ansible-zuul-jobs/pull/1743

SUMMARY
Fixes https://github.com/ansible-collections/community.aws/issues/113

Replaces #583 since it was so far behind.

aws_ssm fails when gathering facts. This fix incorporates some code submitted by others, but also works on windows which others haven't done yet.

ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
aws_ssm

ADDITIONAL INFORMATION
Fixes aws_ssm connection plugin when gathering facts. Uses code a few others submitted but also fixes windows.
Changed logic in the exec_command, wrap_command, and post_process functions that help to unify the output from windows and linux to make it easier to locate return values of the commands.

We have been running this in our environment for over a year and it is working without issue against win2016, win2019, centos7, suse15, and rhel7 ec2 instances.