### PR TITLE
[4.0.0] Bump minimum botocore version to 1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 3.0.0 of this collection supports `boto3 >= 1.16.0` and `botocore >= 1.19.0`
+Version 4.0.0 of this collection supports `boto3 >= 1.17.0` and `botocore >= 1.20.0`
 
 ## Included content
 <!--start collection content-->

--- a/changelogs/fragments/release-4--botocore.yml
+++ b/changelogs/fragments/release-4--botocore.yml
@@ -1,0 +1,7 @@
+major_changes:
+- community.aws collection - The amazon.aws collection has dropped support for
+  ``botocore<1.20.0`` and ``boto3<1.17.0``. Most modules will continue to work
+  with older versions of the AWS SDK, however compatability with older versions
+  of the SDK is not guaranteed and will not be tested. When using older versions
+  of the SDK a warning will be emitted by Ansible
+  (https://github.com/ansible-collections/community.aws/pull/956).

--- a/plugins/modules/aws_msk_cluster.py
+++ b/plugins/modules/aws_msk_cluster.py
@@ -50,7 +50,6 @@ options:
     instance_type:
         description:
             - The type of Amazon EC2 instances to use for Kafka brokers.
-            - Update operation requires botocore version >= 1.19.58.
         choices:
             - kafka.t3.small
             - kafka.m5.large
@@ -520,7 +519,6 @@ def create_or_update_cluster(client, module):
                 }
             },
             "broker_type": {
-                "botocore_version": "1.19.58",
                 "current_value": cluster["BrokerNodeGroupInfo"]["InstanceType"],
                 "target_value": module.params.get("instance_type"),
                 "update_params": {

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -358,7 +358,7 @@ options:
         type: str
         description: >
           - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
-          - Requires boto3 >= 1.18.29
+          - Requires botocore >= 1.21.29
         choices: [enabled, disabled]
         default: 'disabled'
       instance_metadata_tags:
@@ -366,7 +366,7 @@ options:
         type: str
         description:
           - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
-          - Requires boto3 >= 1.20.30
+          - Requires botocore >= 1.23.30
         choices: [enabled, disabled]
         default: 'disabled'
 '''
@@ -534,18 +534,18 @@ def create_or_update(module, template_options):
     lt_data = scrub_none_parameters(lt_data, descend_into_lists=True)
 
     if lt_data.get('MetadataOptions'):
-        if not module.boto3_at_least('1.20.30'):
+        if not module.botocore_at_least('1.23.30'):
             # fail only if enabled is requested
             if lt_data['MetadataOptions'].get('InstanceMetadataTags') == 'enabled':
-                module.require_boto3_at_least('1.20.30', reason='to set instance_metadata_tags')
+                module.require_botocore_at_least('1.23.30', reason='to set instance_metadata_tags')
             # pop if it's not requested to keep backwards compatibility.
             # otherwise the modules failes because parameters are set due default values
             lt_data['MetadataOptions'].pop('InstanceMetadataTags')
 
-        if not module.boto3_at_least('1.18.29'):
+        if not module.botocore_at_least('1.21.29'):
             # fail only if enabled is requested
             if lt_data['MetadataOptions'].get('HttpProtocolIpv6') == 'enabled':
-                module.require_boto3_at_least('1.18.29', reason='to set http_protocol_ipv6')
+                module.require_botocore_at_least('1.21.29', reason='to set http_protocol_ipv6')
             # pop if it's not requested to keep backwards compatibility.
             # otherwise the modules failes because parameters are set due default values
             lt_data['MetadataOptions'].pop('HttpProtocolIpv6')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.19.0
-boto3>=1.16.0
+botocore>=1.20.0
+boto3>=1.17.0

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.16.0
-botocore==1.19.0
+boto3==1.17.0
+botocore==1.20.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.18.160
+awscli==1.19.0

--- a/tests/integration/targets/setup_botocore_pip/defaults/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/defaults/main.yml
@@ -1,2 +1,2 @@
-default_botocore_version: '1.19.0'
-default_boto3_version: '1.16.0'
+default_botocore_version: '1.20.0'
+default_boto3_version: '1.17.0'

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.16.0
-botocore==1.19.0
+boto3==1.17.0
+botocore==1.20.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.18.160
+awscli==1.19.0


### PR DESCRIPTION
##### SUMMARY

With the next major version we can bump botocore/boto3 again.  Since 1.20.0 is now over a year old, we can bump the minimum version in preparation for 4.0.0.  CI should still test backports against the relevant versions for the backported release.

1.20.0 was released 2021-02-02.
1.21.0 was released 2021-07-15, hopefully we'll release 4.0.0 before July.

Should we release after mid-July we can always bump again.

( Follow up to https://github.com/ansible-collections/amazon.aws/pull/692 )

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

requirements.txt

##### ADDITIONAL INFORMATION

```
botocore] $ git show 1.20.0
tag 1.20.0
Tagger: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:44 2021 +0000

Tagging 1.20.0 release.

commit b7d27dc39aea82e22e2c11443fbd02a4904367cd (tag: 1.20.0)
Merge: cc497a593 27ebea65f
Author: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:44 2021 +0000

    Merge branch 'release-1.20.0'
    
    * release-1.20.0:
      Bumping version to 1.20.0
      Update to latest models
      Add changelog for custom endpoints and ARN resources
      Allow custom endpoints when addressing ARN resources
      Add changes for Python 3.4/3.5 removal
      Fall back to Transfer-Encoding 'chunked' if AWSRequest body is not seekable stream
```

```
boto3] $ git show 1.17.0
tag 1.17.0
Tagger: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:35 2021 +0000

Tagging 1.17.0 release.

commit 1a35ed1ab41f967ea43420650075f2693cbbe08b (tag: 1.17.0)
Merge: d77d24f9 35454bc5
Author: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:35 2021 +0000

    Merge branch 'release-1.17.0'
    
    * release-1.17.0:
      Bumping version to 1.17.0
      Add changelog entries from botocore
      Add S3 VPCE examples
      Add changes for Python 3.4/3.5 removal
```