### PR TITLE
Fix documentation about force_update_password in rds_instance module

### DIFF
--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -225,7 +225,7 @@ options:
     master_user_password:
         description:
           - An 8-41 character password for the master database user. The password can contain any printable ASCII character
-            except "/", """, or "@". To modify the password use I(force_password_update). Use I(apply immediately) to change
+            except "/", """, or "@". To modify the password use I(force_update_password). Use I(apply immediately) to change
             the password immediately, otherwise it is updated during the next maintenance window.
         aliases:
           - password


### PR DESCRIPTION
##### SUMMARY
Wrong name used in docs.

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
plugins/modules/rds_instance.py
