### PR TITLE
wafv2_web_acl: prevent exception when element is not a dict

### DIFF
--- a/changelogs/fragments/962-fix-waf-list-conditions.yml
+++ b/changelogs/fragments/962-fix-waf-list-conditions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - wafv2_web_acl - fix exception when a rule contains lists values (https://github.com/ansible-collections/community.aws/pull/962).

--- a/plugins/module_utils/wafv2.py
+++ b/plugins/module_utils/wafv2.py
@@ -46,6 +46,9 @@ def wafv2_list_rule_groups(wafv2, scope, fail_json_aws, nextmarker=None):
 
 
 def wafv2_snake_dict_to_camel_dict(a):
+    if not isinstance(a, dict):
+        return a
+    
     retval = {}
     for item in a.keys():
         if isinstance(a.get(item), dict):

--- a/plugins/module_utils/wafv2.py
+++ b/plugins/module_utils/wafv2.py
@@ -48,7 +48,7 @@ def wafv2_list_rule_groups(wafv2, scope, fail_json_aws, nextmarker=None):
 def wafv2_snake_dict_to_camel_dict(a):
     if not isinstance(a, dict):
         return a
-    
+
     retval = {}
     for item in a.keys():
         if isinstance(a.get(item), dict):

--- a/tests/integration/targets/wafv2/tasks/test_webacl.yml
+++ b/tests/integration/targets/wafv2/tasks/test_webacl.yml
@@ -227,4 +227,4 @@
 - name: verify geo match statement
   assert:
     that:
-      - out.rules[0].statement.geo_match_statement.country_codes[0] == 'RU'
+      - out.rules[0].statement.geo_match_statement.country_codes[0] == 'DE'

--- a/tests/integration/targets/wafv2/tasks/test_webacl.yml
+++ b/tests/integration/targets/wafv2/tasks/test_webacl.yml
@@ -183,3 +183,48 @@
   assert:
     that:
       - out is not changed
+
+- name: test geo match statement
+  wafv2_web_acl:
+    name: "{{ web_acl_name }}"
+    state: present
+    description: hallo eins drei
+    scope: REGIONAL
+    default_action: Allow
+    sampled_requests: no
+    cloudwatch_metrics: yes
+    metric_name: blub
+    purge_rules: yes
+    rules:
+      - name: block-germany
+        priority: 1
+        action:
+          block: {}
+        visibility_config:
+          sampled_requests_enabled: yes
+          cloud_watch_metrics_enabled: yes
+          metric_name: block-germany
+        statement:
+          geo_match_statement:
+            country_codes:
+                - DE
+    tags:
+      A: B
+      C: D
+  register: out
+
+- name: verify change
+  assert:
+    that:
+      - out is changed
+
+- name: re-read webacl
+  wafv2_web_acl_info:
+    name: "{{ web_acl_name }}"
+    scope: REGIONAL
+  register: out
+
+- name: verify geo match statement
+  assert:
+    that:
+      - out.rules[0].statement.geo_match_statement.country_codes[0] == 'RU'


### PR DESCRIPTION
##### SUMMARY

the `geo_match_statement` statement paremeter `country_codes` is a list and will fail the current implementation 

```
  File "/tmp/ansible_community.aws.wafv2_web_acl_payload_8xvwtxvw/ansible_community.aws.wafv2_web_acl_payload.zip/ansible_collections/community/aws/plugins/module_utils/wafv2.py", line 52, in wafv2_snake_dict_to_camel_dict
AttributeError: 'str' object has no attribute 'keys'
```


```yml
rules:
    - name: block-germany
      priority: 0
      action:
        block: {}
      visibility_config:
        sampled_requests_enabled: yes
        cloud_watch_metrics_enabled: yes
        metric_name: block-germany
      statement:
        geo_match_statement:
          country_codes:
             - DE
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
plugins/module_utils/wafv2.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
