### PR TITLE
redshift_info - fix invalid import path for botocore exceptions

### DIFF
--- a/changelogs/fragments/970-redshift_info-boto-import.yml
+++ b/changelogs/fragments/970-redshift_info-boto-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redshift_info - fix invalid import path for botocore exceptions (https://github.com/ansible-collections/community.aws/issues/968).

--- a/plugins/modules/redshift_info.py
+++ b/plugins/modules/redshift_info.py
@@ -277,7 +277,7 @@ iam_roles:
 import re
 
 try:
-    from botocore.exception import BotoCoreError, ClientError
+    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/979

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

 - Fix invalid import path for botocore exceptions
 - Fixes #968 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
redshift_info
