### PR TITLE
Add backoff logic to elb_application_lb_info

### DIFF
--- a/changelogs/fragments/977-add-backoff-logic-elb-info.yml
+++ b/changelogs/fragments/977-add-backoff-logic-elb-info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add backoff retry logic to elb_application_lb_info (https://github.com/ansible-collections/community.aws/pull/977)


### PR DESCRIPTION
##### SUMMARY
From time to time rate limiting failures occur on the usage of this module, this PR adds backoff logic to the module to improve its stability.
```
fatal: [127.0.0.1 -> 127.0.0.1]: FAILED! => changed=false 
boto3_version: 1.20.34
botocore_version: 1.23.34
error:
code: Throttling
message: Rate exceeded
type: Sender
msg: 'Failed to list load balancers: An error occurred (Throttling) when calling the DescribeLoadBalancers operation (reached max retries: 4): Rate exceeded'
response_metadata:
http_headers:
content-length: '271'
content-type: text/xml
date: Thu, 10 Mar 2022 10:34:23 GMT
x-amzn-requestid: xxxxx
http_status_code: 400
max_attempts_reached: true
request_id: xxxxx
retry_attempts: 4
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb_info

##### ADDITIONAL INFORMATION

