### PR TITLE
iam_role_info - Add new preserve_case option

### DIFF
--- a/docs/community.aws.iam_role_info_module.rst
+++ b/docs/community.aws.iam_role_info_module.rst
@@ -182,6 +182,21 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>preserve_case</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                  <div>Return AWS role(s) with their default case (PascalCase) instead of snake case.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>profile</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -271,6 +286,11 @@ Examples
 
     - name: find all existing IAM roles
       community.aws.iam_role_info:
+      register: result
+
+    - name: find all existing IAM roles and preserve casing
+      community.aws.iam_role_info:
+        preserve_case: true
       register: result
 
     - name: describe a single role
@@ -647,3 +667,4 @@ Authors
 ~~~~~~~
 
 - Will Thames (@willthames)
+- Razique Mahroua (@razique)

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: iam_role_info
-version_added: 1.0.1
+version_added: 1.1.0
 short_description: Gather information on IAM roles
 description:
     - Gathers information about IAM roles.

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -15,6 +15,7 @@ description:
     - Gathers information about IAM roles.
 author:
     - "Will Thames (@willthames)"
+    - "Razique Mahroua (@razique)"
 options:
     name:
         description:
@@ -32,6 +33,7 @@ options:
         description:
             - Return information about the role with default case (Pascal Case).
         type: bool
+        default: false
         required: false
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-botocore
+pip botocore
 boto3
 
 python-dateutil # Used by ec2_asg_scheduled_action

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pip botocore
+botocore
 boto3
 
 python-dateutil # Used by ec2_asg_scheduled_action

--- a/tests/integration/targets/iam_role/tasks/description_update.yml
+++ b/tests/integration/targets/iam_role/tasks/description_update.yml
@@ -122,3 +122,19 @@
       - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
       - role_info.iam_roles[0].role_name == test_role
       - role_info.iam_roles[0].tags | length == 0
+
+- name: "iam_role_info with preserve_case parameter"
+  iam_role_info:
+     name: "{{ test_role }}"
+     preserve_case: true
+  register: role_info
+
+- set_fact:
+    policy_document: '{{ lookup("file", "deny-assume.json") }}'
+
+- assert:
+    that:
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0]['AssumeRolePolicyDocument']
+      - role_info.iam_roles[0]['AssumeRolePolicyDocument'] == policy_document

--- a/tests/integration/targets/iam_role/tasks/main.yml
+++ b/tests/integration/targets/iam_role/tasks/main.yml
@@ -5,6 +5,7 @@
 # - Minimal Role creation
 # - Role deletion
 # - Fetching a specific role
+# - Fetching a specific role with original case
 # - Creating roles w/ and w/o instance profiles
 # - Creating roles w/ a path
 # - Updating Max Session Duration


### PR DESCRIPTION
##### SUMMARY
Add a new `preserve_case` option to the `iam_role_info` module per #551. Allows users to get valid data that the be reused "as is".

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
`iam_role_info`

##### ADDITIONAL INFORMATION
I have initially attempted to use the `camel_dict_to_snake_dict` method with its `ignore_list` option, however, this only ignore the values, not the keys. 
The `snact_dict_to_camel_dict` method seems to be broken, it fails with the following message (on both Python 3.8 and Python 3.9)
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: function missing required argument 'year' (pos 1)

fatal: [testhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 121, in 
<module>\n  File \"<stdin>\", line 113, in _ansiballz_main\n  File \"<stdin>\", line 61, in invoke_module\n  File \"/usr/lib/python3.8
/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File 
\"/usr/lib/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File 
\"/usr/lib/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_iam_role_info_payload_4milvilg/ansible_iam_role_info_payload.zip/ansible_collections/community/aws/plugins
/modules/iam_role_info.py\", line 269, in <module>\n  File \"/tmp/ansible_iam_role_info_payload_4milvilg/ansible_iam_role_info_payload.zip/ansible_collections/community/aws/plugins/modules/iam_role_info.py\", line 265, in
main\n  File \"/tmp/ansible_iam_role_info_payload_4milvilg/ansible_iam_role_info_payload.zip/ansible_collections/community/aws/plugins/modules/iam_role_info.py\", line 246, in describe_iam_roles\n  
File \"/tmp/ansible_iam_role_info_payload_4milvilg/ansible_iam_role_info_payload.zip/ansible_collections/community
/aws/plugins/modules/iam_role_info.py\", line 246, in <listcomp>\n  File \"/tmp/ansible_iam_role_info_payload_4milvilg
/ansible_iam_role_info_payload.zip/ansible/module_utils/common/dict_transformations.py\", line 76, in 
snake_dict_to_camel_dict\n  File \"/tmp/ansible_iam_role_info_payload_4milvilg/ansible_iam_role_info_payload.zip/ansible
/module_utils/common/dict_transformations.py\", line 68, in camelize\n  File \"/tmp/ansible_iam_role_info_payload_4milvilg
/ansible_iam_role_info_payload.zip/ansible/module_utils/common/dict_transformations.py\", line 65, in camelize\n

TypeError: function missing required argument 'year' (pos 1)\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

```
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
``` yaml
- name: find all existing IAM roles
  community.aws.iam_role_info:
  register: result
```

After
``` yaml
- name: find all existing IAM roles and preserve casing
  community.aws.iam_role_info:
    preserve_case: true
  register: result
```
