### PR TITLE
Various integration test fixes

### DIFF
--- a/tests/integration/targets/aws_secret/tasks/rotation.yml
+++ b/tests/integration/targets/aws_secret/tasks/rotation.yml
@@ -55,7 +55,7 @@
       name: "{{ lambda_name }}"
       state: present
       zip_file: "{{ tmp.path }}/hello_world.zip"
-      runtime: 'python2.7'
+      runtime: 'python3.9'
       role: "{{ iam_role_output.arn }}"
       handler: 'hello_world.lambda_handler'
     register: lambda_output
@@ -169,7 +169,7 @@
       name: "{{ lambda_name }}"
       state: absent
       zip_file: "{{ tmp.path }}/hello_world.zip"
-      runtime: 'python2.7'
+      runtime: 'python3.9'
       role: "{{ secret_manager_role }}"
       handler: 'hello_world.lambda_handler'
     ignore_errors: yes

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -125,7 +125,7 @@
   - name: test lambda config updates
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: nodejs10.x
+      runtime: nodejs14.x
       tracing_mode: Active
       handler: mini_lambda.handler
       role: '{{ lambda_role_name }}'
@@ -139,13 +139,13 @@
       that:
       - update_result is not failed
       - update_result.changed == True
-      - update_result.configuration.runtime == 'nodejs10.x'
+      - update_result.configuration.runtime == 'nodejs14.x'
       - update_result.configuration.tracing_config.mode == 'Active'
 
   - name: test no changes are made with the same parameters repeated
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: nodejs10.x
+      runtime: nodejs14.x
       tracing_mode: Active
       handler: mini_lambda.handler
       role: '{{ lambda_role_name }}'
@@ -159,7 +159,7 @@
       that:
       - update_result is not failed
       - update_result.changed == False
-      - update_result.configuration.runtime == 'nodejs10.x'
+      - update_result.configuration.runtime == 'nodejs14.x'
       - update_result.configuration.tracing_config.mode == 'Active'
 
   - name: reset config updates for the following tests

--- a/tests/integration/targets/lambda_alias/tasks/main.yml
+++ b/tests/integration/targets/lambda_alias/tasks/main.yml
@@ -37,7 +37,7 @@
   - name: Upload test lambda (version 1)
     lambda:
       name: '{{ lambda_function_name }}'
-      runtime: 'python2.7'
+      runtime: 'python3.7'
       handler: 'mini_lambda.handler'
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
@@ -50,7 +50,7 @@
   - name: Update lambda (version 2)
     lambda:
       name: '{{ lambda_function_name }}'
-      runtime: 'python3.6'
+      runtime: 'python3.8'
       handler: 'mini_lambda.handler'
       role: '{{ lambda_role_name }}'
     register: lambda_b
@@ -62,7 +62,7 @@
   - name: Update lambda (version 3 / LATEST)
     lambda:
       name: '{{ lambda_function_name }}'
-      runtime: 'python3.7'
+      runtime: 'python3.9'
       handler: 'mini_lambda.handler'
       role: '{{ lambda_role_name }}'
     register: lambda_c

--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -61,7 +61,7 @@
   - name: test state=present - upload the lambda
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: python2.7
+      runtime: python3.9
       handler: mini_http_lambda.handler
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'

--- a/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_tagging.yml
+++ b/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_tagging.yml
@@ -143,9 +143,9 @@
           - "result.snapshots.0.engine == 'mariadb'"
 
   always:
-    - name: remove snapshot
+    - name: remove final snapshot
       rds_instance_snapshot:
-        db_snapshot_identifier: "{{ tiny_prefix }}-test-snapshot"
+        db_snapshot_identifier: "{{ instance_id }}"
         state: absent
         wait: false
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket_notification/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket_notification/tasks/main.yml
@@ -85,6 +85,10 @@
       prefix: images/
       suffix: .jpg
     register: result
+    retries: 3
+    delay: 3
+    until:
+    - result is successful
   - name: assert result.changed == True
     assert:
       that:

--- a/tests/integration/targets/wafv2/aliases
+++ b/tests/integration/targets/wafv2/aliases
@@ -1,4 +1,6 @@
 cloud/aws
+# reason: Tests broken - https://github.com/ansible-collections/community.aws/issues/985
+disabled
 
 wafv2_resources
 wafv2_resources_info

--- a/tests/integration/targets/wafv2/defaults/main.yml
+++ b/tests/integration/targets/wafv2/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-web_acl_name: '{{ resource_prefix }}-web-acl'
-rule_group_name: '{{ resource_prefix }}-rule-group'
-alb_name: "my-alb-{{ resource_prefix | regex_search('([0-9]+)$') }}"
-tg_name: "my-tg-{{ resource_prefix | regex_search('([0-9]+)$') }}"
+web_acl_name: '{{ tiny_prefix }}-web-acl'
+rule_group_name: '{{ tiny_prefix }}-rule-group'
+alb_name: "my-alb-{{ tiny_prefix }}"
+tg_name: "my-tg-{{ tiny_prefix }}"
 cidr:
   main: 10.228.228.0/22
   a: 10.228.228.0/24


### PR DESCRIPTION
##### SUMMARY

- Updates the version of Python used by lambda in the `lambda_alias`, `lambda_policy` and `aws_secret` integration tests
- Updates the version of NodeJS used by the lambda in the `lamba` integration tests
- Adds a retry to the `s3_bucket_notification` tests, permissions are sometimes a little slow to update
- Cleans up Snapshots from `rds_instance` integration tests
- Disables broken WAFv2 integration test (#985)

Fixes: #976

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_secret
lambda
lambda_alias
lambda_policy
rds_policy
s3_bucket_notification
wafv2

##### ADDITIONAL INFORMATION

Amazon appear to have dropped support for creating Python2.7 lambdas:
```
botocore.errorfactory.InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: The runtime parameter of python2.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions.
```