### PR TITLE
Add AWSRetry.jittered_backoff to rds_instance_info

### DIFF
--- a/changelogs/fragments/1026-aws-retry-rds-instance-info.yml
+++ b/changelogs/fragments/1026-aws-retry-rds-instance-info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- rds_instance_info - add retries on common AWS failures (https://github.com/ansible-collections/community.aws/pull/1026).


### PR DESCRIPTION
##### SUMMARY

Add AWSRetry.jittered_backoff to the rds_instance_info module.

When calling `rds_instance_info` we have been seeing API rate limit errors from AWS. When calling this module, it usually runs to about 90-150 times in a minute before we get rate limited.

Using jittered_backoff should significantly decrease the number of times we see API rate limits here.

```
02:20:36 An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (Throttling) when calling the DescribeDBInstances operation (reached max retries: 4): Rate exceeded
02:20:36 fatal: [polaris -> localhost]: FAILED! => {"boto3_version": "1.20.22", "botocore_version": "1.23.22", "changed": false, "error": {"code": "Throttling", "message": "Rate exceeded", "type": "Sender"}, "msg": "Couldn't get instance information: An error occurred (Throttling) when calling the DescribeDBInstances operation (reached max retries: 4): Rate exceeded", "response_metadata": {"http_headers": {"connection": "close", "content-length": "254", "content-type": "text/xml", "date": "Tue, 15 Mar 2022 09:20:34 GMT", "x-amzn-requestid": "5de8131e-3f59-4b04-af25-5f7083ee09b9"}, "http_status_code": 400, "max_attempts_reached": true, "request_id": "5de8131e-3f59-4b04-af25-5f7083ee09b9", "retry_attempts": 4}}
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- rds_instance_info

##### ADDITIONAL INFORMATION
Decorated rds_instance_info with AWSRetry.jittered_backoff