### PR TITLE
networkfirewall_rule_group: Add support for "wait" parameter

### DIFF
--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -293,6 +293,8 @@ class BaseResourceManager(Boto3Mixin):
         """
         return self._merge_resource_changes(filter_immutable=False)
 
+    # If you override _flush_update you're responsible for handling check_mode
+    # If you override _do_update_resource you'll only be called if check_mode == False
     def _flush_create(self):
         changed = True
 
@@ -313,6 +315,9 @@ class BaseResourceManager(Boto3Mixin):
             return True
         return False
 
+    # If you override _flush_update you're responsible for handling check_mode
+    # If you override _do_update_resource you'll only be called if there are
+    # updated pending and check_mode == False
     def _flush_update(self):
         if not self._check_updates_pending():
             self.updated_resource = self.original_resource
@@ -337,7 +342,7 @@ class BaseResourceManager(Boto3Mixin):
     def _set_resource_value(self, key, value, description=None, immutable=False):
         if value is None:
             return False
-        if value == self._preupdate_resource.get(key, None):
+        if value == self._get_resource_value(key):
             return False
         if immutable and self.original_resource:
             if description is None:
@@ -347,6 +352,10 @@ class BaseResourceManager(Boto3Mixin):
         self._resource_updates[key] = value
         self.changed = True
         return True
+
+    def _get_resource_value(self, key, default=None):
+        default_value = self._preupdate_resource.get(key, default)
+        return self._resource_updates.get(key, default_value)
 
     def set_wait(self, wait):
         if wait is None:

--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -347,3 +347,21 @@ class BaseResourceManager(Boto3Mixin):
         self._resource_updates[key] = value
         self.changed = True
         return True
+
+    def set_wait(self, wait):
+        if wait is None:
+            return False
+        if wait == self._wait:
+            return False
+
+        self._wait = wait
+        return True
+
+    def set_wait_timeout(self, timeout):
+        if timeout is None:
+            return False
+        if timeout == self._wait_timeout:
+            return False
+
+        self._wait_timeout = timeout
+        return True

--- a/plugins/module_utils/networkfirewall.py
+++ b/plugins/module_utils/networkfirewall.py
@@ -246,7 +246,7 @@ class BaseNetworkFirewallManager(BaseResourceManager):
     def _set_metadata_value(self, key, value, description=None, immutable=False):
         if value is None:
             return False
-        if value == self._preupdate_metadata.get(key, None):
+        if value == self._get_metadata_value(key):
             return False
         if immutable and self.original_resource:
             if description is None:
@@ -256,6 +256,9 @@ class BaseNetworkFirewallManager(BaseResourceManager):
         self._metadata_updates[key] = value
         self.changed = True
         return True
+
+    def _get_metadata_value(self, key, default=None):
+        return self._metadata_updates.get(key, self._preupdate_metadata.get(key, default))
 
     def _do_tagging(self):
         changed = False
@@ -286,7 +289,7 @@ class BaseNetworkFirewallManager(BaseResourceManager):
 
         # Tags are returned as a part of the metadata, but have to be updated
         # via dedicated tagging methods
-        current_tags = boto3_tag_list_to_ansible_dict(self._preupdate_metadata.get('Tags', []))
+        current_tags = boto3_tag_list_to_ansible_dict(self._get_metadata_value('Tags', []))
 
         # So that diff works in check mode we need to know the full target state
         if purge_tags:
@@ -356,7 +359,7 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
         return metadata
 
     def _get_preupdate_arn(self):
-        return self._preupdate_metadata.get('RuleGroupArn')
+        return self._get_metadata_value('RuleGroupArn')
 
     def _get_id_params(self, name=None, rule_type=None, arn=None):
         if arn:
@@ -393,7 +396,7 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
         self.updated_resource = dict()
 
         # Rule Group is already in the process of being deleted (takes time)
-        rule_status = self._preupdate_metadata.get('RuleGroupStatus', '').upper()
+        rule_status = self._get_metadata_value('RuleGroupStatus', '').upper()
         if rule_status == 'DELETING':
             self._wait_for_deletion()
             return False
@@ -485,19 +488,16 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
         if value is None:
             return False
 
-        rule_options = deepcopy(self._preupdate_resource.get('StatefulRuleOptions', dict()))
+        rule_options = deepcopy(self._get_resource_value('StatefulRuleOptions', dict()))
         if value == rule_options.get(option_name, default_value):
             return False
         if immutable and self.original_resource:
             self.module.fail_json(msg='{0} can not be updated after creation'
                                   .format(description))
 
-        # The first time, we grab StatefulRuleOptions from the preupdate state (above),
-        # afterwards we grab it from _resource_updates
-        rule_option_updates = self._resource_updates.get('StatefulRuleOptions', rule_options)
-        rule_option_updates[option_name] = value
+        rule_options[option_name] = value
 
-        return self._set_resource_value('StatefulRuleOptions', rule_option_updates)
+        return self._set_resource_value('StatefulRuleOptions', rule_options)
 
     def set_rule_order(self, order):
         RULE_ORDER_MAP = {
@@ -515,20 +515,17 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
 
         variables = self._transform_rule_variables(variables)
 
-        all_variables = self._preupdate_resource.get('RuleVariables', self._empty_rule_variables())
-        current_variables = all_variables.get(set_name, dict())
+        all_variables = deepcopy(self._get_resource_value('RuleVariables', self._empty_rule_variables()))
 
+        current_variables = all_variables.get(set_name, dict())
         updated_variables = _merge_dict(current_variables, variables, purge)
 
         if current_variables == updated_variables:
             return False
 
-        # The first time we grab RuleVariables from preupdate stata (above),
-        # afterwards we grab it from _resource_updates
-        current_updates = deepcopy(self._resource_updates.get('RuleVariables', all_variables))
-        current_updates[set_name] = updated_variables
+        all_variables[set_name] = updated_variables
 
-        return self._set_resource_value('RuleVariables', current_updates)
+        return self._set_resource_value('RuleVariables', all_variables)
 
     def set_ip_variables(self, variables, purge):
         return self._set_rule_variables('IPSets', variables, purge)
@@ -540,20 +537,16 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
         if not rules:
             return False
         conflicting_types = self.RULE_TYPES.difference({rule_type})
-        original_source = self._preupdate_resource.get('RulesSource', dict())
-        pending_updates = self._resource_updates.get('RulesSource', dict())
-        current_keys = set(original_source.keys())
-        current_keys.union(pending_updates.keys())
+        rules_source = deepcopy(self._get_resource_value('RulesSource', dict()))
+        current_keys = set(rules_source.keys())
         conflicting_rule_type = conflicting_types.intersection(current_keys)
         if conflicting_rule_type:
             self.module.fail_json('Unable to add {0} rules, {1} rules already set'
                                   .format(rule_type, " and ".join(conflicting_rule_type)))
 
-        original_rules = original_source.get(rule_type)
+        original_rules = rules_source.get(rule_type, None)
         if rules == original_rules:
             return False
-
-        rules_source = dict()
         rules_source[rule_type] = rules
         return self._set_resource_value('RulesSource', rules_source)
 
@@ -667,7 +660,7 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
         if 'Capacity' not in self._metadata_updates:
             self.module.fail_json('Capacity must be provided when creating a new Rule Group')
 
-        rules_source = self._resource_updates.get('RulesSource')
+        rules_source = self._get_resource_value('RulesSource', dict())
         rule_type = self.RULE_TYPES.intersection(set(rules_source.keys()))
         if len(rule_type) != 1:
             self.module.fail_json('Exactly one of rule strings, domain list or rule list'

--- a/plugins/module_utils/networkfirewall.py
+++ b/plugins/module_utils/networkfirewall.py
@@ -262,7 +262,7 @@ class BaseNetworkFirewallManager(BaseResourceManager):
     def _get_metadata_value(self, key, default=None):
         return self._metadata_updates.get(key, self._preupdate_metadata.get(key, default))
 
-    def _do_tagging(self):
+    def _flush_tagging(self):
         changed = False
         tags_to_add = self._tagging_updates.get('add')
         tags_to_remove = self._tagging_updates.get('remove')
@@ -692,7 +692,7 @@ class NetworkFirewallRuleManager(NFRuleGroupBoto3Mixin, BaseNetworkFirewallManag
 
     def _flush_update(self):
         changed = False
-        changed |= self._do_tagging()
+        changed |= self._flush_tagging()
         changed |= super(NetworkFirewallRuleManager, self)._flush_update()
         return changed
 

--- a/plugins/module_utils/networkfirewall.py
+++ b/plugins/module_utils/networkfirewall.py
@@ -86,16 +86,18 @@ class NetworkFirewallWaiterFactory(BaseWaiterFactory):
         return data
 
 
-class NFRuleGroupBoto3Mixin(Boto3Mixin):
+class NetworkFirewallBoto3Mixin(Boto3Mixin):
     def __init__(self, module):
         r"""
         Parameters:
             module (AnsibleAWSModule): An Ansible module.
         """
         self.nf_waiter_factory = NetworkFirewallWaiterFactory(module)
-        super(NFRuleGroupBoto3Mixin, self).__init__(module)
+        super(NetworkFirewallBoto3Mixin, self).__init__(module)
         self._update_token = None
 
+
+class NFRuleGroupBoto3Mixin(NetworkFirewallBoto3Mixin):
     # Paginators can't be (easily) wrapped, so we wrap this method with the
     # retry - retries the full fetch, but better than simply giving up.
     @AWSRetry.jittered_backoff()
@@ -104,7 +106,7 @@ class NFRuleGroupBoto3Mixin(Boto3Mixin):
         result = paginator.paginate(**params).build_full_result()
         return result.get('RuleGroups', None)
 
-    @Boto3Mixin.aws_error_handler('listing all rule groups')
+    @Boto3Mixin.aws_error_handler('list all rule groups')
     def _list_rule_groups(self, **params):
         return self._paginated_list_rule_groups(**params)
 

--- a/plugins/modules/networkfirewall_rule_group.py
+++ b/plugins/modules/networkfirewall_rule_group.py
@@ -401,304 +401,309 @@ rule_group:
   type: dict
   returned: success
   contains:
-    rule_variables:
-      description: Settings that are available for use in the rules in the rule group.
-      returned: When rule variables are attached to the rule group.
-      type: complex
-      contains:
-        ip_sets:
-          description: A dictionary mapping variable names to IP addresses in CIDR format.
-          returned: success
-          type: dict
-          example: ['192.0.2.0/24']
-        port_sets:
-          description: A dictionary mapping variable names to ports
-          returned: success
-          type: dict
-          example: ['42']
-    stateful_rule_options:
-      description: Additional options governing how Network Firewall handles stateful rules.
-      returned: When the rule group is either "rules string" or "rules list" based.
+    rule_group:
+      description: Details of the rules in the rule group
       type: dict
-      contains:
-        rule_order:
-          description: The order in which rules will be evaluated.
-          returned: success
-          type: str
-          example: 'DEFAULT_ACTION_ORDER'
-    rules_source:
-      description: Inspection criteria used for a 5-tuple based rule group.
       returned: success
-      type: dict
       contains:
-        stateful_rules:
-          description: A list of dictionaries describing the rules that the rule group is comprised of.
-          returned: When the rule group is "rules list" based.
-          type: list
-          elements: dict
+        rule_variables:
+          description: Settings that are available for use in the rules in the rule group.
+          returned: When rule variables are attached to the rule group.
+          type: complex
           contains:
-            action:
-              description: What action to perform when a flow matches the rule criteria.
-              returned: success
-              type: str
-              example: 'PASS'
-            header:
-              description: A description of the criteria used for the rule.
+            ip_sets:
+              description: A dictionary mapping variable names to IP addresses in CIDR format.
               returned: success
               type: dict
-              contains:
-                protocol:
-                  description: The protocol to inspect for.
-                  returned: success
-                  type: str
-                  example: 'IP'
-                source:
-                  description: The source address or range of addresses to inspect for.
-                  returned: success
-                  type: str
-                  example: '203.0.113.98'
-                source_port:
-                  description: The source port to inspect for.
-                  returned: success
-                  type: str
-                  example: '42'
-                destination:
-                  description: The destination address or range of addresses to inspect for.
-                  returned: success
-                  type: str
-                  example: '198.51.100.0/24'
-                destination_port:
-                  description: The destination port to inspect for.
-                  returned: success
-                  type: str
-                  example: '6666:6667'
-                direction:
-                  description: The direction of traffic flow to inspect.
-                  returned: success
-                  type: str
-                  example: 'FORWARD'
-            rule_options:
-              description: Additional Suricata RuleOptions settings for the rule.
+              example: ['192.0.2.0/24']
+            port_sets:
+              description: A dictionary mapping variable names to ports
               returned: success
-              type: list
-              elements: dict
-              contains:
-                keyword:
-                  description: The keyword for the setting.
-                  returned: success
-                  type: str
-                  example: 'sid:1'
-                settings:
-                  description: A list of values passed to the setting.
-                  returned: When values are available
-                  type: list
-                  elements: str
-        rules_string:
-          description: A string describing the rules that the rule group is comprised of.
-          returned: When the rule group is "rules string" based.
-          type: str
-        rules_source_list:
-          description: A description of the criteria for a domain list rule group.
-          returned: When the rule group is "domain list" based.
+              type: dict
+              example: ['42']
+        stateful_rule_options:
+          description: Additional options governing how Network Firewall handles stateful rules.
+          returned: When the rule group is either "rules string" or "rules list" based.
           type: dict
           contains:
-            targets:
-              description: A list of domain names to be inspected for.
-              returned: success
-              type: list
-              elements: str
-              example: ['abc.example.com', '.example.net']
-            target_types:
-              description: The protocols to be inspected by the rule group.
-              returned: success
-              type: list
-              elements: str
-              example: ['TLS_SNI', 'HTTP_HOST']
-            generated_rules_type:
-              description: Whether the rule group allows or denies access to the domains in the list.
+            rule_order:
+              description: The order in which rules will be evaluated.
               returned: success
               type: str
-              example: 'ALLOWLIST'
-        stateless_rules_and_custom_actions:
-          description: A description of the criteria for a stateless rule group.
-          returned: When the rule group is a stateless rule group.
+              example: 'DEFAULT_ACTION_ORDER'
+        rules_source:
+          description: Inspection criteria used for a 5-tuple based rule group.
+          returned: success
           type: dict
           contains:
-            stateless_rules:
-              description: A list of stateless rules for use in a stateless rule group.
+            stateful_rules:
+              description: A list of dictionaries describing the rules that the rule group is comprised of.
+              returned: When the rule group is "rules list" based.
               type: list
               elements: dict
               contains:
-                rule_definition:
-                  description: Describes the stateless 5-tuple inspection criteria and actions for the rule.
-                  returned: success
-                  type: dict
-                  contains:
-                    match_attributes:
-                      description: Describes the stateless 5-tuple inspection criteria for the rule.
-                      returned: success
-                      type: dict
-                      contains:
-                        sources:
-                          description: The source IP addresses and address ranges to inspect for.
-                          returned: success
-                          type: list
-                          elements: dict
-                          contains:
-                            address_definition:
-                              description: An IP address or a block of IP addresses in CIDR notation.
-                              returned: success
-                              type: str
-                              example: '192.0.2.3'
-                        destinations:
-                          description: The destination IP addresses and address ranges to inspect for.
-                          returned: success
-                          type: list
-                          elements: dict
-                          contains:
-                            address_definition:
-                              description: An IP address or a block of IP addresses in CIDR notation.
-                              returned: success
-                              type: str
-                              example: '192.0.2.3'
-                        source_ports:
-                          description: The source port ranges to inspect for.
-                          returned: success
-                          type: list
-                          elements: dict
-                          contains:
-                            from_port:
-                              description: The lower limit of the port range.
-                              returned: success
-                              type: int
-                            to_port:
-                              description: The upper limit of the port range.
-                              returned: success
-                              type: int
-                        destination_ports:
-                          description: The destination port ranges to inspect for.
-                          returned: success
-                          type: list
-                          elements: dict
-                          contains:
-                            from_port:
-                              description: The lower limit of the port range.
-                              returned: success
-                              type: int
-                            to_port:
-                              description: The upper limit of the port range.
-                              returned: success
-                              type: int
-                        protocols:
-                          description: The IANA protocol numbers of the protocols to inspect for.
-                          returned: success
-                          type: list
-                          elements: int
-                          example: [6]
-                        tcp_flags:
-                          description: The TCP flags and masks to inspect for.
-                          returned: success
-                          type: list
-                          elements: dict
-                          contains:
-                            flags:
-                              description: Used with masks to define the TCP flags that flows are inspected for.
-                              returned: success
-                              type: list
-                              elements: str
-                            masks:
-                              description: The set of flags considered during inspection.
-                              returned: success
-                              type: list
-                              elements: str
-                    actions:
-                      description: The actions to take when a flow matches the rule.
-                      returned: success
-                      type: list
-                      elements: str
-                      example: ['aws:pass', 'CustomActionName']
-                priority:
-                  description: Indicates the order in which to run this rule relative to all of the rules that are defined for a stateless rule group.
-                  returned: success
-                  type: int
-            custom_actions:
-              description: A list of individual custom action definitions that are available for use in stateless rules.
-              type: list
-              elements: dict
-              contains:
-                action_name:
-                  description: The name for the custom action.
+                action:
+                  description: What action to perform when a flow matches the rule criteria.
                   returned: success
                   type: str
-                action_definition:
-                  description: The custom action associated with the action name.
+                  example: 'PASS'
+                header:
+                  description: A description of the criteria used for the rule.
                   returned: success
                   type: dict
                   contains:
-                    publish_metric_action:
-                      description: The description of an action which publishes to CloudWatch.
-                      returned: When the action publishes to CloudWatch.
+                    protocol:
+                      description: The protocol to inspect for.
+                      returned: success
+                      type: str
+                      example: 'IP'
+                    source:
+                      description: The source address or range of addresses to inspect for.
+                      returned: success
+                      type: str
+                      example: '203.0.113.98'
+                    source_port:
+                      description: The source port to inspect for.
+                      returned: success
+                      type: str
+                      example: '42'
+                    destination:
+                      description: The destination address or range of addresses to inspect for.
+                      returned: success
+                      type: str
+                      example: '198.51.100.0/24'
+                    destination_port:
+                      description: The destination port to inspect for.
+                      returned: success
+                      type: str
+                      example: '6666:6667'
+                    direction:
+                      description: The direction of traffic flow to inspect.
+                      returned: success
+                      type: str
+                      example: 'FORWARD'
+                rule_options:
+                  description: Additional Suricata RuleOptions settings for the rule.
+                  returned: success
+                  type: list
+                  elements: dict
+                  contains:
+                    keyword:
+                      description: The keyword for the setting.
+                      returned: success
+                      type: str
+                      example: 'sid:1'
+                    settings:
+                      description: A list of values passed to the setting.
+                      returned: When values are available
+                      type: list
+                      elements: str
+            rules_string:
+              description: A string describing the rules that the rule group is comprised of.
+              returned: When the rule group is "rules string" based.
+              type: str
+            rules_source_list:
+              description: A description of the criteria for a domain list rule group.
+              returned: When the rule group is "domain list" based.
+              type: dict
+              contains:
+                targets:
+                  description: A list of domain names to be inspected for.
+                  returned: success
+                  type: list
+                  elements: str
+                  example: ['abc.example.com', '.example.net']
+                target_types:
+                  description: The protocols to be inspected by the rule group.
+                  returned: success
+                  type: list
+                  elements: str
+                  example: ['TLS_SNI', 'HTTP_HOST']
+                generated_rules_type:
+                  description: Whether the rule group allows or denies access to the domains in the list.
+                  returned: success
+                  type: str
+                  example: 'ALLOWLIST'
+            stateless_rules_and_custom_actions:
+              description: A description of the criteria for a stateless rule group.
+              returned: When the rule group is a stateless rule group.
+              type: dict
+              contains:
+                stateless_rules:
+                  description: A list of stateless rules for use in a stateless rule group.
+                  type: list
+                  elements: dict
+                  contains:
+                    rule_definition:
+                      description: Describes the stateless 5-tuple inspection criteria and actions for the rule.
+                      returned: success
                       type: dict
                       contains:
-                        dimensions:
-                          description: The value to use in an Amazon CloudWatch custom metric dimension.
+                        match_attributes:
+                          description: Describes the stateless 5-tuple inspection criteria for the rule.
+                          returned: success
+                          type: dict
+                          contains:
+                            sources:
+                              description: The source IP addresses and address ranges to inspect for.
+                              returned: success
+                              type: list
+                              elements: dict
+                              contains:
+                                address_definition:
+                                  description: An IP address or a block of IP addresses in CIDR notation.
+                                  returned: success
+                                  type: str
+                                  example: '192.0.2.3'
+                            destinations:
+                              description: The destination IP addresses and address ranges to inspect for.
+                              returned: success
+                              type: list
+                              elements: dict
+                              contains:
+                                address_definition:
+                                  description: An IP address or a block of IP addresses in CIDR notation.
+                                  returned: success
+                                  type: str
+                                  example: '192.0.2.3'
+                            source_ports:
+                              description: The source port ranges to inspect for.
+                              returned: success
+                              type: list
+                              elements: dict
+                              contains:
+                                from_port:
+                                  description: The lower limit of the port range.
+                                  returned: success
+                                  type: int
+                                to_port:
+                                  description: The upper limit of the port range.
+                                  returned: success
+                                  type: int
+                            destination_ports:
+                              description: The destination port ranges to inspect for.
+                              returned: success
+                              type: list
+                              elements: dict
+                              contains:
+                                from_port:
+                                  description: The lower limit of the port range.
+                                  returned: success
+                                  type: int
+                                to_port:
+                                  description: The upper limit of the port range.
+                                  returned: success
+                                  type: int
+                            protocols:
+                              description: The IANA protocol numbers of the protocols to inspect for.
+                              returned: success
+                              type: list
+                              elements: int
+                              example: [6]
+                            tcp_flags:
+                              description: The TCP flags and masks to inspect for.
+                              returned: success
+                              type: list
+                              elements: dict
+                              contains:
+                                flags:
+                                  description: Used with masks to define the TCP flags that flows are inspected for.
+                                  returned: success
+                                  type: list
+                                  elements: str
+                                masks:
+                                  description: The set of flags considered during inspection.
+                                  returned: success
+                                  type: list
+                                  elements: str
+                        actions:
+                          description: The actions to take when a flow matches the rule.
                           returned: success
                           type: list
-                          elements: dict
+                          elements: str
+                          example: ['aws:pass', 'CustomActionName']
+                    priority:
+                      description: Indicates the order in which to run this rule relative to all of the rules that are defined for a stateless rule group.
+                      returned: success
+                      type: int
+                custom_actions:
+                  description: A list of individual custom action definitions that are available for use in stateless rules.
+                  type: list
+                  elements: dict
+                  contains:
+                    action_name:
+                      description: The name for the custom action.
+                      returned: success
+                      type: str
+                    action_definition:
+                      description: The custom action associated with the action name.
+                      returned: success
+                      type: dict
+                      contains:
+                        publish_metric_action:
+                          description: The description of an action which publishes to CloudWatch.
+                          returned: When the action publishes to CloudWatch.
+                          type: dict
                           contains:
-                            value:
-                              description: The value to use in the custom metric dimension.
+                            dimensions:
+                              description: The value to use in an Amazon CloudWatch custom metric dimension.
                               returned: success
-                              type: str
-rule_group_metadata:
-  description: Details of the rules in the rule group
-  type: dict
-  returned: success
-  contains:
-    capacity:
-      description: The maximum operating resources that this rule group can use.
-      type: int
-      returned: success
-    consumed_capacity:
-      description: The number of capacity units currently consumed by the rule group rules.
-      type: int
-      returned: success
-    description:
-      description: A description of the rule group.
-      type: str
-      returned: success
-    number_of_associations:
-      description: The number of firewall policies that use this rule group.
-      type: int
-      returned: success
-    rule_group_arn:
-      description: The ARN for the rule group
-      type: int
-      returned: success
-      example: 'arn:aws:network-firewall:us-east-1:123456789012:stateful-rulegroup/ExampleGroup'
-    rule_group_id:
-      description: A unique identifier for the rule group.
-      type: int
-      returned: success
-      example: '12345678-abcd-1234-abcd-123456789abc'
-    rule_group_name:
-      description: The name of the rule group.
-      type: str
-      returned: success
-    rule_group_status:
-      description: The current status of a rule group.
-      type: str
-      returned: success
-      example: 'DELETING'
-    tags:
-      description: A dictionary representing the tags associated with the rule group.
+                              type: list
+                              elements: dict
+                              contains:
+                                value:
+                                  description: The value to use in the custom metric dimension.
+                                  returned: success
+                                  type: str
+    rule_group_metadata:
+      description: Details of the rules in the rule group
       type: dict
       returned: success
-    type:
-      description: Whether the rule group is stateless or stateful.
-      type: str
-      returned: success
-      example: 'STATEFUL'
+      contains:
+        capacity:
+          description: The maximum operating resources that this rule group can use.
+          type: int
+          returned: success
+        consumed_capacity:
+          description: The number of capacity units currently consumed by the rule group rules.
+          type: int
+          returned: success
+        description:
+          description: A description of the rule group.
+          type: str
+          returned: success
+        number_of_associations:
+          description: The number of firewall policies that use this rule group.
+          type: int
+          returned: success
+        rule_group_arn:
+          description: The ARN for the rule group
+          type: int
+          returned: success
+          example: 'arn:aws:network-firewall:us-east-1:123456789012:stateful-rulegroup/ExampleGroup'
+        rule_group_id:
+          description: A unique identifier for the rule group.
+          type: int
+          returned: success
+          example: '12345678-abcd-1234-abcd-123456789abc'
+        rule_group_name:
+          description: The name of the rule group.
+          type: str
+          returned: success
+        rule_group_status:
+          description: The current status of a rule group.
+          type: str
+          returned: success
+          example: 'DELETING'
+        tags:
+          description: A dictionary representing the tags associated with the rule group.
+          type: dict
+          returned: success
+        type:
+          description: Whether the rule group is stateless or stateful.
+          type: str
+          returned: success
+          example: 'STATEFUL'
 '''
 
 

--- a/plugins/modules/networkfirewall_rule_group.py
+++ b/plugins/modules/networkfirewall_rule_group.py
@@ -262,6 +262,21 @@ options:
     type: bool
     required: false
     default: True
+  wait:
+    description:
+      - Whether to wait for the firewall rule group to reach the
+        C(ACTIVE) or C(DELETED) state before the module returns.
+    type: bool
+    required: false
+    default: true
+  wait_timeout:
+    description:
+      - Maximum time, in seconds, to wait for the firewall rule group
+        to reach the expected state.
+      - Defaults to 600 seconds.
+    type: int
+    required: false
+
 
 author: Mark Chappell (@tremble)
 extends_documentation_fragment:
@@ -751,6 +766,8 @@ def main():
         rule_list=dict(type='list', elements='dict', aliases=['stateful_rule_list'], options=rule_list_spec, required=False),
         tags=dict(type='dict', required=False),
         purge_tags=dict(type='bool', required=False, default=True),
+        wait=dict(type='bool', required=False, default=True),
+        wait_timeout=dict(type='int', required=False),
     )
 
     module = AnsibleAWSModule(
@@ -790,6 +807,8 @@ def main():
         module.require_botocore_at_least('1.23.23', reason='to set the rule order')
 
     manager = NetworkFirewallRuleManager(module, arn=arn, name=name, rule_type=rule_type)
+    manager.set_wait(module.params.get('wait', None))
+    manager.set_wait_timeout(module.params.get('wait_timeout', None))
 
     if state == 'absent':
         manager.delete()

--- a/plugins/modules/networkfirewall_rule_group_info.py
+++ b/plugins/modules/networkfirewall_rule_group_info.py
@@ -378,7 +378,7 @@ rule_groups:
           returned: success
           example: 'DELETING'
         tags:
-          description: A dcitionary representing the tags associated with the rule group.
+          description: A dictionary representing the tags associated with the rule group.
           type: dict
           returned: success
         type:

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/5-tuple.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/5-tuple.yml
@@ -527,6 +527,7 @@
         name: '{{ tuple_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: tuple_group
       check_mode: true
 
@@ -539,6 +540,7 @@
         name: '{{ tuple_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: tuple_group
 
     - assert:
@@ -552,6 +554,7 @@
         name: '{{ tuple_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: tuple_group
       check_mode: true
 
@@ -564,6 +567,7 @@
         name: '{{ tuple_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: tuple_group
 
     - assert:
@@ -576,4 +580,5 @@
         name: '{{ tuple_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       ignore_errors: true

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/cleanup.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/cleanup.yml
@@ -15,5 +15,6 @@
   networkfirewall_rule_group:
     arn: '{{ item }}'
     state: absent
+    wait: True
   ignore_errors: true
   loop: '{{ matching_rules }}'

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/domain_list.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/domain_list.yml
@@ -1635,6 +1635,7 @@
         name: '{{ domains_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: domain_group
       check_mode: true
 
@@ -1647,6 +1648,7 @@
         name: '{{ domains_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: domain_group
 
     - assert:
@@ -1659,4 +1661,5 @@
         name: '{{ domains_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       ignore_errors: true

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/main.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/main.yml
@@ -8,11 +8,6 @@
   collections:
     - amazon.aws
     - community.aws
-  # We have a base need of botocore >= 1.19.20 which should be fulfilled by the
-  # time we release 4.0.0, this has been locally tested against 1.20.0 only
-  # bumping the requirements for specific tests to 1.23.23
-  vars:
-    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   block:
     # Fetch some info about the account so we can build ARNs
     - aws_caller_info: {}
@@ -35,6 +30,11 @@
 
     # Tests Manipulation of common Stateful settings
     - include_tasks: 'stateful.yml'
+
+    # XXX Not yet supported,
+    # please also update networkfirewall_policy tests once supported.
+    # # Tests Manipulation of common Stateless rule group settings
+    # - include_tasks: 'stateless.yml'
 
     # Tests Manipulation of Suricata formatted rule strings
     - include_tasks: 'rule_strings.yml'

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/minimal.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/minimal.yml
@@ -696,6 +696,7 @@
         name: '{{ minimal_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: minimal_group
       check_mode: true
 
@@ -708,6 +709,7 @@
         name: '{{ minimal_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: minimal_group
 
     - assert:
@@ -721,6 +723,7 @@
         name: '{{ minimal_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: minimal_group
       check_mode: true
 
@@ -733,6 +736,7 @@
         name: '{{ minimal_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: minimal_group
 
     - assert:
@@ -768,4 +772,5 @@
         name: '{{ minimal_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       ignore_errors: true

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/rule_strings.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/rule_strings.yml
@@ -428,6 +428,7 @@
         name: '{{ strings_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: strings_group
       check_mode: true
 
@@ -440,6 +441,7 @@
         name: '{{ strings_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: strings_group
 
     - assert:
@@ -453,6 +455,7 @@
         name: '{{ strings_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: strings_group
       check_mode: true
 
@@ -465,6 +468,7 @@
         name: '{{ strings_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: strings_group
 
     - assert:
@@ -477,4 +481,5 @@
         name: '{{ strings_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       ignore_errors: true

--- a/tests/integration/targets/networkfirewall_rule_group/tasks/stateful.yml
+++ b/tests/integration/targets/networkfirewall_rule_group/tasks/stateful.yml
@@ -1329,6 +1329,7 @@
         name: '{{ stateful_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: stateful_group
 
     - assert:
@@ -1340,6 +1341,7 @@
         name: '{{ strict_ro_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       register: strict_group
 
     - assert:
@@ -1352,6 +1354,7 @@
         name: '{{ stateful_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       ignore_errors: true
 
     - name: '(always) Delete Strict rule group'
@@ -1359,4 +1362,5 @@
         name: '{{ strict_ro_group_name }}'
         type: 'stateful'
         state: absent
+        wait: False
       ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Add support for 'wait' to networkfirewall_rule_group to speed up the integration tests a little.

Note: Module not available in a release yet, so no changelog required.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

networkfirewall_rule_group

##### ADDITIONAL INFORMATION
