### PR TITLE
eks_fargate_profile: incr version added

### DIFF
--- a/plugins/modules/eks_fargate_profile.py
+++ b/plugins/modules/eks_fargate_profile.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: eks_fargate_profile
-version_added: 3.2.0
+version_added: 4.0.0
 short_description: Manage EKS Fargate Profile
 description:
     - Manage EKS Fargate Profile.


### PR DESCRIPTION
##### SUMMARY
CI is failing for `stable-3`  branch

>     NotImplementedError: Waiter fargate_profile_active could not be found for client <class 'botocore.client.EKS'>.

Possibly because the boto3 version in the `main` branch is higher as in the `stable-3` branch.  
It's still possible to backport this for the next 3.3.0 release. The integration test must install a higher boto3 version.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
eks_fargate_profile
