### PR TITLE
aws_kms - stabilize and add integration tests

### DIFF
--- a/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
+++ b/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as a short wait after update for requested changes to be reflected on AWS (https://github.com/ansible-collections/community.aws/pull/1052).
-  - aws_kms - add extra key/value pair to return data (policies_dict) to return each policy as a dictionary rather than json string (https://github.com/ansible-collections/community.aws/pull/1052).
+  - aws_kms - add extra key/value pair to return data (key_policies) to return each policy as a dictionary rather than json string (https://github.com/ansible-collections/community.aws/pull/1052).

--- a/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
+++ b/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as a short wait after update (https://github.com/ansible-collections/community.aws/pull/1052).
+  - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as a short wait after update for requested changes to be reflected on AWS (https://github.com/ansible-collections/community.aws/pull/1052).

--- a/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
+++ b/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as a short wait after update for requested changes to be reflected on AWS (https://github.com/ansible-collections/community.aws/pull/1052).
+  - aws_kms - add extra key/value pair to return data (policies_dict) to return each policy as a dictionary rather than json string (https://github.com/ansible-collections/community.aws/pull/1052).

--- a/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
+++ b/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as a short wait after update for requested changes to be reflected on AWS (https://github.com/ansible-collections/community.aws/pull/1052).
+  - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as document issues with time taken for requested changes to be reflected on AWS (https://github.com/ansible-collections/community.aws/pull/1052).
   - aws_kms - add extra key/value pair to return data (key_policies) to return each policy as a dictionary rather than json string (https://github.com/ansible-collections/community.aws/pull/1052).

--- a/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
+++ b/changelogs/fragments/1052-aws_kms-stabilize-integration-tests.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_kms - fix some bugs in integration tests and add check mode support for key rotation as well as a short wait after update (https://github.com/ansible-collections/community.aws/pull/1052).

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -317,7 +317,7 @@ enabled:
   returned: always
   sample: false
 enable_key_rotation:
-  description: Whether the automatically key rotation every year is enabled. Returns None if key rotation status can't be determined.
+  description: Whether the automatic annual key rotation is enabled. Returns None if key rotation status can't be determined.
   type: bool
   returned: always
   sample: false

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -321,6 +321,42 @@ policies:
   description: list of policy documents for the keys. Empty when access is denied even if there are policies.
   type: list
   returned: always
+  elements: str
+  sample:
+    Version: "2012-10-17"
+    Id: "auto-ebs-2"
+    Statement:
+    - Sid: "Allow access through EBS for all principals in the account that are authorized to use EBS"
+      Effect: "Allow"
+      Principal:
+      AWS: "*"
+      Action:
+      - "kms:Encrypt"
+      - "kms:Decrypt"
+      - "kms:ReEncrypt*"
+      - "kms:GenerateDataKey*"
+      - "kms:CreateGrant"
+      - "kms:DescribeKey"
+      Resource: "*"
+      Condition:
+        StringEquals:
+          kms:CallerAccount: "111111111111"
+          kms:ViaService: "ec2.ap-southeast-2.amazonaws.com"
+    - Sid: "Allow direct access to key metadata to the account"
+      Effect: "Allow"
+      Principal:
+      AWS: "arn:aws:iam::111111111111:root"
+      Action:
+      - "kms:Describe*"
+      - "kms:Get*"
+      - "kms:List*"
+      - "kms:RevokeGrant"
+      Resource: "*"
+policies_dict:
+  description: list of policy documents for the keys. Empty when access is denied even if there are policies.
+  type: list
+  returned: always
+  elements: dict
   sample:
     Version: "2012-10-17"
     Id: "auto-ebs-2"
@@ -351,6 +387,7 @@ policies:
       - "kms:List*"
       - "kms:RevokeGrant"
       Resource: "*"
+  version_added: 3.3.0
 tags:
   description: dictionary of tags applied to the key
   type: dict
@@ -536,7 +573,7 @@ def get_kms_tags(connection, module, key_id):
 def get_kms_policies(connection, module, key_id):
     try:
         policies = list_key_policies_with_backoff(connection, key_id)['PolicyNames']
-        return [json.loads(get_key_policy_with_backoff(connection, key_id, policy)['Policy']) for
+        return [get_key_policy_with_backoff(connection, key_id, policy)['Policy'] for
                 policy in policies]
     except is_boto3_error_code('AccessDeniedException'):
         return []
@@ -585,6 +622,7 @@ def get_key_details(connection, module, key_id):
     tags = get_kms_tags(connection, module, key_id)
     result['tags'] = boto3_tag_list_to_ansible_dict(tags, 'TagKey', 'TagValue')
     result['policies'] = get_kms_policies(connection, module, key_id)
+    result['policies_dict'] = [json.loads(policy) for policy in result['policies']]
     return result
 
 

--- a/plugins/modules/aws_kms.py
+++ b/plugins/modules/aws_kms.py
@@ -1149,6 +1149,9 @@ def main():
 
     kms = module.client('kms')
 
+    module.deprecate("The 'policies' return key is deprecated and will be replaced by 'policies_dict'. Both values are returned for now.",
+                     date='2022-12-01', collection_name='community.aws')
+
     key_metadata = fetch_key_metadata(kms, module, module.params.get('key_id'), module.params.get('alias'))
     # We can't create keys with a specific ID, if we can't access the key we'll have to fail
     if module.params.get('state') == 'present' and module.params.get('key_id') and not key_metadata:

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -240,6 +240,7 @@ kms_keys:
           sample: arn:aws:sts::0123456789012:assumed-role/lambda_xyz/xyz
 '''
 
+import json
 
 try:
     import botocore
@@ -354,7 +355,7 @@ def get_kms_tags(connection, module, key_id):
 def get_kms_policies(connection, module, key_id):
     try:
         policies = list_key_policies_with_backoff(connection, key_id)['PolicyNames']
-        return [get_key_policy_with_backoff(connection, key_id, policy)['Policy'] for
+        return [json.loads(get_key_policy_with_backoff(connection, key_id, policy)['Policy']) for
                 policy in policies]
     except is_boto3_error_code('AccessDeniedException'):
         return []

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -499,6 +499,9 @@ def main():
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Failed to connect to AWS')
 
+    module.deprecate("The 'policies' return key is deprecated and will be replaced by 'policies_dict'. Both values are returned for now.",
+                     date='2022-12-01', collection_name='community.aws')
+
     all_keys = get_kms_info(connection, module)
     filtered_keys = [key for key in all_keys if key_matches_filters(key, module.params['filters'])]
     ret_params = dict(kms_keys=filtered_keys)

--- a/plugins/modules/aws_kms_info.py
+++ b/plugins/modules/aws_kms_info.py
@@ -150,7 +150,7 @@ kms_keys:
         Name: myKey
         Purpose: protecting_stuff
     policies:
-      description: list of policy documents for the keys. Empty when access is denied even if there are policies.
+      description: list of policy documents for the key. Empty when access is denied even if there are policies.
       type: list
       returned: always
       elements: str
@@ -184,8 +184,8 @@ kms_keys:
           - "kms:List*"
           - "kms:RevokeGrant"
           Resource: "*"
-    policies_dict:
-      description: list of policy documents for the keys. Empty when access is denied even if there are policies.
+    key_policies:
+      description: list of policy documents for the key. Empty when access is denied even if there are policies.
       type: list
       returned: always
       elements: dict
@@ -456,7 +456,7 @@ def get_key_details(connection, module, key_id, tokens=None):
     result = camel_dict_to_snake_dict(result)
     result['tags'] = boto3_tag_list_to_ansible_dict(tags, 'TagKey', 'TagValue')
     result['policies'] = get_kms_policies(connection, module, key_id)
-    result['policies_dict'] = [json.loads(policy) for policy in result['policies']]
+    result['key_policies'] = [json.loads(policy) for policy in result['policies']]
     return result
 
 
@@ -499,8 +499,8 @@ def main():
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Failed to connect to AWS')
 
-    module.deprecate("The 'policies' return key is deprecated and will be replaced by 'policies_dict'. Both values are returned for now.",
-                     date='2022-12-01', collection_name='community.aws')
+    module.deprecate("The 'policies' return key is deprecated and will be replaced by 'key_policies'. Both values are returned for now.",
+                     date='2024-05-01', collection_name='community.aws')
 
     all_keys = get_kms_info(connection, module)
     filtered_keys = [key for key in all_keys if key_matches_filters(key, module.params['filters'])]

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,7 +1,3 @@
-# Various race conditions - likely needs waiters
-# https://github.com/ansible-collections/community.aws/issues/433
-unstable
-
 cloud/aws
 
 aws_kms_info

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,3 +1,9 @@
+# Various race conditions - likely needs waiters
+# https://github.com/ansible-collections/community.aws/issues/433
+# No KMS supported waiters, and manual waiting for updates didn't fix the issue either.
+# Issue likely from AWS side - added sleep(5) on change to help.
+unstable
+
 cloud/aws
 
 aws_kms_info

--- a/tests/integration/targets/aws_kms/aliases
+++ b/tests/integration/targets/aws_kms/aliases
@@ -1,8 +1,7 @@
 # Various race conditions - likely needs waiters
 # https://github.com/ansible-collections/community.aws/issues/433
 # No KMS supported waiters, and manual waiting for updates didn't fix the issue either.
-# Issue likely from AWS side - added sleep(5) on change to help.
-unstable
+# Issue likely from AWS side - added waits on updates in integration tests to workaround this.
 
 cloud/aws
 

--- a/tests/integration/targets/aws_kms/defaults/main.yml
+++ b/tests/integration/targets/aws_kms/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-kms_alias: 'ansible-test-{{ resource_prefix }}-kms'
+kms_key_alias: 'ansible-test-{{ resource_prefix }}-kms'

--- a/tests/integration/targets/aws_kms/defaults/main.yml
+++ b/tests/integration/targets/aws_kms/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-kms_role_name: 'ansible-test-{{ resource_prefix }}-kms'
-kms_key_alias: '{{ resource_prefix }}-kms'
+kms_alias: 'ansible-test-{{ resource_prefix }}-kms'

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -21,7 +21,7 @@
     # to ensure it exists when we need it for updating the policies
     - name: create an IAM role that can do nothing
       iam_role:
-        name: '{{ kms_alias }}'
+        name: '{{ kms_key_alias }}'
         state: present
         assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect": "Deny"} }'
       register: iam_role_result
@@ -30,11 +30,11 @@
     #   TESTS
     - name: See whether key exists and its current state
       aws_kms_info:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
 
     - name: create a key - check mode
       aws_kms:
-        alias: '{{ kms_alias }}-check'
+        alias: '{{ kms_key_alias }}-check'
         tags:
           Hello: World
         state: present
@@ -44,7 +44,7 @@
 
     - name: find facts about the check mode key
       aws_kms_info:
-        alias: '{{ kms_alias }}-check'
+        alias: '{{ kms_key_alias }}-check'
       register: check_key
 
     - name: ensure that check mode worked as expected
@@ -55,7 +55,7 @@
 
     - name: create a key
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -81,7 +81,7 @@
 
     - name: create a key (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -95,7 +95,7 @@
 
     - name: create a key (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -127,7 +127,7 @@
 
     - name: Enable key rotation - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -142,7 +142,7 @@
 
     - name: Enable key rotation
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -160,7 +160,7 @@
 
     - name: Enable key rotation (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -175,7 +175,7 @@
 
     - name: Enable key rotation (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         tags:
           Hello: World
         state: present
@@ -228,7 +228,7 @@
 
     - name: Update policy (idempotence) - check mode
       aws_kms:
-        alias: "alias/{{ kms_alias }}"
+        alias: "alias/{{ kms_key_alias }}"
         policy: "{{ lookup('template', 'console-policy.j2') }}"
       register: kms_policy_changed
       check_mode: yes
@@ -239,7 +239,7 @@
 
     - name: Update policy (idempotence)
       aws_kms:
-        alias: "alias/{{ kms_alias }}"
+        alias: "alias/{{ kms_key_alias }}"
         policy: "{{ lookup('template', 'console-policy.j2') }}"
       register: kms_policy_changed
 
@@ -252,8 +252,8 @@
     - name: grant user-style access to production secrets
       aws_kms:
         mode: grant
-        alias: "alias/{{ kms_alias }}"
-        role_name: '{{ kms_alias }}'
+        alias: "alias/{{ kms_key_alias }}"
+        role_name: '{{ kms_key_alias }}'
         grant_types: "role,role grant"
       register: new_key
 
@@ -264,12 +264,12 @@
     - name: remove access to production secrets from role
       aws_kms:
         mode: deny
-        alias: "alias/{{ kms_alias }}"
+        alias: "alias/{{ kms_key_alias }}"
         role_arn: "{{ iam_role_result.iam_role.arn }}"
 
     - name: Add grant - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         purge_tags: yes
@@ -294,7 +294,7 @@
 
     - name: Add grant
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         purge_tags: yes
@@ -319,7 +319,7 @@
 
     - name: Add grant (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         purge_tags: yes
@@ -343,7 +343,7 @@
 
     - name: Add grant (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         purge_tags: yes
@@ -367,7 +367,7 @@
 
     - name: Add a second grant
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         grants:
           - name: another_grant
@@ -390,7 +390,7 @@
 
     - name: Add a second grant again
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         grants:
           - name: another_grant
@@ -413,7 +413,7 @@
 
     - name: Update the grants with purge_grants set
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
         grants:
@@ -437,7 +437,7 @@
 
     - name: Update third grant to change encryption context equals to subset
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         grants:
           - name: third_grant
@@ -464,7 +464,7 @@
 
     - name: Tag encryption key
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         tags:
           tag_one: tag_one
@@ -481,7 +481,7 @@
 
     - name: Modify tags - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_tags: yes
         tags:
@@ -496,7 +496,7 @@
 
     - name: Modify tags
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_tags: yes
         tags:
@@ -516,7 +516,7 @@
 
     - name: Modify tags (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_tags: yes
         tags:
@@ -531,7 +531,7 @@
 
     - name: Modify tags (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         purge_tags: yes
         tags:
@@ -552,7 +552,7 @@
 
     - name: Update description - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
       register: key
@@ -564,7 +564,7 @@
 
     - name: Update description
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
       register: key
@@ -581,7 +581,7 @@
 
     - name: Update description (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
       register: key
@@ -593,7 +593,7 @@
 
     - name: Update description (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
       register: key
@@ -612,7 +612,7 @@
 
     - name: Disable key - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
         enabled: no
@@ -625,7 +625,7 @@
 
     - name: Disable key
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
         enabled: no
@@ -640,7 +640,7 @@
 
     - name: Disable key (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
         enabled: no
@@ -653,7 +653,7 @@
 
     - name: Disable key (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
         description: test key for testing
         enabled: no
@@ -669,13 +669,13 @@
 
     - name: update policy to remove access to key rotation status
       aws_kms:
-        alias: 'alias/{{ kms_alias }}'
+        alias: 'alias/{{ kms_key_alias }}'
         policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') }}"
       register: key
 
     - name: find facts about the key without key rotation status
       aws_kms_info:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
       register: updated_key
 
     - name: assert that key rotation status is set to None
@@ -697,7 +697,7 @@
           - "'kms_keys' in info_tag_filtered"
           - info_tag_filtered.kms_keys | length == 1
           - "'aliases' in key"
-          - kms_alias in key.aliases
+          - kms_key_alias in key.aliases
           - "'aws_account_id' in key"
           - key.aws_account_id == aws_caller_info.account
           - "'creation_date' in key"
@@ -735,7 +735,7 @@
 
     - name: Delete key - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: key
       check_mode: yes
@@ -746,7 +746,7 @@
 
     - name: Delete key
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: key
 
@@ -764,7 +764,7 @@
 
     - name: Delete key (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: key
       check_mode: yes
@@ -775,7 +775,7 @@
 
     - name: Delete key (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: absent
       register: key
 
@@ -788,7 +788,7 @@
 
     - name: Cancel key deletion - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
       register: key
       check_mode: yes
@@ -799,7 +799,7 @@
 
     - name: Cancel key deletion
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
       register: key
 
@@ -810,7 +810,7 @@
 
     - name: Cancel key deletion (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
       register: key
       check_mode: yes
@@ -821,7 +821,7 @@
 
     - name: Cancel key deletion (idempotence)
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: present
       register: key
 
@@ -834,7 +834,7 @@
 
     - name: delete the key with a specific deletion window
       aws_kms:
-        alias: '{{ kms_alias }}'
+        alias: '{{ kms_key_alias }}'
         state: absent
         pending_window: 7
       register: delete_kms
@@ -855,7 +855,7 @@
     # test different key usage and specs
     - name: create kms key with different specs
       aws_kms:
-        alias: '{{ kms_alias }}-diff-spec-usage'
+        alias: '{{ kms_key_alias }}-diff-spec-usage'
         purge_grants: yes
         key_spec: ECC_NIST_P256
         key_usage: SIGN_VERIFY
@@ -876,34 +876,19 @@
   always:
     # ============================================================
     #   CLEAN-UP
-    - name: finish off by deleting key
+    - name: finish off by deleting keys
       aws_kms:
         state: absent
-        alias: '{{ kms_alias }}'
+        alias: "{{ item }}"
         pending_window: 7
-      register: destroy_result
       ignore_errors: True
-
-    - name: delete kms key with different specs
-      aws_kms:
-        state: absent
-        alias: '{{ kms_alias }}-diff-spec-usage'
-        pending_window: 7
-      register: destroy_result
-      ignore_errors: True
-
-    # Should never exist, but just in case
-    - name: finish off by deleting key
-      aws_kms:
-        state: absent
-        alias: '{{ kms_alias }}-check'
-        pending_window: 7
-      register: destroy_result
-      ignore_errors: True
+      loop:
+        - "{{ kms_key_alias }}"
+        - "{{ kms_key_alias }}-diff-spec-usage"
+        - "{{ kms_key_alias }}-check"
 
     - name: remove the IAM role
       iam_role:
-        name: '{{ kms_alias }}'
+        name: '{{ kms_key_alias }}'
         state: absent
-      register: iam_role_result
       ignore_errors: True

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -21,7 +21,7 @@
     # to ensure it exists when we need it for updating the policies
     - name: create an IAM role that can do nothing
       iam_role:
-        name: '{{ kms_role_name }}'
+        name: '{{ kms_alias }}'
         state: present
         assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect": "Deny"} }'
       register: iam_role_result
@@ -30,41 +30,43 @@
     #   TESTS
     - name: See whether key exists and its current state
       aws_kms_info:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
 
-    - name: create a key in check mode
-      check_mode: yes
+    - name: create a key - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}-check'
+        alias: '{{ kms_alias }}-check'
         tags:
           Hello: World
         state: present
         enabled: yes
       register: create_kms_check
+      check_mode: yes
 
     - name: find facts about the check mode key
       aws_kms_info:
-        alias: '{{ kms_key_alias }}-check'
+        alias: '{{ kms_alias }}-check'
       register: check_key
 
     - name: ensure that check mode worked as expected
       assert:
         that:
-          - check_key["keys"]|length == 0
+          - check_key.kms_keys | length == 0
           - create_kms_check is changed
 
     - name: create a key
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         tags:
           Hello: World
         state: present
         enabled: yes
+        enable_key_rotation: no
       register: create_kms
 
     - name: assert that state is enabled
       assert:
         that:
+          - create_kms is changed
           - '"key_id" in create_kms'
           - create_kms.key_id | length >= 36
           - not create_kms.key_id.startswith("arn:aws")
@@ -77,14 +79,70 @@
           - create_kms.key_usage == 'ENCRYPT_DECRYPT'
           - create_kms.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
 
+    - name: create a key (idempotence) - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        tags:
+          Hello: World
+        state: present
+        enabled: yes
+      register: create_kms
+      check_mode: yes
+
+    - assert:
+        that:
+          - create_kms is not changed
+
+    - name: create a key (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        tags:
+          Hello: World
+        state: present
+        enabled: yes
+      register: create_kms
+      check_mode: yes
+
+    - assert:
+        that:
+          - create_kms is not changed
+          - '"key_id" in create_kms'
+          - create_kms.key_id | length >= 36
+          - not create_kms.key_id.startswith("arn:aws")
+          - '"key_arn" in create_kms'
+          - create_kms.key_arn.endswith(create_kms.key_id)
+          - create_kms.key_arn.startswith("arn:aws")
+          - create_kms.key_state == "Enabled"
+          - create_kms.tags['Hello'] == 'World'
+          - create_kms.enable_key_rotation == false
+          - create_kms.key_usage == 'ENCRYPT_DECRYPT'
+          - create_kms.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+
+    # ------------------------------------------------------------------------------------------
+
     - name: Save IDs for later
       set_fact:
         kms_key_id: '{{ create_kms.key_id }}'
         kms_key_arn: '{{ create_kms.key_arn }}'
 
-    - name: enable key rotation
+    - name: Enable key rotation - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
+        tags:
+          Hello: World
+        state: present
+        enabled: yes
+        enable_key_rotation: yes
+      register: create_kms
+      check_mode: yes
+
+    - assert:
+        that:
+          - create_kms.changed
+
+    - name: Enable key rotation
+      aws_kms:
+        alias: '{{ kms_alias }}'
         tags:
           Hello: World
         state: present
@@ -95,20 +153,44 @@
     - name: assert that key rotation is enabled
       assert:
         that:
+          - create_kms.changed
           - create_kms.key_state == "Enabled"
           - create_kms.tags['Hello'] == 'World'
           - create_kms.enable_key_rotation == true
 
-    - name: delete the key in check mode
-      check_mode: yes
+    - name: Enable key rotation (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
-        state: absent
-      register: delete_kms_check
+        alias: '{{ kms_alias }}'
+        tags:
+          Hello: World
+        state: present
+        enabled: yes
+        enable_key_rotation: yes
+      register: create_kms
+      check_mode: yes
 
     - assert:
         that:
-          - delete_kms_check is changed
+          - not create_kms.changed
+
+    - name: Enable key rotation (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        tags:
+          Hello: World
+        state: present
+        enabled: yes
+        enable_key_rotation: yes
+      register: create_kms
+
+    - assert:
+        that:
+          - not create_kms.changed
+          - create_kms.key_state == "Enabled"
+          - create_kms.tags['Hello'] == 'World'
+          - create_kms.enable_key_rotation == true
+
+    # ------------------------------------------------------------------------------------------
 
     - name: find facts about the key (by ID)
       aws_kms_info:
@@ -118,14 +200,25 @@
     - name: check that a key was found
       assert:
         that:
-          - new_key["keys"]|length == 1
-          - new_key["keys"][0]["enable_key_rotation"] == true
-          - new_key["keys"][0]["key_state"] != "PendingDeletion"
+          - new_key.kms_keys | length == 1
+          - new_key.kms_keys[0].enable_key_rotation == true
+          - new_key.kms_keys[0].key_state != "PendingDeletion"
 
-    - name: Update Policy on key to match AWS Console generate policy
+    - name: Update policy - check mode
       aws_kms:
         key_id: '{{ kms_key_id }}'
-        policy: "{{ lookup('template', 'console-policy.j2') | to_json }}"
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
+      register: kms_policy_changed
+      check_mode: yes
+
+    - assert:
+        that:
+          - kms_policy_changed is changed
+
+    - name: Update policy
+      aws_kms:
+        key_id: '{{ kms_key_id }}'
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
       register: kms_policy_changed
 
     - name: Policy should have been changed
@@ -133,43 +226,75 @@
         that:
           - kms_policy_changed is changed
 
-    - name: Attempt to re-assert the same policy
+    - name: Update policy (idempotence) - check mode
       aws_kms:
-        alias: "alias/{{ kms_key_alias }}"
-        policy: "{{ lookup('template', 'console-policy.j2') | to_json }}"
+        alias: "alias/{{ kms_alias }}"
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
+      register: kms_policy_changed
+      check_mode: yes
+
+    - assert:
+        that:
+          - not kms_policy_changed.changed
+
+    - name: Update policy (idempotence)
+      aws_kms:
+        alias: "alias/{{ kms_alias }}"
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
       register: kms_policy_changed
 
-    - name: Policy should not have changed since it was last set
-      assert:
+    - assert:
         that:
-          - kms_policy_changed is succeeded
+          - not kms_policy_changed.changed
+
+    # ------------------------------------------------------------------------------------------
 
     - name: grant user-style access to production secrets
       aws_kms:
         mode: grant
-        alias: "alias/{{ kms_key_alias }}"
-        role_name: '{{ kms_role_name }}'
+        alias: "alias/{{ kms_alias }}"
+        role_name: '{{ kms_alias }}'
         grant_types: "role,role grant"
-
-    - name: find facts about the key (by ARN)
-      aws_kms_info:
-        key_id: '{{ kms_key_arn }}'
       register: new_key
+
+    - assert:
+        that:
+          - new_key.changed
 
     - name: remove access to production secrets from role
       aws_kms:
         mode: deny
-        alias: "alias/{{ kms_key_alias }}"
+        alias: "alias/{{ kms_alias }}"
         role_arn: "{{ iam_role_result.iam_role.arn }}"
 
-    - name: find facts about the key (by alias)
-      aws_kms_info:
-        alias: '{{ kms_key_alias }}'
-      register: new_key
-
-    - name: Allow the IAM role to use a specific Encryption Context
+    - name: Add grant - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
+        state: present
+        purge_grants: yes
+        purge_tags: yes
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: grant_one
+      check_mode: yes
+
+    - name: assert grant would have been added
+      assert:
+        that:
+          - grant_one.changed
+
+    - name: Add grant
+      aws_kms:
+        alias: '{{ kms_alias }}'
         state: present
         purge_grants: yes
         purge_tags: yes
@@ -190,11 +315,59 @@
       assert:
         that:
           - grant_one.changed
-          - grant_one.grants|length == 1
+          - grant_one.grants | length == 1
+
+    - name: Add grant (idempotence) - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        purge_grants: yes
+        purge_tags: yes
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: grant_one
+      check_mode: yes
+
+    - assert:
+        that:
+          - not grant_one.changed
+
+    - name: Add grant (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        purge_grants: yes
+        purge_tags: yes
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: grant_one
+
+    - assert:
+        that:
+          - not grant_one.changed
+          - grant_one.grants | length == 1
 
     - name: Add a second grant
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
         grants:
           - name: another_grant
@@ -209,7 +382,7 @@
               - RetireGrant
       register: grant_two
 
-    - name: assert grant added
+    - name: Assert grant added
       assert:
         that:
           - grant_two.changed
@@ -217,7 +390,7 @@
 
     - name: Add a second grant again
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
         grants:
           - name: another_grant
@@ -232,7 +405,7 @@
               - RetireGrant
       register: grant_two_again
 
-    - name: assert grant added
+    - name: Assert grant added
       assert:
         that:
           - not grant_two_again.changed
@@ -240,7 +413,7 @@
 
     - name: Update the grants with purge_grants set
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
         purge_grants: yes
         grants:
@@ -256,15 +429,15 @@
               - RetireGrant
       register: grant_three
 
-    - name: assert grants replaced
+    - name: Assert grants replaced
       assert:
         that:
           - grant_three.changed
-          - grant_three.grants|length == 1
+          - grant_three.grants | length == 1
 
-    - name: update third grant to change encryption context equals to subset
+    - name: Update third grant to change encryption context equals to subset
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
         grants:
           - name: third_grant
@@ -279,99 +452,236 @@
               - RetireGrant
       register: grant_three_update
 
-    - name: assert grants replaced
+    - name: Assert grants replaced
       assert:
         that:
-          - "grant_three_update.changed"
-          - "grant_three_update.grants|length == 1"
+          - grant_three_update.changed
+          - grant_three_update.grants | length == 1
           - "'encryption_context_equals' not in grant_three_update.grants[0].constraints"
           - "'encryption_context_subset' in grant_three_update.grants[0].constraints"
 
-    - name: tag encryption key
+    # ------------------------------------------------------------------------------------------
+
+    - name: Tag encryption key
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
         tags:
           tag_one: tag_one
           tag_two: tag_two
       register: tag_kms
 
-    - name: assert tags added and grants remain in place
+    - name: Assert tags added and grants remain in place
       assert:
         that:
-          - "tag_kms.changed"
-          - "tag_kms.grants|length == 1"
+          - tag_kms.changed
+          - tag_kms.grants | length == 1
           - "'tag_one' in tag_kms.tags"
           - "'tag_two' in tag_kms.tags"
 
-    - name: add, replace, remove tags
+    - name: Modify tags - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
         purge_tags: yes
         tags:
           tag_two: tag_two_updated
           Tag Three: '{{ resource_prefix }}'
-      register: tag_kms_update
+      register: key
+      check_mode: yes
 
-    - name: assert tags correctly changed
-      assert:
+    - assert:
         that:
-          - "tag_kms_update.changed"
-          - "'tag_one' not in tag_kms_update.tags"
-          - "'tag_two' in tag_kms_update.tags"
-          - "tag_kms_update.tags.tag_two == 'tag_two_updated'"
-          - "'Tag Three' in tag_kms_update.tags"
-          - "tag_kms_update.tags['Tag Three'] == resource_prefix"
+          - key.changed
 
-    - name: make no real tag change
+    - name: Modify tags
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: present
+        purge_tags: yes
         tags:
+          tag_two: tag_two_updated
           Tag Three: '{{ resource_prefix }}'
-      register: tag_kms_no_update
+      register: key
 
-    - name: assert no change to tags
+    - name: Assert tags correctly changed
       assert:
         that:
-          - "not tag_kms_no_update.changed"
-          - "'tag_one' not in tag_kms_no_update.tags"
-          - "'tag_two' in tag_kms_no_update.tags"
-          - "tag_kms_no_update.tags.tag_two == 'tag_two_updated'"
-          - "'Tag Three' in tag_kms_update.tags"
-          - "tag_kms_update.tags['Tag Three'] == resource_prefix"
+          - key.changed
+          - "'tag_one' not in key.tags"
+          - "'tag_two' in key.tags"
+          - "key.tags.tag_two == 'tag_two_updated'"
+          - "'Tag Three' in key.tags"
+          - "key.tags['Tag Three'] == resource_prefix"
 
-    - name: update the key's description and disable it
+    - name: Modify tags (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
+        state: present
+        purge_tags: yes
+        tags:
+          tag_two: tag_two_updated
+          Tag Three: '{{ resource_prefix }}'
+      register: key
+      check_mode: yes
+
+    - assert:
+        that:
+          - not key.changed
+
+    - name: Modify tags (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        purge_tags: yes
+        tags:
+          tag_two: tag_two_updated
+          Tag Three: '{{ resource_prefix }}'
+      register: key
+
+    - assert:
+        that:
+          - not key.changed
+          - "'tag_one' not in key.tags"
+          - "'tag_two' in key.tags"
+          - "key.tags.tag_two == 'tag_two_updated'"
+          - "'Tag Three' in key.tags"
+          - "key.tags['Tag Three'] == resource_prefix"
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Update description - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+      register: key
+      check_mode: yes
+
+    - assert:
+        that:
+          - key.changed
+
+    - name: Update description
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+      register: key
+
+    - assert:
+        that:
+          - key.changed
+          - key.description == "test key for testing"
+          - "'tag_one' not in key.tags"
+          - "'tag_two' in key.tags"
+          - "key.tags.tag_two == 'tag_two_updated'"
+          - "'Tag Three' in key.tags"
+          - "key.tags['Tag Three'] == resource_prefix"
+
+    - name: Update description (idempotence) - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+      register: key
+      check_mode: yes
+
+    - assert:
+        that:
+          - not key.changed
+
+    - name: Update description (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+      register: key
+
+    - assert:
+        that:
+          - not key.changed
+          - key.description == "test key for testing"
+          - "'tag_one' not in key.tags"
+          - "'tag_two' in key.tags"
+          - "key.tags.tag_two == 'tag_two_updated'"
+          - "'Tag Three' in key.tags"
+          - "key.tags['Tag Three'] == resource_prefix"
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Disable key - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
         state: present
         description: test key for testing
         enabled: no
-      register: update_key
+      register: key
+      check_mode: yes
 
-    - name: assert that state is enabled
+    - assert:
+        that:
+          - key.changed
+
+    - name: Disable key
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+        enabled: no
+      register: key
+
+    - name: assert that state is disabled
       assert:
         that:
-          - update_key.description == "test key for testing"
-          - update_key.key_state == "Disabled"
-          - update_key.changed
+          - key.changed
+          - key.key_state == "Disabled"
+          - not key.enabled
+
+    - name: Disable key (idempotence) - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+        enabled: no
+      register: key
+      check_mode: yes
+
+    - assert:
+        that:
+          - not key.changed
+
+    - name: Disable key (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+        description: test key for testing
+        enabled: no
+      register: key
+
+    - assert:
+        that:
+          - not key.changed
+          - key.key_state == "Disabled"
+          - not key.enabled
+
+    # ------------------------------------------------------------------------------------------
 
     - name: update policy to remove access to key rotation status
       aws_kms:
-        alias: 'alias/{{ kms_key_alias }}'
-        policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') | to_json }}"
-      register: update_key
+        alias: 'alias/{{ kms_alias }}'
+        policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') }}"
+      register: key
 
     - name: find facts about the key without key rotation status
       aws_kms_info:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
       register: updated_key
 
     - name: assert that key rotation status is set to None
       assert:
         that:
-          - update_key.enable_key_rotation is none
+          - key.enable_key_rotation is none
 
     - name: Perform a search for key by tag
       aws_kms_info:
@@ -381,103 +691,150 @@
 
     - name: Verify all expected attributes
       vars:
-        tagged_key: '{{ info_tag_filtered["keys"][0] }}'
+        tagged_key: '{{ info_tag_filtered.kms_keys[0] }}'
       assert:
         that:
-          - "'keys' in info_tag_filtered"
-          - info_tag_filtered["keys"] | length == 1
-          - "'aliases' in tagged_key"
-          - kms_key_alias in tagged_key.aliases
-          - "'aws_account_id' in tagged_key"
-          - tagged_key.aws_account_id == aws_caller_info.account
-          - "'creation_date' in tagged_key"
-          - "'customer_master_key_spec' in tagged_key"
-          - tagged_key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-          - "'description' in tagged_key"
-          - tagged_key.description == 'test key for testing'
-          - "'enable_key_rotation' in tagged_key"
-          - "'enabled' in tagged_key"
-          - tagged_key.enabled == True
-          - "'encryption_algorithms' in tagged_key"
-          - "'SYMMETRIC_DEFAULT' in tagged_key.encryption_algorithms"
-          - "'grants' in tagged_key"
-          - "'key_arn' in tagged_key"
-          - tagged_key.key_arn == kms_key_arn
-          - "'key_id' in tagged_key"
-          - tagged_key.key_id == kms_key_id
-          - "'key_manager' in tagged_key"
-          - tagged_key.key_manager == 'CUSTOMER'
-          - "'key_state' in tagged_key"
-          - tagged_key.key_state == 'Enabled'
-          - "'key_usage' in tagged_key"
-          - tagged_key.key_usage == 'ENCRYPT_DECRYPT'
-          - "'origin' in tagged_key"
-          - tagged_key.origin == "AWS_KMS"
-          - "'policies' in tagged_key"
-          - tagged_key.policies | length == 1
-          - "'tags' in tagged_key"
-          - "'Tag Three' in tagged_key.tags"
-          - tagged_key.tags['Tag Three'] == resource_prefix
-          - "'tag_two' in tagged_key.tags"
-          - tagged_key.tags['tag_two'] == 'tag_two_updated'
+          - "'kms_keys' in info_tag_filtered"
+          - info_tag_filtered.kms_keys | length == 1
+          - "'aliases' in key"
+          - kms_alias in key.aliases
+          - "'aws_account_id' in key"
+          - key.aws_account_id == aws_caller_info.account
+          - "'creation_date' in key"
+          - "'customer_master_key_spec' in key"
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - "'description' in key"
+          - key.description == 'test key for testing'
+          - "'enable_key_rotation' in key"
+          - "'enabled' in key"
+          - key.enabled
+          - "'encryption_algorithms' in key"
+          - "'SYMMETRIC_DEFAULT' in key.encryption_algorithms"
+          - "'grants' in key"
+          - "'key_arn' in key"
+          - key.key_arn == kms_key_arn
+          - "'key_id' in key"
+          - key.key_id == kms_key_id
+          - "'key_manager' in key"
+          - key.key_manager == 'CUSTOMER'
+          - "'key_state' in key"
+          - key.key_state == 'Enabled'
+          - "'key_usage' in key"
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - "'origin' in key"
+          - key.origin == "AWS_KMS"
+          - "'policies' in key"
+          - key.policies | length == 1
+          - "'tags' in key"
+          - "'Tag Three' in key.tags"
+          - key.tags['Tag Three'] == resource_prefix
+          - "'tag_two' in key.tags"
+          - key.tags['tag_two'] == 'tag_two_updated'
 
-    - name: delete the key
+    # ------------------------------------------------------------------------------------------
+
+    - name: Delete key - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: absent
-      register: delete_kms
+      register: key
+      check_mode: yes
 
-    - name: assert that state is pending deletion
+    - assert:
+        that:
+          - key is changed
+
+    - name: Delete key
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: absent
+      register: key
+
+    - name: Assert that state is pending deletion
       vars:
         now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
-        deletion_time: '{{ delete_kms.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
+        deletion_time: '{{ key.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
       assert:
         that:
-          - delete_kms.key_state == "PendingDeletion"
-          - delete_kms.changed
+          - key.key_state == "PendingDeletion"
+          - key.changed
           # Times won't be perfect, allow a 24 hour window
           - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 30
           - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
 
-    - name: re-delete the key
+    - name: Delete key (idempotence) - check mode
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: absent
-      register: delete_kms
+      register: key
+      check_mode: yes
 
-    - name: assert that state is pending deletion
-      assert:
+    - assert:
         that:
-          - delete_kms.key_state == "PendingDeletion"
-          - delete_kms is not changed
+          - not key.changed
 
-    - name: undelete and enable the key
+    - name: Delete key (idempotence)
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
+        state: absent
+      register: key
+
+    - assert:
+        that:
+          - not key.changed
+          - key.key_state == "PendingDeletion"
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Cancel key deletion - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
         state: present
-        enabled: yes
-      register: undelete_kms
+      register: key
+      check_mode: yes
 
-    - name: assert that state is enabled
-      assert:
+    - assert:
         that:
-          - undelete_kms.key_state == "Enabled"
-          - undelete_kms.changed
+          - key.changed
 
-    - name: delete a non-existant key
+    - name: Cancel key deletion
       aws_kms:
-        key_id: '00000000-0000-0000-0000-000000000000'
-        state: absent
-      register: delete_kms
+        alias: '{{ kms_alias }}'
+        state: present
+      register: key
 
-    - name: assert that state is unchanged
-      assert:
+    - assert:
         that:
-          - delete_kms is not changed
+          - key.changed
+          - key.key_state != "PendingDeletion"
+
+    - name: Cancel key deletion (idempotence) - check mode
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+      register: key
+      check_mode: yes
+
+    - assert:
+        that:
+          - not key.changed
+
+    - name: Cancel key deletion (idempotence)
+      aws_kms:
+        alias: '{{ kms_alias }}'
+        state: present
+      register: key
+
+    - assert:
+        that:
+          - not key.changed
+          - key.key_state != "PendingDeletion"
+
+    # ------------------------------------------------------------------------------------------
 
     - name: delete the key with a specific deletion window
       aws_kms:
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         state: absent
         pending_window: 7
       register: delete_kms
@@ -498,7 +855,7 @@
     # test different key usage and specs
     - name: create kms key with different specs
       aws_kms:
-        alias: '{{ kms_role_name }}-diff-spec-usage'
+        alias: '{{ kms_alias }}-diff-spec-usage'
         purge_grants: yes
         key_spec: ECC_NIST_P256
         key_usage: SIGN_VERIFY
@@ -522,7 +879,7 @@
     - name: finish off by deleting key
       aws_kms:
         state: absent
-        alias: '{{ kms_key_alias }}'
+        alias: '{{ kms_alias }}'
         pending_window: 7
       register: destroy_result
       ignore_errors: True
@@ -530,7 +887,7 @@
     - name: delete kms key with different specs
       aws_kms:
         state: absent
-        alias: '{{ kms_role_name }}-diff-spec-usage'
+        alias: '{{ kms_alias }}-diff-spec-usage'
         pending_window: 7
       register: destroy_result
       ignore_errors: True
@@ -539,14 +896,14 @@
     - name: finish off by deleting key
       aws_kms:
         state: absent
-        alias: '{{ kms_key_alias }}-check'
+        alias: '{{ kms_alias }}-check'
         pending_window: 7
       register: destroy_result
       ignore_errors: True
 
     - name: remove the IAM role
       iam_role:
-        name: '{{ kms_role_name }}'
+        name: '{{ kms_alias }}'
         state: absent
       register: iam_role_result
       ignore_errors: True

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -28,6 +28,11 @@
 
     # ============================================================
     #   TESTS
+    # Note - there are waits placed after each action to account for inconsistencies in what
+    #        is being returned when fetching key metadata.
+    # Combinations of manual waiters, checking expecting key values to actual key value, and static sleeps
+    #        have all been tried, but none of those available options have solved the problem.
+
     - name: See whether key exists and its current state
       aws_kms_info:
         alias: '{{ kms_key_alias }}'
@@ -78,6 +83,10 @@
           - create_kms.enable_key_rotation == false
           - create_kms.key_usage == 'ENCRYPT_DECRYPT'
           - create_kms.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
 
     - name: create a key (idempotence) - check mode
       aws_kms:
@@ -158,6 +167,10 @@
           - create_kms.tags['Hello'] == 'World'
           - create_kms.enable_key_rotation == true
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Enable key rotation (idempotence) - check mode
       aws_kms:
         alias: '{{ kms_key_alias }}'
@@ -226,6 +239,10 @@
         that:
           - kms_policy_changed is changed
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Update policy (idempotence) - check mode
       aws_kms:
         alias: "alias/{{ kms_key_alias }}"
@@ -267,12 +284,15 @@
         alias: "alias/{{ kms_key_alias }}"
         role_arn: "{{ iam_role_result.iam_role.arn }}"
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Add grant - check mode
       aws_kms:
         alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
-        purge_tags: yes
         grants:
           - name: test_grant
             grantee_principal: "{{ iam_role_result.iam_role.arn }}"
@@ -297,7 +317,6 @@
         alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
-        purge_tags: yes
         grants:
           - name: test_grant
             grantee_principal: "{{ iam_role_result.iam_role.arn }}"
@@ -317,12 +336,15 @@
           - grant_one.changed
           - grant_one.grants | length == 1
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Add grant (idempotence) - check mode
       aws_kms:
         alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
-        purge_tags: yes
         grants:
           - name: test_grant
             grantee_principal: "{{ iam_role_result.iam_role.arn }}"
@@ -346,7 +368,6 @@
         alias: '{{ kms_key_alias }}'
         state: present
         purge_grants: yes
-        purge_tags: yes
         grants:
           - name: test_grant
             grantee_principal: "{{ iam_role_result.iam_role.arn }}"
@@ -387,6 +408,10 @@
         that:
           - grant_two.changed
           - grant_two.grants|length == 2
+
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
 
     - name: Add a second grant again
       aws_kms:
@@ -514,6 +539,10 @@
           - "'Tag Three' in key.tags"
           - "key.tags['Tag Three'] == resource_prefix"
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Modify tags (idempotence) - check mode
       aws_kms:
         alias: '{{ kms_key_alias }}'
@@ -579,6 +608,10 @@
           - "'Tag Three' in key.tags"
           - "key.tags['Tag Three'] == resource_prefix"
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Update description (idempotence) - check mode
       aws_kms:
         alias: '{{ kms_key_alias }}'
@@ -638,6 +671,10 @@
           - key.key_state == "Disabled"
           - not key.enabled
 
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
+
     - name: Disable key (idempotence) - check mode
       aws_kms:
         alias: '{{ kms_key_alias }}'
@@ -673,15 +710,15 @@
         policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') }}"
       register: key
 
-    - name: find facts about the key without key rotation status
-      aws_kms_info:
-        alias: '{{ kms_key_alias }}'
-      register: updated_key
-
-    - name: assert that key rotation status is set to None
-      assert:
+    - assert:
         that:
+          - key.changed
+          - key.key_state == "Enabled"
           - key.enable_key_rotation is none
+
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
 
     - name: Perform a search for key by tag
       aws_kms_info:
@@ -691,45 +728,45 @@
 
     - name: Verify all expected attributes
       vars:
-        key: '{{ info_tag_filtered.kms_keys[0] }}'
+        tagged_key: '{{ info_tag_filtered.kms_keys[0] }}'
       assert:
         that:
-          - "'kms_keys' in info_tag_filtered"
           - info_tag_filtered.kms_keys | length == 1
-          - "'aliases' in key"
-          - kms_key_alias in key.aliases
-          - "'aws_account_id' in key"
-          - key.aws_account_id == aws_caller_info.account
-          - "'creation_date' in key"
-          - "'customer_master_key_spec' in key"
-          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-          - "'description' in key"
-          - key.description == 'test key for testing'
-          - "'enable_key_rotation' in key"
-          - "'enabled' in key"
-          - key.enabled
-          - "'encryption_algorithms' in key"
-          - "'SYMMETRIC_DEFAULT' in key.encryption_algorithms"
-          - "'grants' in key"
-          - "'key_arn' in key"
-          - key.key_arn == kms_key_arn
-          - "'key_id' in key"
-          - key.key_id == kms_key_id
-          - "'key_manager' in key"
-          - key.key_manager == 'CUSTOMER'
-          - "'key_state' in key"
-          - key.key_state == 'Enabled'
-          - "'key_usage' in key"
-          - key.key_usage == 'ENCRYPT_DECRYPT'
-          - "'origin' in key"
-          - key.origin == "AWS_KMS"
-          - "'policies' in key"
-          - key.policies | length == 1
-          - "'tags' in key"
-          - "'Tag Three' in key.tags"
-          - key.tags['Tag Three'] == resource_prefix
-          - "'tag_two' in key.tags"
-          - key.tags['tag_two'] == 'tag_two_updated'
+          - "'aliases' in tagged_key"
+          - kms_key_alias in tagged_key.aliases
+          - "'aws_account_id' in tagged_key"
+          - tagged_key.aws_account_id == aws_caller_info.account
+          - "'creation_date' in tagged_key"
+          - "'customer_master_key_spec' in tagged_key"
+          - tagged_key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - "'description' in tagged_key"
+          - tagged_key.description == 'test key for testing'
+          - "'enable_key_rotation' in tagged_key"
+          - tagged_key.enable_key_rotation is none
+          - "'enabled' in tagged_key"
+          - tagged_key.enabled
+          - "'encryption_algorithms' in tagged_key"
+          - "'SYMMETRIC_DEFAULT' in tagged_key.encryption_algorithms"
+          - "'grants' in tagged_key"
+          - "'key_arn' in tagged_key"
+          - tagged_key.key_arn == kms_key_arn
+          - "'key_id' in tagged_key"
+          - tagged_key.key_id == kms_key_id
+          - "'key_manager' in tagged_key"
+          - tagged_key.key_manager == 'CUSTOMER'
+          - "'key_state' in tagged_key"
+          - tagged_key.key_state == 'Enabled'
+          - "'key_usage' in tagged_key"
+          - tagged_key.key_usage == 'ENCRYPT_DECRYPT'
+          - "'origin' in tagged_key"
+          - tagged_key.origin == "AWS_KMS"
+          - "'policies' in tagged_key"
+          - tagged_key.policies | length == 1
+          - "'tags' in tagged_key"
+          - "'Tag Three' in tagged_key.tags"
+          - tagged_key.tags['Tag Three'] == resource_prefix
+          - "'tag_two' in tagged_key.tags"
+          - tagged_key.tags['tag_two'] == 'tag_two_updated'
 
     # ------------------------------------------------------------------------------------------
 
@@ -749,6 +786,10 @@
         alias: '{{ kms_key_alias }}'
         state: absent
       register: key
+
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
 
     - name: Assert that state is pending deletion
       vars:
@@ -807,6 +848,10 @@
         that:
           - key.changed
           - key.key_state != "PendingDeletion"
+
+    - name: Sleep to wait for updates to propagate
+      wait_for:
+        timeout: 10
 
     - name: Cancel key deletion (idempotence) - check mode
       aws_kms:

--- a/tests/integration/targets/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/aws_kms/tasks/main.yml
@@ -691,7 +691,7 @@
 
     - name: Verify all expected attributes
       vars:
-        tagged_key: '{{ info_tag_filtered.kms_keys[0] }}'
+        key: '{{ info_tag_filtered.kms_keys[0] }}'
       assert:
         that:
           - "'kms_keys' in info_tag_filtered"

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,4 +1,5 @@
 plugins/modules/aws_kms.py pylint:ansible-deprecated-no-version
+plugins/modules/aws_kms_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_metric_alarm.py pylint:ansible-deprecated-no-version
 plugins/modules/elb_network_lb.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_policy.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY
- update/add integration tests for various actions
- return list of policies as a list of jsons for clarity
- sleep on updates (no kms waiter, attempted manual waiters but still had test failures)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_kms

##### ADDITIONAL INFORMATION
I tried adding manual waiters for different actions like waiting for tags to be correct, policy to be updated, etc, but would still fail ~half of the time on idempotency tests. seems like after updating the key's status is a bit buggy.
