### PR TITLE
ec2_asg_lifecycle_hook: add integration tests  (#1048)

### DIFF
--- a/changelogs/fragments/1048-ec2_asg_lifecycle_hook-add-integration-tests.yml
+++ b/changelogs/fragments/1048-ec2_asg_lifecycle_hook-add-integration-tests.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_asg_lifecycle_hook - add integration tests (https://github.com/ansible-collections/community.aws/pull/1048).
+- ec2_asg_lifecycle_hook - module now returns info about Life Cycle Hook (https://github.com/ansible-collections/community.aws/pull/1048).

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/aliases
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/aliases
@@ -1,0 +1,1 @@
+cloud/aws

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/inventory
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/inventory
@@ -1,0 +1,6 @@
+[tests]
+create_update_delete
+
+[all:vars]
+ansible_connection=local
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/main.yml
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/main.yml
@@ -1,0 +1,40 @@
+---
+# Beware: most of our tests here are run in parallel.
+# To add new tests you'll need to add a new host to the inventory and a matching
+# '{{ inventory_hostname }}'.yml file in roles/ec2_asg_lifecycle_hook/tasks/
+
+
+# Prepare the VPC and figure out which AMI to use
+- hosts: all
+  gather_facts: no
+  tasks:
+  - module_defaults:
+      group/aws:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token | default(omit) }}"
+        region: "{{ aws_region }}"
+    vars:
+      # We can't just use "run_once" because the facts don't propagate when
+      # running an 'include' that was run_once
+      setup_run_once: yes
+    block:
+    - include_role:
+        name: 'ec2_asg_lifecycle_hook'
+        tasks_from: env_setup.yml
+    rescue:
+    - include_role:
+        name: 'ec2_asg_lifecycle_hook'
+        tasks_from: env_cleanup.yml
+      run_once: yes
+    - fail:
+        msg: 'Environment preparation failed'
+      run_once: yes
+
+# VPC should get cleaned up once all hosts have run
+- hosts: all
+  gather_facts: no
+  strategy: free
+  serial: 6
+  roles:
+    - ec2_asg_lifecycle_hook

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/defaults/main.yml
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for ec2_asg_lifecycle_hook
+# Amazon Linux 2 AMI 2019.06.12 (HVM), GP2 Volume Type
+ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
+load_balancer_name: "{{ tiny_prefix }}-lb"

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/create_update_delete.yml
@@ -1,0 +1,140 @@
+---
+- name: Test create/update/delete AutoScalingGroups Lifecycle Hooks with ec2_asg_lifecycle_hook
+
+  block:
+  #----------------------------------------------------------------------
+    - name: create a launch configuration
+      ec2_lc:
+        name: "{{ resource_prefix }}-lc"
+        image_id: "{{ ec2_ami_image }}"
+        region: "{{ aws_region }}"
+        instance_type: t2.micro
+        assign_public_ip: yes
+      register: create_lc
+
+    - name: ensure that lc is created
+      assert:
+        that:
+          - create_lc is changed
+          - create_lc.failed is false
+
+    #----------------------------------------------------------------------
+    - name: create a AutoScalingGroup
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        health_check_period: 60
+        health_check_type: ELB
+        replace_all_instances: yes
+        min_size: 1
+        max_size: 1
+        desired_capacity: 1
+        region: "{{ aws_region }}"
+      register: create_asg
+
+    - name: ensure that AutoScalingGroup is created
+      assert:
+        that:
+          - create_asg is changed
+          - create_asg.failed is false
+          - '"autoscaling:CreateAutoScalingGroup" in create_asg.resource_actions'
+
+    #----------------------------------------------------------------------
+
+    - name: Create lifecycle hook
+      community.aws.ec2_asg_lifecycle_hook:
+        region: "{{ aws_region }}"
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        lifecycle_hook_name: "{{ resource_prefix }}-test-hook"
+        transition: autoscaling:EC2_INSTANCE_LAUNCHING
+        heartbeat_timeout: 7000
+        default_result: ABANDON
+        state: present
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"lifecycle_hook_info" in output'
+          - output.lifecycle_hook_info[0].heartbeat_timeout == 7000
+
+    - name: Create lifecycle hook - Idempotency
+      community.aws.ec2_asg_lifecycle_hook:
+        region: "{{ aws_region }}"
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        lifecycle_hook_name: "{{ resource_prefix }}-test-hook"
+        transition: autoscaling:EC2_INSTANCE_LAUNCHING
+        heartbeat_timeout: 7000
+        default_result: ABANDON
+        state: present
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+          - output is not failed
+          - '"lifecycle_hook_info" not in output'
+
+    - name: Update lifecycle hook
+      community.aws.ec2_asg_lifecycle_hook:
+        region: "{{ aws_region }}"
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        lifecycle_hook_name: "{{ resource_prefix }}-test-hook"
+        transition: autoscaling:EC2_INSTANCE_LAUNCHING
+        heartbeat_timeout: 6000
+        default_result: ABANDON
+        state: present
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"lifecycle_hook_info" in output'
+          - output.lifecycle_hook_info[0].heartbeat_timeout == 6000
+
+    - name: Update lifecycle hook - Idempotency
+      community.aws.ec2_asg_lifecycle_hook:
+        region: "{{ aws_region }}"
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        lifecycle_hook_name: "{{ resource_prefix }}-test-hook"
+        transition: autoscaling:EC2_INSTANCE_LAUNCHING
+        heartbeat_timeout: 6000
+        default_result: ABANDON
+        state: present
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+          - output is not failed
+          - '"lifecycle_hook_info" not in output'
+
+    - name: Delete lifecycle hook
+      community.aws.ec2_asg_lifecycle_hook:
+        region: "{{ aws_region }}"
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        lifecycle_hook_name: "{{ resource_prefix }}-test-hook"
+        state: absent
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"lifecycle_hook_removed" in output'
+
+    - name: Delete lifecycle hook - Idempotency
+      community.aws.ec2_asg_lifecycle_hook:
+        region: "{{ aws_region }}"
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        lifecycle_hook_name: "{{ resource_prefix }}-test-hook"
+        state: absent
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+          - output is not failed
+          - '"lifecycle_hook_removed" not in output'

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/env_cleanup.yml
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/env_cleanup.yml
@@ -1,0 +1,123 @@
+- name: kill asg
+  ec2_asg:
+    name: "{{ resource_prefix }}-asg"
+    state: absent
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+
+# Remove the testing dependencies
+- name: remove target group
+  elb_target_group:
+    name: "{{ item }}"
+    state: absent
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+  loop:
+    - "{{ tg1_name }}"
+    - "{{ tg2_name }}"
+
+- name: remove the load balancer
+  ec2_elb_lb:
+    name: "{{ load_balancer_name }}"
+    state: absent
+    security_group_ids:
+      - "{{ sg.group_id }}"
+    subnets: "{{ testing_subnet.subnet.id }}"
+    wait: true
+    connection_draining_timeout: 60
+    listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
+    health_check:
+        ping_protocol: tcp
+        ping_port: 80
+        ping_path: "/"
+        response_timeout: 5
+        interval: 10
+        unhealthy_threshold: 4
+        healthy_threshold: 2
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+
+- name: remove launch configs
+  ec2_lc:
+    name: "{{ item }}"
+    state: absent
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+  loop:
+    - "{{ resource_prefix }}-lc"
+
+- name: delete launch template
+  ec2_launch_template:
+    name: "{{ resource_prefix }}-lt"
+    state: absent
+  register: del_lt
+  retries: 10
+  until: del_lt is not failed
+  ignore_errors: true
+
+- name: remove the security group
+  ec2_group:
+    name: "{{ resource_prefix }}-sg"
+    description: a security group for ansible tests
+    vpc_id: "{{ testing_vpc.vpc.id }}"
+    state: absent
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+
+- name: remove routing rules
+  ec2_vpc_route_table:
+    state: absent
+    vpc_id: "{{ testing_vpc.vpc.id }}"
+    tags:
+      created: "{{ resource_prefix }}-route"
+    routes:
+      - dest: 0.0.0.0/0
+        gateway_id: "{{ igw.gateway_id }}"
+    subnets:
+      - "{{ testing_subnet.subnet.id }}"
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+
+- name: remove internet gateway
+  ec2_vpc_igw:
+    vpc_id: "{{ testing_vpc.vpc.id }}"
+    state: absent
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+
+- name: remove the subnet
+  ec2_vpc_subnet:
+    state: absent
+    vpc_id: "{{ testing_vpc.vpc.id }}"
+    cidr: 10.55.77.0/24
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10
+
+- name: remove the VPC
+  ec2_vpc_net:
+    name: "{{ resource_prefix }}-vpc"
+    cidr_block: 10.55.77.0/24
+    state: absent
+  register: removed
+  until: removed is not failed
+  ignore_errors: true
+  retries: 10

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/env_setup.yml
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/env_setup.yml
@@ -1,0 +1,65 @@
+- name: Run ec2_asg_lifecycle_hook integration tests.
+
+  block:
+
+    # ============================================================
+
+    - name: Find AMI to use
+      ec2_ami_info:
+        owners: 'amazon'
+        filters:
+          name: '{{ ec2_ami_name }}'
+      register: ec2_amis
+    - set_fact:
+        ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
+
+    # Set up the testing dependencies: VPC, subnet, security group, and two launch configurations
+    - name: Create VPC for use in testing
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.55.77.0/24
+        tenancy: default
+      register: testing_vpc
+
+    - name: Create internet gateway for use in testing
+      ec2_vpc_igw:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: present
+      register: igw
+
+    - name: Create subnet for use in testing
+      ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.55.77.0/24
+        az: "{{ aws_region }}a"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet"
+      register: testing_subnet
+
+    - name: create routing rules
+      ec2_vpc_route_table:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        tags:
+          created: "{{ resource_prefix }}-route"
+        routes:
+          - dest: 0.0.0.0/0
+            gateway_id: "{{ igw.gateway_id }}"
+        subnets:
+          - "{{ testing_subnet.subnet.id }}"
+
+    - name: create a security group with the vpc created in the ec2_setup
+      ec2_group:
+        name: "{{ resource_prefix }}-sg"
+        description: a security group for ansible tests
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 0.0.0.0/0
+          - proto: tcp
+            from_port: 80
+            to_port: 80
+            cidr_ip: 0.0.0.0/0
+      register: sg

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/roles/ec2_asg_lifecycle_hook/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# Beware: most of our tests here are run in parallel.
+# To add new tests you'll need to add a new host to the inventory and a matching
+# '{{ inventory_hostname }}'.yml file in roles/ec2_asg_lifecycle_hook/tasks/
+
+- name: "Wrap up all tests and setup AWS credentials"
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+      aws_config:
+        retries:
+          # Unfortunately AWSRetry doesn't support paginators and boto3's paginators
+          # don't support any configuration of the delay between retries.
+          max_attempts: 20
+  collections:
+    - community.aws
+  block:
+    - debug:
+        msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"
+    - include_tasks: '{{ inventory_hostname }}.yml'
+    - debug:
+        msg: "{{ inventory_hostname }} finish: {{ lookup('pipe','date') }}"
+
+  always:
+    - set_fact:
+        _role_complete: True
+    - vars:
+        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+        hosts_in_play: '{{ ansible_play_hosts_all | length }}'
+      debug:
+        msg: "{{ completed_hosts }} of {{ hosts_in_play }} complete"
+    - include_tasks: env_cleanup.yml
+      vars:
+        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+        hosts_in_play: '{{ ansible_play_hosts_all | length }}'
+      when:
+      - completed_hosts == hosts_in_play

--- a/tests/integration/targets/ec2_asg_lifecycle_hook/runme.sh
+++ b/tests/integration/targets/ec2_asg_lifecycle_hook/runme.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Beware: most of our tests here are run in parallel.
+# To add new tests you'll need to add a new host to the inventory and a matching
+# '{{ inventory_hostname }}'.yml file in roles/ec2_instance/tasks/
+
+
+set -eux
+
+export ANSIBLE_ROLES_PATH=../
+
+ansible-playbook main.yml -i inventory "$@"


### PR DESCRIPTION
Backport ec2_asg_lifecycle_hook: add integration tests https://github.com/ansible-collections/community.aws/pull/1048

SUMMARY

Adding integration tests to ec2_asg_lifecycle_hook module.
Fixing idempotency.

ISSUE TYPE


Feature Pull Request

COMPONENT NAME

ec2_asg_lifecycle_hook

Reviewed-by: Joseph Torcasso <None>
Reviewed-by: Mandar Kulkarni <mandar242@gmail.com>
Reviewed-by: Jill R <None>
