### PR TITLE
ec2_asg: minor fix - run setup only once

### DIFF
--- a/changelogs/fragments/1061-ec2_asg-integration-test-setup-bugfix.yml
+++ b/changelogs/fragments/1061-ec2_asg-integration-test-setup-bugfix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_asg - bugfix to make test setup run once (https://github.com/ansible-collections/community.aws/pull/1061).

--- a/tests/integration/targets/ec2_asg/main.yml
+++ b/tests/integration/targets/ec2_asg/main.yml
@@ -14,10 +14,6 @@
         aws_secret_key: "{{ aws_secret_key }}"
         security_token: "{{ security_token | default(omit) }}"
         region: "{{ aws_region }}"
-    vars:
-      # We can't just use "run_once" because the facts don't propagate when
-      # running an 'include' that was run_once
-      setup_run_once: yes
     block:
     - include_role:
         name: 'ec2_asg'

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/defaults/main.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/defaults/main.yml
@@ -3,3 +3,4 @@
 # Amazon Linux 2 AMI 2019.06.12 (HVM), GP2 Volume Type
 ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
 load_balancer_name: "{{ tiny_prefix }}-lb"
+ec2_asg_setup_run_once: true

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/env_setup.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/env_setup.yml
@@ -1,5 +1,5 @@
 - name: Run ec2_asg integration tests.
-
+  run_once: '{{ ec2_asg_setup_run_once }}'
   block:
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix integration tests bug in ec2_asg and run env_setup only once.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The bug causes env_setup.yml to run as many times as the number of tests in inventory file.
This causes removing test VPC to fail with the error
`
"msg": "Currently there are 3 VPCs that have the same name and CIDR block you specified. If you would like to create the VPC anyway please pass True to the multi_ok param.",
`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_asg