### PR TITLE
ec2_asg: Change purge_tags default value to False

### DIFF
--- a/plugins/modules/ec2_asg.py
+++ b/plugins/modules/ec2_asg.py
@@ -224,7 +224,7 @@ options:
     description:
       - If C(true), existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter.
       - If the I(tags) parameter is not set then tags will not be modified.
-    default: true
+    default: false
     type: bool
     version_added: 3.2.0
   health_check_period:
@@ -1861,7 +1861,7 @@ def main():
         wait_timeout=dict(type='int', default=300),
         state=dict(default='present', choices=['present', 'absent']),
         tags=dict(type='list', default=[], elements='dict'),
-        purge_tags=dict(type='bool', default=True),
+        purge_tags=dict(type='bool', default=False),
         health_check_period=dict(type='int', default=300),
         health_check_type=dict(default='EC2', choices=['EC2', 'ELB']),
         default_cooldown=dict(type='int', default=300),

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/tag_operations.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/tag_operations.yml
@@ -102,6 +102,7 @@
         tags:
         - tag_c: 'value 3'
           propagate_at_launch: no
+        purge_tags: true
       register: output
 
     - assert:
@@ -126,6 +127,7 @@
       ec2_asg:
         name: "{{ resource_prefix }}-asg-tag-test"
         tags: []
+        purge_tags: true
       register: add_empty
 
     - name: Get asg info
@@ -155,7 +157,6 @@
             propagate_at_launch: yes
           - snake_case: "simple_snake_case"
             propagate_at_launch: no
-        purge_tags: false
       register: add_result
 
     - name: Get asg info
@@ -188,7 +189,6 @@
             propagate_at_launch: yes
           - snake_case: "simple_snake_case"
             propagate_at_launch: no
-        purge_tags: false
       register: add_result
 
     - name: Get asg info
@@ -210,6 +210,7 @@
             propagate_at_launch: no
           - tag_b: 'val_b'
             propagate_at_launch: yes
+        purge_tags: true
       register: add_purge_result
 
     - name: Get asg info
@@ -275,7 +276,6 @@
             propagate_at_launch: no
           - Title Case: "Hello Cruel World"
             propagate_at_launch: yes
-        purge_tags: false
       register: add_result
 
     - name: Get asg info
@@ -325,6 +325,7 @@
       ec2_asg:
         name: "{{ resource_prefix }}-asg-tag-test"
         tags: []
+        purge_tags: true
       register: add_empty
 
     - name: Get asg info


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed default value of `purge_tags` to `False`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
With the addition of `purge_tags` to `ec2_asg` module #960, the default value was kept to `True` similar to many other modules in this collection and also as specified in [ansible dev guide](https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst#dealing-with-tags).

With this addition, the issue was discovered that there is a possibility of this change breaking existing playbooks for users if they don't update their playbooks and specify `purge_tags: false` where required.

This PR's change will prevent accidental breakage.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_asg