### PR TITLE
In integration tests use a common AMI rather than hard coded per test

### DIFF
--- a/tests/integration/targets/ec2_asg_instance_refresh/defaults/main.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/defaults/main.yml
@@ -2,3 +2,15 @@
 # defaults file for ec2_asg
 vpc_seed: '{{ tiny_prefix }}'
 subnet_a_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
+
+default_resource_name: '{{ resource_prefix }}-asg-refresh'
+short_resource_name: '{{ tiny_prefix }}-asg-refresh'
+
+vpc_name: '{{ default_resource_name }}'
+subnet_name: '{{ default_resource_name }}'
+route_name: '{{ default_resource_name }}'
+sg_name: '{{ default_resource_name }}'
+asg_name: '{{ default_resource_name }}'
+lc_name_1: '{{ default_resource_name }}-1'
+lc_name_2: '{{ default_resource_name }}-2'
+load_balancer_name: '{{ short_resource_name }}'

--- a/tests/integration/targets/ec2_asg_instance_refresh/defaults/main.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 # defaults file for ec2_asg
 vpc_seed: '{{ tiny_prefix }}'
-ec2_ami_name: 'amzn2-ami-hvm-2.*-x86_64-gp2'
 subnet_a_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'

--- a/tests/integration/targets/ec2_asg_instance_refresh/meta/main.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/meta/main.yml
@@ -1,4 +1,2 @@
 dependencies:
-  - prepare_tests
-  - setup_ec2
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_asg_instance_refresh/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/tasks/main.yml
@@ -11,16 +11,10 @@
     - amazon.aws
 
   block:
-
-    - name: load balancer name has to be less than 32 characters
-      set_fact:
-        load_balancer_name: "{{ item }}-lb"
-      loop: "{{ resource_prefix | regex_findall('.{8}$') }}"
-
     # Set up the testing dependencies: VPC, subnet, security group, and two launch configurations
     - name: Create VPC for use in testing
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc"
+        name: "{{ vpc_name }}"
         cidr_block: '{{ subnet_a_cidr }}'
         tenancy: default
       register: testing_vpc
@@ -38,14 +32,14 @@
         cidr: '{{ subnet_a_cidr }}'
         az: "{{ aws_region }}a"
         resource_tags:
-          Name: "{{ resource_prefix }}-subnet"
+          Name: "{{ subnet_name }}"
       register: testing_subnet
 
     - name: create routing rules
       ec2_vpc_route_table:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         tags:
-          created: "{{ resource_prefix }}-route"
+          created: "{{ route_name }}"
         routes:
           - dest: 0.0.0.0/0
             gateway_id: "{{ igw.gateway_id }}"
@@ -54,7 +48,7 @@
 
     - name: create a security group with the vpc created in the ec2_setup
       ec2_group:
-        name: "{{ resource_prefix }}-sg"
+        name: "{{ sg_name }}"
         description: a security group for ansible tests
         vpc_id: "{{ testing_vpc.vpc.id }}"
         rules:
@@ -83,13 +77,13 @@
         security_groups: "{{ sg.group_id }}"
         instance_type: t3.micro
       loop:
-        - "{{ resource_prefix }}-lc"
-        - "{{ resource_prefix }}-lc-2"
+        - "{{ lc_name_1 }}"
+        - "{{ lc_name_2 }}"
 
     - name: launch asg and do not wait for instances to be deemed healthy (no ELB)
       ec2_asg:
-        name: "{{ resource_prefix }}-asg"
-        launch_config_name: "{{ resource_prefix }}-lc"
+        name: "{{ asg_name }}"
+        launch_config_name: "{{ lc_name_1 }}"
         desired_capacity: 1
         min_size: 1
         max_size: 1
@@ -106,7 +100,7 @@
 
     - name: test invalid cancelation - V1 - (pre-refresh)
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       ignore_errors: yes
       register: result
@@ -117,7 +111,7 @@
 
     - name: test starting a refresh with a valid ASG name - check_mode
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
       check_mode: true
       register: output
@@ -130,7 +124,7 @@
 
     - name: test starting a refresh with a valid ASG name
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
       register: output
 
@@ -140,7 +134,7 @@
 
     - name: test starting a refresh with a valid ASG name - Idempotent
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
       ignore_errors: true
       register: output
@@ -152,7 +146,7 @@
 
     - name: test starting a refresh with a valid ASG name - Idempotent (check_mode)
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
       ignore_errors: true
       check_mode: true
@@ -177,7 +171,7 @@
 
     - name: test canceling a refresh with an ASG name - check_mode
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       check_mode: true
       register: output
@@ -190,7 +184,7 @@
 
     - name: test canceling a refresh with an ASG name
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       register: output
 
@@ -200,7 +194,7 @@
 
     - name: test canceling a refresh with a ASG name - Idempotent
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       ignore_errors: yes
       register: output
@@ -211,7 +205,7 @@
 
     - name: test cancelling a refresh with a valid ASG name - Idempotent (check_mode)
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       ignore_errors: true
       check_mode: true
@@ -224,7 +218,7 @@
 
     - name: test starting a refresh with an ASG name and preferences dict
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
         preferences:
           min_healthy_percentage: 10
@@ -239,7 +233,7 @@
 
     - name: re-test canceling a refresh with an ASG name
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       register: output
 
@@ -249,7 +243,7 @@
 
     - name: test valid start - V1 - (with preferences missing instance_warmup)
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
         preferences:
           min_healthy_percentage: 10
@@ -264,7 +258,7 @@
 
     - name: re-test canceling a refresh with an ASG name
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
       register: output
 
@@ -274,7 +268,7 @@
 
     - name: test valid start - V2 - (with preferences missing min_healthy_percentage)
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "started"
         preferences:
           instance_warmup: 10
@@ -289,7 +283,7 @@
 
     - name: test invalid cancelation - V2 - (with preferences)
       ec2_asg_instance_refresh:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: "cancelled"
         preferences:
           min_healthy_percentage: 10
@@ -309,7 +303,7 @@
 
     - name: test getting info for an ASG name
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         region: "{{ aws_region }}"
       ignore_errors: yes
       register: output
@@ -322,7 +316,7 @@
 
     - name: test using fake refresh ID
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         ids: ['0e367f58-blabla-bla-bla-ca870dc5dbfe']
       ignore_errors: yes
       register: output
@@ -333,7 +327,7 @@
 
     - name: test using a real refresh ID
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         ids: [ '{{ refreshout.instance_refreshes.instance_refresh_id }}' ]
       ignore_errors: yes
       register: output
@@ -354,7 +348,7 @@
 
     - name: assert that the correct number of records are returned
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
       ignore_errors: yes
       register: output
 
@@ -364,7 +358,7 @@
 
     - name: assert that valid message with fake-token is returned
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         next_token: "fake-token-123"
       ignore_errors: yes
       register: output
@@ -375,7 +369,7 @@
 
     - name: assert that max records=1 returns no more than one record
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         max_records: 1
       ignore_errors: yes
       register: output
@@ -386,7 +380,7 @@
 
     - name: assert that valid message with real-token is returned
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         next_token: "{{ output.next_token }}"
       ignore_errors: yes
       register: output
@@ -397,7 +391,7 @@
 
     - name: test using both real nextToken and max_records=1
       ec2_asg_instance_refresh_info:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         max_records: 1
         next_token: "{{ output.next_token }}"
       ignore_errors: yes
@@ -411,7 +405,7 @@
 
     - name: kill asg
       ec2_asg:
-        name: "{{ resource_prefix }}-asg"
+        name: "{{ asg_name }}"
         state: absent
       register: removed
       until: removed is not failed
@@ -454,8 +448,8 @@
       ignore_errors: yes
       retries: 10
       loop:
-        - "{{ resource_prefix }}-lc"
-        - "{{ resource_prefix }}-lc-2"
+        - "{{ lc_name_1 }}"
+        - "{{ lc_name_2 }}"
 
     - name: delete launch template
       ec2_launch_template:
@@ -468,7 +462,7 @@
 
     - name: remove the security group
       ec2_group:
-        name: "{{ resource_prefix }}-sg"
+        name: "{{ sg_name }}"
         description: a security group for ansible tests
         vpc_id: "{{ testing_vpc.vpc.id }}"
         state: absent
@@ -482,7 +476,7 @@
         state: absent
         vpc_id: "{{ testing_vpc.vpc.id }}"
         tags:
-          created: "{{ resource_prefix }}-route"
+          created: "{{ route_name }}"
         routes:
           - dest: 0.0.0.0/0
             gateway_id: "{{ igw.gateway_id }}"
@@ -514,7 +508,7 @@
 
     - name: remove the VPC
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc"
+        name: "{{ vpc_name }}"
         cidr_block: '{{ subnet_a_cidr }}'
         state: absent
       register: removed

--- a/tests/integration/targets/ec2_asg_instance_refresh/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/tasks/main.yml
@@ -441,7 +441,7 @@
 
     - name: remove launch configs
       ec2_lc:
-        name: "{{ resource_prefix }}-lc"
+        name: "{{ item }}"
         state: absent
       register: removed
       until: removed is not failed

--- a/tests/integration/targets/ec2_asg_instance_refresh/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/tasks/main.yml
@@ -12,16 +12,6 @@
 
   block:
 
-    #NOTE: entire ASG setup is 'borrowed' from ec2_asg
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: 'amazon'
-        filters:
-          name: '{{ ec2_ami_name }}'
-      register: ec2_amis
-    - set_fact:
-        ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
-
     - name: load balancer name has to be less than 32 characters
       set_fact:
         load_balancer_name: "{{ item }}-lb"
@@ -82,7 +72,7 @@
       ec2_lc:
         name: "{{ item }}"
         assign_public_ip: true
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         user_data: |
           package_upgrade: true
           package_update: true

--- a/tests/integration/targets/ec2_asg_instance_refresh/tasks/refresh_and_cancel_three_times.yml
+++ b/tests/integration/targets/ec2_asg_instance_refresh/tasks/refresh_and_cancel_three_times.yml
@@ -2,13 +2,13 @@
 
 - name: try to cancel pre-loop
   ec2_asg_instance_refresh:
-    name: "{{ resource_prefix }}-asg"
+    name: "{{ asg_name }}"
     state: "cancelled"
   ignore_errors: yes
 
 - name: test starting a refresh with an ASG name
   ec2_asg_instance_refresh:
-    name: "{{ resource_prefix }}-asg"
+    name: "{{ asg_name }}"
     state: "started"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
@@ -21,7 +21,7 @@
 
 - name: test cancelling a refresh with an ASG name
   ec2_asg_instance_refresh:
-    name: "{{ resource_prefix }}-asg"
+    name: "{{ asg_name }}"
     state: "cancelled"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"

--- a/tests/integration/targets/ec2_asg_scheduled_action/defaults/main.yml
+++ b/tests/integration/targets/ec2_asg_scheduled_action/defaults/main.yml
@@ -1,3 +1,1 @@
 ---
-# Amazon Linux 2 AMI 2.0.20211005.0 x86_64 HVM gp2
-ec2_ami_name: "amzn2-ami-hvm-2.0.20211005.0-x86_64-gp2"

--- a/tests/integration/targets/ec2_asg_scheduled_action/meta/main.yml
+++ b/tests/integration/targets/ec2_asg_scheduled_action/meta/main.yml
@@ -1,4 +1,5 @@
 dependencies:
+  - role: setup_ec2_facts
   - role: setup_botocore_pip
     vars:
       botocore_version: "1.20.24"

--- a/tests/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
+++ b/tests/integration/targets/ec2_asg_scheduled_action/tasks/main.yml
@@ -15,17 +15,6 @@
         ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       block:
         ## Set up the testing dependencies: VPC, subnet, security group, and launch configuration
-        - name: Find AMI to use
-          ec2_ami_info:
-            owners: "amazon"
-            filters:
-              name: "{{ ec2_ami_name }}"
-          register: ec2_amis
-
-        - name: Set ec2_ami_image fact
-          set_fact:
-            ec2_ami_image: "{{ ec2_amis.images[0].image_id }}"
-
         - name: Create VPC for use in testing
           ec2_vpc_net:
             name: "{{ resource_prefix }}-vpc"
@@ -63,7 +52,7 @@
           ec2_lc:
             name: "{{ resource_prefix }}-lc"
             assign_public_ip: true
-            image_id: "{{ ec2_ami_image }}"
+            image_id: "{{ ec2_ami_id }}"
             security_groups: "{{ sg.group_id }}"
             instance_type: t3.micro
 

--- a/tests/integration/targets/ec2_launch_template/defaults/main.yml
+++ b/tests/integration/targets/ec2_launch_template/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-ec2_ami_name: amzn2-ami-hvm-2.*-x86_64-gp2
 test_role_name: ansible-test-{{ tiny_prefix }}

--- a/tests/integration/targets/ec2_launch_template/meta/main.yml
+++ b/tests/integration/targets/ec2_launch_template/meta/main.yml
@@ -1,6 +1,7 @@
 dependencies:
   - prepare_tests
   - setup_ec2
+  - setup_ec2_facts
   - setup_remote_tmp_dir
   - role: setup_botocore_pip
     vars:

--- a/tests/integration/targets/ec2_launch_template/tasks/cpu_options.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/cpu_options.yml
@@ -11,7 +11,7 @@
   - name: create c4.large instance with cpu_options
     ec2_launch_template:
       name: "{{ resource_prefix }}-c4large-1-threads-per-core"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ resource_prefix }}"
       instance_type: c4.large

--- a/tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
@@ -22,7 +22,7 @@
     - name: Make instance with an instance_role
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-instance-role"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         iam_instance_profile: "{{ test_role_name }}-1"
       register: template_with_role
@@ -34,7 +34,7 @@
     - name: Create template again, with no change to instance_role
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-instance-role"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         iam_instance_profile: "{{ test_role_name }}-1"
       register: template_with_role
@@ -47,7 +47,7 @@
     - name: Update instance with new instance_role
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-instance-role"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         iam_instance_profile: "{{ test_role_name }}-2"
       register: template_with_updated_role
@@ -63,7 +63,7 @@
     - name: Re-set with same new instance_role
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-instance-role"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         iam_instance_profile: "{{ test_role_name }}-2"
       register: template_with_updated_role
@@ -76,7 +76,7 @@
     - name: Update instance with original instance_role (pass profile ARN)
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-instance-role"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         # By default an instance profile will be created with the same name as the role
         iam_instance_profile: '{{ iam_role.arn.replace(":role/", ":instance-profile/") }}'
@@ -93,7 +93,7 @@
     - name: Re-set with same new instance_role (pass profile ARN)
       ec2_launch_template:
         name: "{{ resource_prefix }}-test-instance-role"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         iam_instance_profile: '{{ iam_role.arn.replace(":role/", ":instance-profile/") }}'
       register: template_with_updated_role

--- a/tests/integration/targets/ec2_launch_template/tasks/main.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/main.yml
@@ -6,15 +6,6 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: 'amazon'
-        filters:
-          name: '{{ ec2_ami_name }}'
-      register: ec2_amis
-    - set_fact:
-        ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
-
     - include_tasks: cpu_options.yml
     - include_tasks: iam_instance_role.yml
     - include_tasks: versions.yml

--- a/tests/integration/targets/ec2_launch_template/tasks/tags_and_vpc_settings.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/tags_and_vpc_settings.yml
@@ -49,7 +49,7 @@
   - name: Make instance in the testing subnet created in the test VPC
     ec2_instance:
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       user_data: |
         #cloud-config
         package_upgrade: true
@@ -71,7 +71,7 @@
   - name: Try to re-make the instance, hopefully this shows changed=False
     ec2_instance:
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       user_data: |
         #cloud-config
         package_upgrade: true
@@ -96,7 +96,7 @@
   - name: Alter it by adding tags
     ec2_instance:
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ resource_prefix }}"
         Another: thing
@@ -117,7 +117,7 @@
   - name: Purge a tag
     ec2_instance:
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       purge_tags: true
       tags:
         TestId: "{{ resource_prefix }}"

--- a/tests/integration/targets/ec2_launch_template/tasks/versions.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/versions.yml
@@ -2,7 +2,7 @@
   - name: create simple instance template
     ec2_launch_template:
       name: "{{ resource_prefix }}-simple"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ resource_prefix }}"
       instance_type: c4.large
@@ -20,7 +20,7 @@
     ec2_launch_template:
       name: "{{ resource_prefix }}-simple"
       default_version: 1
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ resource_prefix }}"
       instance_type: m5.large
@@ -37,7 +37,7 @@
   - name: update simple instance template
     ec2_launch_template:
       name: "{{ resource_prefix }}-simple"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ resource_prefix }}"
       instance_type: t3.medium

--- a/tests/integration/targets/ec2_lc/defaults/main.yml
+++ b/tests/integration/targets/ec2_lc/defaults/main.yml
@@ -3,5 +3,4 @@
 ec2_instance_name: '{{ resource_prefix }}-node'
 ec2_instance_owner: 'integration-run-{{ resource_prefix }}'
 ec2_instance_type: t2.micro
-ec2_ami_name: "amzn-ami-hvm*"
 alarm_prefix: "ansible-test"

--- a/tests/integration/targets/ec2_metric_alarm/defaults/main.yml
+++ b/tests/integration/targets/ec2_metric_alarm/defaults/main.yml
@@ -2,5 +2,4 @@
 # defaults file for ec2_instance
 ec2_instance_name: '{{ resource_prefix }}-node'
 ec2_instance_owner: 'integration-run-{{ resource_prefix }}'
-ec2_ami_name: "amzn-ami-hvm*"
 alarm_prefix: "ansible-test"

--- a/tests/integration/targets/ec2_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/ec2_metric_alarm/tasks/main.yml
@@ -24,19 +24,10 @@
         AWS_DEFAULT_REGION: "{{ aws_region }}"
       register: alarm_info_query
 
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: "amazon"
-        filters:
-          name: "{{ ec2_ami_name }}"
-      register: ec2_amis
-    - set_fact:
-        ec2_ami_image: "{{ ec2_amis.images[0].image_id }}"
-
     - name: Make instance in a default subnet of the VPC
       ec2_instance:
         name: "{{ resource_prefix }}-test-default-vpc"
-        image_id: "{{ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         security_groups: "{{ sg.group_id }}"

--- a/tests/integration/targets/ec2_scaling_policy/defaults/main.yml
+++ b/tests/integration/targets/ec2_scaling_policy/defaults/main.yml
@@ -1,3 +1,2 @@
 scaling_policy_lc_name: "{{ resource_prefix }}_lc"
 scaling_policy_asg_name: "{{ resource_prefix }}_asg"
-ec2_ami_name: 'amzn2-ami-hvm-2.*-x86_64-gp2'

--- a/tests/integration/targets/ec2_scaling_policy/meta/main.yml
+++ b/tests/integration/targets/ec2_scaling_policy/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_ec2
+  - setup_ec2_facts

--- a/tests/integration/targets/ec2_scaling_policy/tasks/main.yml
+++ b/tests/integration/targets/ec2_scaling_policy/tasks/main.yml
@@ -19,25 +19,12 @@
     - amazon.aws
   block:
 
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: 'amazon'
-        filters:
-          name: '{{ ec2_ami_name }}'
-      register: ec2_amis
-
-    - name: Set fact with latest AMI
-      vars:
-        latest_ami: '{{ ec2_amis.images | sort(attribute="creation_date") | last }}'
-      set_fact:
-        scaling_policy_image_id: '{{ latest_ami.image_id }}'
-
     - name: create trivial launch_configuration
       ec2_lc:
         name: "{{ scaling_policy_lc_name }}"
         state: present
         instance_type: t3.nano
-        image_id: "{{ scaling_policy_image_id }}"
+        image_id: "{{ ec2_ami_id }}"
 
     - name: create trivial ASG
       ec2_asg:

--- a/tests/integration/targets/elb_network_lb/meta/main.yml
+++ b/tests/integration/targets/elb_network_lb/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_ec2
+  - setup_ec2_facts

--- a/tests/integration/targets/elb_network_lb/tasks/test_nlb_with_asg.yml
+++ b/tests/integration/targets/elb_network_lb/tasks/test_nlb_with_asg.yml
@@ -1,18 +1,6 @@
 - block:
 
     # create instances
-
-    - ec2_ami_info:
-        filters:
-          architecture: x86_64
-          virtualization-type: hvm
-          root-device-type: ebs
-          name: "amzn-ami-hvm*"
-      register: amis
-
-    - set_fact:
-        latest_amazon_linux: "{{ amis.images | sort(attribute='creation_date') | last }}"
-
     - ec2_asg:
         state: absent
         name: "{{ resource_prefix }}-webservers"
@@ -26,7 +14,7 @@
       ec2_lc:
         name: "{{ resource_prefix }}-web-lcfg"
         assign_public_ip: true
-        image_id: "{{ latest_amazon_linux.image_id }}"
+        image_id: "{{ ec2_ami_id }}"
         security_groups: "{{ sec_group.group_id }}"
         instance_type: t2.micro
         user_data: |

--- a/tests/integration/targets/elb_target/defaults/main.yml
+++ b/tests/integration/targets/elb_target/defaults/main.yml
@@ -7,7 +7,6 @@ lambda_name: '{{ unique_id }}-elb-target'
 elb_target_group_name: "{{ unique_id }}-elb"
 
 # Defaults used by the EC2 based test
-ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
 tg_name: "{{ unique_id }}-tg"
 tg_used_name: "{{ unique_id }}-tgu"
 tg_tcpudp_name: "{{ unique_id }}-udp"

--- a/tests/integration/targets/elb_target/meta/main.yml
+++ b/tests/integration/targets/elb_target/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_ec2
+  - setup_ec2_facts

--- a/tests/integration/targets/elb_target/tasks/ec2_target.yml
+++ b/tests/integration/targets/elb_target/tasks/ec2_target.yml
@@ -7,14 +7,6 @@
       debug: msg="********** Setting up elb_target EC2 test dependencies **********"
 
     # ============================================================
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: "amazon"
-        filters:
-          name: "{{ ec2_ami_name }}"
-      register: ec2_amis
-    - set_fact:
-        ec2_ami_image: "{{ ec2_amis.images[0].image_id }}"
 
     - name: set up testing VPC
       ec2_vpc_net:
@@ -166,7 +158,7 @@
         name: "{{ resource_prefix }}-inst"
         security_group: "{{ sg.group_id }}"
         instance_type: t3.micro
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         vpc_subnet_id: "{{ subnet_2.subnet.id }}"
         network:
           assign_public_ip: true

--- a/tests/integration/targets/elb_target_info/defaults/main.yml
+++ b/tests/integration/targets/elb_target_info/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
-ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
-
 tg_name: "ansible-test-{{ resource_prefix | regex_search('([0-9]+)$') }}-tg"
 lb_name: "ansible-test-{{ resource_prefix | regex_search('([0-9]+)$') }}-lb"

--- a/tests/integration/targets/elb_target_info/meta/main.yml
+++ b/tests/integration/targets/elb_target_info/meta/main.yml
@@ -1,4 +1,2 @@
 dependencies:
-  - prepare_tests
-  - setup_ec2
   - setup_ec2_facts

--- a/tests/integration/targets/elb_target_info/tasks/main.yml
+++ b/tests/integration/targets/elb_target_info/tasks/main.yml
@@ -16,17 +16,6 @@
     - name:
       debug: msg="********** Setting up elb_target_info test dependencies **********"
 
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: 'amazon'
-        filters:
-          name: '{{ ec2_ami_name }}'
-      register: ec2_amis
-    - set_fact:
-        ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
-
-    # ============================================================
-
     - name: set up testing VPC
       ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
@@ -140,7 +129,7 @@
         name: "{{ resource_prefix }}-inst"
         security_group: "{{ sg.group_id }}"
         instance_type: t3.micro
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         vpc_subnet_id: "{{ subnet_2.subnet.id }}"
         network:
           assign_public_ip: true


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/1068

##### SUMMARY

Rather than hard coding the AMIs on a per-test basis, use a common AMI defined in setup_ec2_facts

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_asg_instance_refresh
ec2_asg_lifecycle_hook
ec2_asg_scheduled_action
ec2_launch_template
ec2_lc
ec2_metric_alarm
ec2_scaling_policy
elb_network_lb
elb_target
elb_target_info

##### ADDITIONAL INFORMATION