### PR TITLE
s3_lifecycle: support value '0' for transition_days

### DIFF
--- a/changelogs/fragments/1077-s3_lifecycle-transition-days-zero.yml
+++ b/changelogs/fragments/1077-s3_lifecycle-transition-days-zero.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - s3_lifecycle - add support of value *0* for ``transition_days`` (https://github.com/ansible-collections/community.aws/pull/1077).

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -314,7 +314,7 @@ def build_rule(client, module):
             t_out = dict()
             if transition.get('transition_date'):
                 t_out['Date'] = transition['transition_date']
-            elif transition.get('transition_days'):
+            elif transition.get('transition_days') is not None:
                 t_out['Days'] = transition['transition_days']
             if transition.get('storage_class'):
                 t_out['StorageClass'] = transition['storage_class'].upper()
@@ -596,7 +596,7 @@ def main():
                                  'noncurrent_version_transition_days',
                                  'noncurrent_version_transitions')
         for param in required_when_present:
-            if module.params.get(param):
+            if module.params.get(param) is None:
                 break
         else:
             msg = "one of the following is required when 'state' is 'present': %s" % ', '.join(required_when_present)

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -184,6 +184,30 @@
         that:
           - output is not changed
   # ============================================================
+    - name: Create a lifecycle policy, with glacier and transition_days to 0
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        transition_days: 0
+        storage_class: glacier
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Create a lifecycle policy, with glacier and transition_days to 0 (idempotency)
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        transition_days: 0
+        storage_class: glacier
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
     - name: Create a lifecycle policy with infrequent access
       s3_lifecycle:
         name: '{{ bucket_name }}'


### PR DESCRIPTION
##### SUMMARY
`s3_lifecycle` module does not support value *0* for **transition_days** parameter. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_lifecycle

##### ADDITIONAL INFORMATION
A lifecycle rule with *0* as **transition_days** allows to create a rule that will move objects with a delta of just few hours (if set to *1*, objects will be moved with a delta of 1d + few hours).

When the value *0* is set, the value is stripped from the query and we get an error that is hard to correlate with an "invalid"  value on this parameter (which is valid as *0* is an integer):

```
- name: Create s3 buckets lifecycle rules
  s3_lifecycle:
    ec2_url: "FIXME"
    region: "FIXME"
    aws_access_key: "FIXME"
    aws_secret_key: "FIXME"
    name: "FIXME"
    rule_id: "onezone"
    transitions:
    - transition_days: 0
      storage_class: "ONEZONE_IA"
    state: present
    status: enabled

fatal: [localhost]: FAILED! => {
    "boto3_version": "1.21.3",
    "botocore_version": "1.24.19",
    "changed": false,
    "error": {
        "code": "MalformedXML",
        "message": "Extra element Transition in interleave"
    },
    "lifecycle_configuration": {
        "Rules": [
            {
                "Filter": {
                    "Prefix": ""
                },
                "ID": "onezone",
                "Status": "Enabled",
                "Transitions": [
                    {
                        "StorageClass": "ONEZONE_IA"
                    }
                ]
            }
        ]
    },
    ...
MSG:

An error occurred (MalformedXML) when calling the PutBucketLifecycleConfiguration operation: Extra element Transition in interleave
```

This is because `transition.get('transition_days')` returns *0* which is considered as *False* on a condition (this patch just check if the value is defined; e.g. is not *None*).