### PR TITLE
aws_s3_bucket_info - remove custom botocore environment from test

### DIFF
--- a/tests/integration/targets/aws_s3_bucket_info/meta/main.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/meta/main.yml
@@ -1,4 +1,1 @@
-dependencies:
-  - prepare_tests
-  - setup_remote_tmp_dir
-  - setup_ec2
+dependencies: []

--- a/tests/integration/targets/aws_s3_bucket_info/tasks/bucket_ownership_controls.yml
+++ b/tests/integration/targets/aws_s3_bucket_info/tasks/bucket_ownership_controls.yml
@@ -1,108 +1,81 @@
 ---
-- name: Test community.aws.aws_s3_bucket_info
-  block:
-    - pip:
-        name: virtualenv
-    - set_fact:
-        virtualenv: "{{ remote_tmp_dir }}/virtualenv"
-        virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
-    - set_fact:
-        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
-    - pip:
-        name:
-          - 'boto3>=1.15.0'
-          - 'botocore==1.18.11'
-          - 'coverage<5'
-        virtualenv: '{{ virtualenv }}'
-        virtualenv_command: '{{ virtualenv_command }}'
-        virtualenv_site_packages: no
-    - name: Wrap test in virtualenv
-      vars:
-        ansible_python_interpreter: "{{ virtualenv }}/bin/python"
-      block:
+- name: Get S3 bucket ownership controls
+  aws_s3_bucket_info:
+    name_filter: "{{ name_pattern }}"
+    bucket_facts:
+      bucket_ownership_controls: true
+    transform_location: true
+  register: bucket_list
 
-        - name: Get S3 bucket ownership controls
-          aws_s3_bucket_info:
-            name_filter: "{{ name_pattern }}"
-            bucket_facts:
-              bucket_ownership_controls: true
-            transform_location: true
-          register: bucket_list
+- name: Assert that buckets list contains requested bucket facts
+  assert:
+    that:
+      - item.name is search(name_pattern)
+      - item.bucket_ownership_controls is defined
+  loop: "{{ bucket_list.buckets }}"
+  loop_control:
+    label: "{{ item.name }}"
 
-        - name: Assert that buckets list contains requested bucket facts
-          assert:
-            that:
-              - item.name is search(name_pattern)
-              - item.bucket_ownership_controls is defined
-          loop: "{{ bucket_list.buckets }}"
-          loop_control:
-            label: "{{ item.name }}"
+- name: Get complex S3 bucket list (including ownership controls)
+  aws_s3_bucket_info:
+    name_filter: "{{ name_pattern }}"
+    bucket_facts:
+      bucket_accelerate_configuration: true
+      bucket_acl: true
+      bucket_cors: true
+      bucket_encryption: true
+      bucket_lifecycle_configuration: true
+      bucket_location: true
+      bucket_logging: true
+      bucket_notification_configuration: true
+      bucket_ownership_controls: true
+      bucket_policy: true
+      bucket_policy_status: true
+      bucket_replication: true
+      bucket_request_payment: true
+      bucket_tagging: true
+      bucket_website: true
+      public_access_block: true
+    transform_location: true
+  register: bucket_list
 
-        - name: Get complex S3 bucket list (including ownership controls)
-          aws_s3_bucket_info:
-            name_filter: "{{ name_pattern }}"
-            bucket_facts:
-              bucket_accelerate_configuration: true
-              bucket_acl: true
-              bucket_cors: true
-              bucket_encryption: true
-              bucket_lifecycle_configuration: true
-              bucket_location: true
-              bucket_logging: true
-              bucket_notification_configuration: true
-              bucket_ownership_controls: true
-              bucket_policy: true
-              bucket_policy_status: true
-              bucket_replication: true
-              bucket_request_payment: true
-              bucket_tagging: true
-              bucket_website: true
-              public_access_block: true
-            transform_location: true
-          register: bucket_list
+- name: Assert that buckets list contains requested bucket facts
+  assert:
+    that:
+      - item.name is search(name_pattern)
+      - item.bucket_accelerate_configuration is defined
+      - item.bucket_acl is defined
+      - item.bucket_cors is defined
+      - item.bucket_encryption is defined
+      - item.bucket_lifecycle_configuration is defined
+      - item.bucket_location is defined
+      - item.bucket_logging is defined
+      - item.bucket_notification_configuration is defined
+      - item.bucket_ownership_controls is defined
+      - item.bucket_policy is defined
+      - item.bucket_policy_status is defined
+      - item.bucket_replication is defined
+      - item.bucket_request_payment is defined
+      - item.bucket_tagging is defined
+      - item.bucket_website is defined
+      - item.public_access_block is defined
+  loop: "{{ bucket_list.buckets }}"
+  loop_control:
+    label: "{{ item.name }}"
 
-        - name: Assert that buckets list contains requested bucket facts
-          assert:
-            that:
-              - item.name is search(name_pattern)
-              - item.bucket_accelerate_configuration is defined
-              - item.bucket_acl is defined
-              - item.bucket_cors is defined
-              - item.bucket_encryption is defined
-              - item.bucket_lifecycle_configuration is defined
-              - item.bucket_location is defined
-              - item.bucket_logging is defined
-              - item.bucket_notification_configuration is defined
-              - item.bucket_ownership_controls is defined
-              - item.bucket_policy is defined
-              - item.bucket_policy_status is defined
-              - item.bucket_replication is defined
-              - item.bucket_request_payment is defined
-              - item.bucket_tagging is defined
-              - item.bucket_website is defined
-              - item.public_access_block is defined
-          loop: "{{ bucket_list.buckets }}"
-          loop_control:
-            label: "{{ item.name }}"
-
-        - name: Assert that retrieved bucket facts contains valid data
-          assert:
-            that:
-              - item.bucket_acl.Owner is defined
-              - item.bucket_tagging.snake_case is defined
-              - item.bucket_tagging.CamelCase is defined
-              - item.bucket_tagging["lowercase spaced"] is defined
-              - item.bucket_tagging["Title Case"] is defined
-              - item.bucket_tagging.snake_case == 'simple_snake_case'
-              - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
-              - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
-              - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
-              - item.bucket_location.LocationConstraint == aws_region
-          loop: "{{ bucket_list.buckets }}"
-          loop_control:
-            label: "{{ item.name }}"
-
-  always:
-    - file:
-        path: "{{ virtualenv }}"
-        state: absent
+- name: Assert that retrieved bucket facts contains valid data
+  assert:
+    that:
+      - item.bucket_acl.Owner is defined
+      - item.bucket_tagging.snake_case is defined
+      - item.bucket_tagging.CamelCase is defined
+      - item.bucket_tagging["lowercase spaced"] is defined
+      - item.bucket_tagging["Title Case"] is defined
+      - item.bucket_tagging.snake_case == 'simple_snake_case'
+      - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
+      - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
+      - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
+      - item.bucket_location.LocationConstraint == aws_region
+  loop: "{{ bucket_list.buckets }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
##### SUMMARY

We now support botocore 1.20, there's no reason to run the tests in a custom environment

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_s3_bucket_info

##### ADDITIONAL INFORMATION
