### PR TITLE
Fixing parameter name in example.

### DIFF
--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -202,7 +202,7 @@ EXAMPLES = '''
 - name: create/update a certificate with a chain
   community.aws.aws_acm:
     certificate: "{{ lookup('file', 'cert.pem' ) }}"
-    privateKey: "{{ lookup('file', 'key.pem' ) }}"
+    private_key: "{{ lookup('file', 'key.pem' ) }}"
     name_tag: my_cert
     certificate_chain: "{{ lookup('file', 'chain.pem' ) }}"
     state: present


### PR DESCRIPTION
##### SUMMARY
Fixing parameter used in example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_acm

##### ADDITIONAL INFORMATION
Using the example as is gives in an error -
```
fatal: [localhost]: FAILED! => changed=false 
  msg: 'state is present but all of the following are missing: private_key'
```
