### PR TITLE
ec2_transit_gateway_IncorrectState: retry on IncorrectState

### DIFF
--- a/changelogs/fragments/ec2_transit_gateway_IncorrectState.yaml
+++ b/changelogs/fragments/ec2_transit_gateway_IncorrectState.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ec2_transit_gateway_IncorrectState - wait and retry if API returns an IncorrectState error.

--- a/changelogs/fragments/ec2_transit_gateway_IncorrectState.yaml
+++ b/changelogs/fragments/ec2_transit_gateway_IncorrectState.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- ec2_transit_gateway_IncorrectState - wait and retry if API returns an IncorrectState error.
+- ec2_transit_gateway - wait and retry if API returns an IncorrectState error.

--- a/plugins/modules/ec2_transit_gateway.py
+++ b/plugins/modules/ec2_transit_gateway.py
@@ -242,7 +242,11 @@ class AnsibleEc2Tgw(object):
     def __init__(self, module, results):
         self._module = module
         self._results = results
-        self._connection = self._module.client('ec2')
+        retry_decorator = AWSRetry.jittered_backoff(
+            catch_extra_error_codes=['IncorrectState'],
+        )
+        connection = module.client('ec2', retry_decorator=retry_decorator)
+        self._connection = connection
         self._check_mode = self._module.check_mode
 
     def process(self):


### PR DESCRIPTION
Do not immediately bail out in case of IncorrectState error. We now
instead wait and retry.

E.g: https://ddf1d621d7b816539203-e56a3e9170eb32404c2ff3e77b13356f.ssl.cf2.rackcdn.com/799/690df9c2d3f69323837542b96fa7318650fd5308/check/integration-community.aws-1/f30fb4f/job-output.txt
