### PR TITLE
execute_lambda - fix check mode and update RETURN docs

### DIFF
--- a/changelogs/fragments/1115-execute_lambda-checkmode-fix-update-return-docs.yml
+++ b/changelogs/fragments/1115-execute_lambda-checkmode-fix-update-return-docs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - execute_lambda - fix check mode and update RETURN documentation (https://github.com/ansible-collections/community.aws/pull/1115).

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -70,6 +70,16 @@
       - '"handler" in result.msg'
       - '"role" in result.msg'
 
+  - name: test execute lambda with no function arn or name
+    execute_lambda:
+    register: result
+    ignore_errors: true
+  - name: assert failure when called with no parameters
+    assert:
+      that:
+      - result.failed
+      - "result.msg == 'one of the following is required: name, function_arn'"
+
   - name: test state=present with security group but no vpc
     lambda:
       name: '{{ lambda_function_name }}'
@@ -122,6 +132,19 @@
       - result.configuration.tracing_config.mode == "PassThrough"
 
   # Test basic operation of Uploaded lambda
+  - name: test lambda works (check mode)
+    execute_lambda:
+      name: '{{lambda_function_name}}'
+      payload:
+        name: Mr Ansible Tests
+    register: result
+    check_mode: yes
+  - name: assert check mode works correctly
+    assert:
+      that:
+        - result.changed
+        - "'result' not in result"
+
   - name: test lambda works
     execute_lambda:
       name: '{{lambda_function_name}}'


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/1116

##### SUMMARY
- check_mode fix
- update RETURN docs to match what is actually being returned
- require one of `name`, `function_arn`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
execute_lambda

##### ADDITIONAL INFORMATION
I noticed some modules in community.aws will return data _directly_, and others will return data nested in a dict.

Example: let iam_group be the module, retrieving a key called `group_arn`, and registering the response as `response`. Some modules you would need to query `result.iam_group.group_arn`, meanwhile in others, you can `result.group_arn` (where iam_group is assumed, since its the name of the module). Do we have a preference for either method? Should we come to some sort of collection-wide consensus on which to use moving forward?
