### PR TITLE
route53: add support for GeoLocation parameter

### DIFF
--- a/changelogs/fragments/1117-route53-add_geo_location_support.yml
+++ b/changelogs/fragments/1117-route53-add_geo_location_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - route53 - add support for GeoLocation param (https://github.com/ansible-collections/amazon.aws/pull/1117).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -195,6 +195,7 @@ set:
       returned: when configured
       type: dict
       sample: { continent_code: "NA", country_code: "US", subdivision_code: "CA" }
+      version_added: 3.3.0
     health_check:
       description: health_check associated with this record.
       returned: always

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -647,14 +647,14 @@ def main():
         if geo_location.get('subdivision_code') and geo_location.get('country_code').lower() != 'us':
             module.fail_json(changed=False, msg='To use subdivision_code, you must specify country_code as US.')
 
-        #build geo_location suboptions specification
+        # Build geo_location suboptions specification
         resource_record_set['GeoLocation'] = {}
         if continent_code:
-          resource_record_set['GeoLocation']['ContinentCode'] = continent_code
+            resource_record_set['GeoLocation']['ContinentCode'] = continent_code
         if country_code:
-          resource_record_set['GeoLocation']['CountryCode'] = country_code
+            resource_record_set['GeoLocation']['CountryCode'] = country_code
         if subdivision_code:
-          resource_record_set['GeoLocation']['SubdivisionCode'] = subdivision_code
+            resource_record_set['GeoLocation']['SubdivisionCode'] = subdivision_code
 
     if command_in == 'delete' and aws_record is not None:
         resource_record_set['TTL'] = aws_record.get('TTL')

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -380,28 +380,28 @@ EXAMPLES = r'''
       - 0 issuewild ";"
       - 0 iodef "mailto:security@example.com"
 - name: Create a record with geo_location - country_code
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: 'geo-test.{{ zone_one }}'
-      identifier: "geohost@www"
-      type: A
-      value: 1.1.1.1
-      ttl: 30
-      geo_location:
-        country_code: US
+  route53:
+    state: present
+    zone: '{{ zone_one }}'
+    record: 'geo-test.{{ zone_one }}'
+    identifier: "geohost@www"
+    type: A
+    value: 1.1.1.1
+    ttl: 30
+    geo_location:
+      country_code: US
 - name: Create a record with geo_location - subdivision code
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: 'geo-test.{{ zone_one }}'
-      identifier: "geohost@www"
-      type: A
-      value: 1.1.1.1
-      ttl: 30
-      geo_location:
-        country_code: US
-        subdivision_code: TX
+  route53:
+    state: present
+    zone: '{{ zone_one }}'
+    record: 'geo-test.{{ zone_one }}'
+    identifier: "geohost@www"
+    type: A
+    value: 1.1.1.1
+    ttl: 30
+    geo_location:
+      country_code: US
+      subdivision_code: TX
 '''
 
 from operator import itemgetter

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -190,6 +190,11 @@ set:
       returned: always
       type: str
       sample: PRIMARY
+    geo_location:
+      description: geograpic location based on which Route53 resonds to DNS queries.
+      returned: when configured
+      type: dict
+      sample: { continent_code: "NA", country_code: "US", subdivision_code: "CA" }
     health_check:
       description: health_check associated with this record.
       returned: always
@@ -374,6 +379,29 @@ EXAMPLES = r'''
       - 0 issue "ca.example.net"
       - 0 issuewild ";"
       - 0 iodef "mailto:security@example.com"
+- name: Create a record with geo_location - country_code
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test.{{ zone_one }}'
+      identifier: "geohost@www"
+      type: A
+      value: 1.1.1.1
+      ttl: 30
+      geo_location:
+        country_code: US
+- name: Create a record with geo_location - subdivision code
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test.{{ zone_one }}'
+      identifier: "geohost@www"
+      type: A
+      value: 1.1.1.1
+      ttl: 30
+      geo_location:
+        country_code: US
+        subdivision_code: TX
 '''
 
 from operator import itemgetter

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -108,6 +108,29 @@ options:
         latency-based routing
       - Mutually exclusive with I(weight) and I(failover).
     type: str
+  geo_location:
+    description:
+      - Allows to control how Amazon Route 53 responds to DNS queries based on the geographic origin of the query.
+      - Two geolocation resource record sets that specify same geographic location cannot be created.
+      - Non-geolocation resource record sets that have the same values for the Name and Type elements as geolocation
+        resource record sets cannot be created.
+    suboptions:
+      continent_code:
+        description:
+          - The two-letter code for the continent.
+          - Specifying continent_code with either country_code or subdivision_code returns an InvalidInput error.
+        type: str
+      country_code:
+        description:
+          - The two-letter code for a country.
+          - Amazon Route 53 uses the two-letter country codes that are specified in ISO standard 3166-1 alpha-2 .
+        type: str
+      subdivision_code:
+        description:
+          - The two-letter code for a state of the United States.
+          - To specify subdivision_code, country_code must be set to US.
+        type: str
+    type: dict
   health_check:
     description:
       - Health check to associate with this record

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -543,7 +543,7 @@ def main():
             ('failover', 'region', 'weight'),
             ('alias', 'ttl'),
         ],
-        # failover, region and weight require identifier
+        # failover, region, weight and geo_location require identifier
         required_by=dict(
             failover=('identifier',),
             region=('identifier',),

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -118,7 +118,7 @@ options:
       continent_code:
         description:
           - The two-letter code for the continent.
-          - Specifying continent_code with either country_code or subdivision_code returns an InvalidInput error.
+          - Specifying I(continent_code) with either I(country_code) or I(subdivision_code) returns an InvalidInput error.
         type: str
       country_code:
         description:
@@ -128,9 +128,10 @@ options:
       subdivision_code:
         description:
           - The two-letter code for a state of the United States.
-          - To specify subdivision_code, country_code must be set to US.
+          - To specify I(subdivision_code), I(country_code) must be set to C(US).
         type: str
     type: dict
+    version_added: 4.0.0
   health_check:
     description:
       - Health check to associate with this record
@@ -547,6 +548,7 @@ def main():
             failover=('identifier',),
             region=('identifier',),
             weight=('identifier',),
+            geo_location=('identifier'),
         ),
     )
 
@@ -634,9 +636,6 @@ def main():
         continent_code = geo_location.get('continent_code')
         country_code = geo_location.get('country_code')
         subdivision_code = geo_location.get('subdivision_code')
-
-        if geo_location and not module.params.get('identifier'):
-            module.fail_json(changed=False, msg='To use geo_location please specify identifier.')
 
         if continent_code and (country_code or subdivision_code):
             module.fail_json(changed=False, msg='While using geo_location, continent_code is mutually exclusive with country_code and subdivision_code.')

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -667,11 +667,22 @@
       geo_location:
         continent_code: NA
     register: create_geo_continent
+  # Get resulting A record and geo_location parameters are applied
+  - name: 'get Route53 A record information'
+    route53_info:
+      type: A
+      query: record_sets
+      hosted_zone_id: '{{ z1.zone_id }}'
+      start_record_name: 'geo-test-1.{{ zone_one }}'
+      max_items: 1
+    register: result
+
   - assert:
       that:
         - create_geo_continent is changed
         - create_geo_continent is not failed
         - '"route53:ChangeResourceRecordSets" in create_geo_continent.resource_actions'
+        - result.ResourceRecordSets[0].GeoLocation.ContinentCode == "NA"
 
   - name: Create a record with geo_location - continent_code (idempotency)
     route53:
@@ -704,8 +715,7 @@
         continent_code: NA
     check_mode: true
     register: create_geo_continent_idem_check
-  - debug:
-      var: create_geo_continent_idem_check
+
   - assert:
       that:
         - create_geo_continent_idem_check is not changed
@@ -744,11 +754,21 @@
       geo_location:
         country_code: US
     register: create_geo_country
+  # Get resulting A record and geo_location parameters are applied
+  - name: 'get Route53 A record information'
+    route53_info:
+      type: A
+      query: record_sets
+      hosted_zone_id: '{{ z1.zone_id }}'
+      start_record_name: 'geo-test-2.{{ zone_one }}'
+      max_items: 1
+    register: result
   - assert:
       that:
         - create_geo_country is changed
         - create_geo_country is not failed
         - '"route53:ChangeResourceRecordSets" in create_geo_country.resource_actions'
+        - result.ResourceRecordSets[0].GeoLocation.CountryCode == "US"
 
   - name: Create a record with geo_location - country_code (idempotency)
     route53:
@@ -781,8 +801,7 @@
         country_code: US
     check_mode: true
     register: create_geo_country_idem_check
-  - debug:
-      var: create_geo_country_idem_check
+
   - assert:
       that:
         - create_geo_country_idem_check is not changed
@@ -823,11 +842,22 @@
         country_code: US
         subdivision_code: TX
     register: create_geo_subdivision
+  # Get resulting A record and geo_location parameters are applied
+  - name: 'get Route53 A record information'
+    route53_info:
+      type: A
+      query: record_sets
+      hosted_zone_id: '{{ z1.zone_id }}'
+      start_record_name: 'geo-test-3.{{ zone_one }}'
+      max_items: 1
+    register: result
   - assert:
       that:
         - create_geo_subdivision is changed
         - create_geo_subdivision is not failed
         - '"route53:ChangeResourceRecordSets" in create_geo_subdivision.resource_actions'
+        - result.ResourceRecordSets[0].GeoLocation.CountryCode == "US"
+        - result.ResourceRecordSets[0].GeoLocation.SubdivisionCode == "TX"
 
   - name: Create a record with geo_location - subdivision_code (idempotency)
     route53:
@@ -862,14 +892,12 @@
         subdivision_code: TX
     check_mode: true
     register: create_geo_subdivision_idem_check
-  - debug:
-      var: create_geo_subdivision_idem_check
+
   - assert:
       that:
         - create_geo_subdivision_idem_check is not changed
         - create_geo_subdivision_idem_check is not failed
         - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem_check.resource_actions'
-
 
 #Cleanup------------------------------------------------------
 
@@ -887,12 +915,6 @@
       geo_location:
         continent_code: NA
     ignore_errors: true
-    register: delete_geo_continent
-  - assert:
-      that:
-        - delete_geo_continent is changed
-        - delete_geo_continent is not failed
-        - '"route53:ChangeResourceRecordSets" in delete_geo_continent.resource_actions'
 
   - name: delete a record with geo_location - country_code
     route53:
@@ -906,12 +928,6 @@
       geo_location:
         country_code: US
     ignore_errors: true
-    register: delete_geo_country
-  - assert:
-      that:
-        - delete_geo_country is changed
-        - delete_geo_country is not failed
-        - '"route53:ChangeResourceRecordSets" in delete_geo_country.resource_actions'
 
   - name: delete a record with geo_location - subdivision_code
     route53:
@@ -926,12 +942,6 @@
         country_code: US
         subdivision_code: TX
     ignore_errors: true
-    register: delete_geo_subdivision
-  - assert:
-      that:
-        - delete_geo_subdivision is changed
-        - delete_geo_subdivision is not failed
-        - '"route53:ChangeResourceRecordSets" in delete_geo_subdivision.resource_actions'
 
   - route53_info:
       query: record_sets

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -635,7 +635,304 @@
         - weighted_record is not failed
         - weighted_record is not changed
 
+#Test Geo Location - Continent Code
+  - name: Create a record with geo_location - continent_code (check_mode)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-1.{{ zone_one }}'
+      identifier: "geohost1@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        continent_code: NA
+    check_mode: true
+    register: create_geo_continent_check_mode
+  - assert:
+      that:
+        - create_geo_continent_check_mode is changed
+        - create_geo_continent_check_mode is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_continent_check_mode.resource_actions'
+
+  - name: Create a record with geo_location - continent_code
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-1.{{ zone_one }}'
+      identifier: "geohost1@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        continent_code: NA
+    register: create_geo_continent
+  - assert:
+      that:
+        - create_geo_continent is changed
+        - create_geo_continent is not failed
+        - '"route53:ChangeResourceRecordSets" in create_geo_continent.resource_actions'
+
+  - name: Create a record with geo_location - continent_code (idempotency)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-1.{{ zone_one }}'
+      identifier: "geohost1@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        continent_code: NA
+    register: create_geo_continent_idem
+  - assert:
+      that:
+        - create_geo_continent_idem is not changed
+        - create_geo_continent_idem is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_continent_idem.resource_actions'
+
+  - name: Create a record with geo_location - continent_code (idempotency - check_mode)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-1.{{ zone_one }}'
+      identifier: "geohost1@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        continent_code: NA
+    check_mode: true
+    register: create_geo_continent_idem_check
+  - debug:
+      var: create_geo_continent_idem_check
+  - assert:
+      that:
+        - create_geo_continent_idem_check is not changed
+        - create_geo_continent_idem_check is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_continent_idem_check.resource_actions'
+
+#Test Geo Location - Country Code
+  - name: Create a record with geo_location - country_code (check_mode)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-2.{{ zone_one }}'
+      identifier: "geohost2@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+    check_mode: true
+    register: create_geo_country_check_mode
+  - assert:
+      that:
+        - create_geo_country_check_mode is changed
+        - create_geo_country_check_mode is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_country_check_mode.resource_actions'
+
+  - name: Create a record with geo_location - country_code
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-2.{{ zone_one }}'
+      identifier: "geohost2@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+    register: create_geo_country
+  - assert:
+      that:
+        - create_geo_country is changed
+        - create_geo_country is not failed
+        - '"route53:ChangeResourceRecordSets" in create_geo_country.resource_actions'
+
+  - name: Create a record with geo_location - country_code (idempotency)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-2.{{ zone_one }}'
+      identifier: "geohost2@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+    register: create_geo_country_idem
+  - assert:
+      that:
+        - create_geo_country_idem is not changed
+        - create_geo_country_idem is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_country_idem.resource_actions'
+
+  - name: Create a record with geo_location - country_code (idempotency - check_mode)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-2.{{ zone_one }}'
+      identifier: "geohost2@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+    check_mode: true
+    register: create_geo_country_idem_check
+  - debug:
+      var: create_geo_country_idem_check
+  - assert:
+      that:
+        - create_geo_country_idem_check is not changed
+        - create_geo_country_idem_check is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_country_idem_check.resource_actions'
+
+#Test Geo Location - Subdivision Code
+  - name: Create a record with geo_location - subdivision_code (check_mode)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-3.{{ zone_one }}'
+      identifier: "geohost3@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+        subdivision_code: TX
+    check_mode: true
+    register: create_geo_subdivision_check_mode
+  - assert:
+      that:
+        - create_geo_subdivision_check_mode is changed
+        - create_geo_subdivision_check_mode is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_check_mode.resource_actions'
+
+  - name: Create a record with geo_location - subdivision_code
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-3.{{ zone_one }}'
+      identifier: "geohost3@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+        subdivision_code: TX
+    register: create_geo_subdivision
+  - assert:
+      that:
+        - create_geo_subdivision is changed
+        - create_geo_subdivision is not failed
+        - '"route53:ChangeResourceRecordSets" in create_geo_subdivision.resource_actions'
+
+  - name: Create a record with geo_location - subdivision_code (idempotency)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-3.{{ zone_one }}'
+      identifier: "geohost3@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+        subdivision_code: TX
+    register: create_geo_subdivision_idem
+  - assert:
+      that:
+        - create_geo_subdivision_idem is not changed
+        - create_geo_subdivision_idem is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem.resource_actions'
+
+  - name: Create a record with geo_location - subdivision_code (idempotency - check_mode)
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'geo-test-3.{{ zone_one }}'
+      identifier: "geohost3@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+        subdivision_code: TX
+    check_mode: true
+    register: create_geo_subdivision_idem_check
+  - debug:
+      var: create_geo_subdivision_idem_check
+  - assert:
+      that:
+        - create_geo_subdivision_idem_check is not changed
+        - create_geo_subdivision_idem_check is not failed
+        - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem_check.resource_actions'
+
+
+#Cleanup------------------------------------------------------
+
   always:
+
+  - name: delete a record with geo_location - continent_code
+    route53:
+      state: absent
+      zone: '{{ zone_one }}'
+      record: 'geo-test-1.{{ zone_one }}'
+      identifier: "geohost1@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        continent_code: NA
+    ignore_errors: true
+    register: delete_geo_continent
+  - assert:
+      that:
+        - delete_geo_continent is changed
+        - delete_geo_continent is not failed
+        - '"route53:ChangeResourceRecordSets" in delete_geo_continent.resource_actions'
+
+  - name: delete a record with geo_location - country_code
+    route53:
+      state: absent
+      zone: '{{ zone_one }}'
+      record: 'geo-test-2.{{ zone_one }}'
+      identifier: "geohost2@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+    ignore_errors: true
+    register: delete_geo_country
+  - assert:
+      that:
+        - delete_geo_country is changed
+        - delete_geo_country is not failed
+        - '"route53:ChangeResourceRecordSets" in delete_geo_country.resource_actions'
+
+  - name: delete a record with geo_location - subdivision_code
+    route53:
+      state: absent
+      zone: '{{ zone_one }}'
+      record: 'geo-test-3.{{ zone_one }}'
+      identifier: "geohost3@www"
+      type: A
+      value: 127.0.0.1
+      ttl: 30
+      geo_location:
+        country_code: US
+        subdivision_code: TX
+    ignore_errors: true
+    register: delete_geo_subdivision
+  - assert:
+      that:
+        - delete_geo_subdivision is changed
+        - delete_geo_subdivision is not failed
+        - '"route53:ChangeResourceRecordSets" in delete_geo_subdivision.resource_actions'
+
   - route53_info:
       query: record_sets
       hosted_zone_id: '{{ z1.zone_id }}'
@@ -737,7 +1034,7 @@
       state: absent
       zone: '{{ zone_one }}'
     register: delete_one
-    ignore_errors: yes
+    ignore_errors: true
     retries: 10
     until: delete_one is not failed
 
@@ -746,7 +1043,7 @@
       state: absent
       zone: '{{ zone_two }}'
     register: delete_two
-    ignore_errors: yes
+    ignore_errors: True
     retries: 10
     until: delete_two is not failed
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for `GeoLocation` parameter to `community.aws.route53`
Fixes #89.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Uses [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53.html#Route53.Client.change_resource_record_sets](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53.html#Route53.Client.change_resource_record_sets)