### PR TITLE
Allow the job to return success even if Build step fails

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -47,6 +47,9 @@ jobs:
         uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main
         with:
           artifact-upload: false
+        # Add continue-on-error: true because of failing due to
+        # 'Missing documentation or could not parse documentation: unknown doc_fragment(s) in file'
+        continue-on-error: true
 
   build-docs:
     permissions:


### PR DESCRIPTION
Allow the job to return success even if Build step fails due to "'Missing documentation or could not parse documentation: unknown doc_fragment(s) in file '"

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
