### PR TITLE
Backport stable-3: Add missing `elements` option to type: list that did not specify

### DIFF
--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -558,6 +558,7 @@ options:
                 restriction should apply to.
               - 'See the ISO website for a full list of codes U(https://www.iso.org/obp/ui/#search/code/).'
               type: list
+              elements: str
 
     web_acl_id:
       description:

--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -88,6 +88,7 @@ options:
                     - This parameter is only supported if I(network_mode=bridge).
                 required: False
                 type: list
+                elements: str
             portMappings:
                 description: The list of port mappings for the container.
                 required: False
@@ -118,9 +119,10 @@ options:
                 required: False
                 type: str
             command:
-                description: The command that is passed to the container.
+                description: The command that is passed to the container. If there are multiple arguments, each argument is a separated string in the array.
                 required: False
                 type: list
+                elements: str
             environment:
                 description: The environment variables to pass to a container.
                 required: False
@@ -210,6 +212,7 @@ options:
                                           "NET_ADMIN", "NET_BIND_SERVICE", "NET_BROADCAST", "NET_RAW", "SETFCAP", "SETGID", "SETPCAP", "SETUID",
                                           "SYS_ADMIN", "SYS_BOOT", "SYS_CHROOT", "SYS_MODULE", "SYS_NICE", "SYS_PACCT", "SYS_PTRACE", "SYS_RAWIO",
                                           "SYS_RESOURCE", "SYS_TIME", "SYS_TTY_CONFIG", "SYSLOG", "WAKE_ALARM"]
+                                elements: str
                             drop:
                                 description:
                                     - The Linux capabilities for the container that have been removed from the default configuration provided by Docker.
@@ -220,6 +223,7 @@ options:
                                           "NET_ADMIN", "NET_BIND_SERVICE", "NET_BROADCAST", "NET_RAW", "SETFCAP", "SETGID", "SETPCAP", "SETUID",
                                           "SYS_ADMIN", "SYS_BOOT", "SYS_CHROOT", "SYS_MODULE", "SYS_NICE", "SYS_PACCT", "SYS_PTRACE", "SYS_RAWIO",
                                           "SYS_RESOURCE", "SYS_TIME", "SYS_TTY_CONFIG", "SYSLOG", "WAKE_ALARM"]
+                                elements: str
                     devices:
                         description:
                             - Any host devices to expose to the container.
@@ -240,6 +244,7 @@ options:
                                 description: The explicit permissions to provide to the container for the device.
                                 required: False
                                 type: list
+                                elements: str
                     initProcessEnabled:
                         description: Run an init process inside the container that forwards signals and reaps processes.
                         required: False
@@ -274,6 +279,7 @@ options:
                                           "remount", "mand", "nomand", "atime", "noatime", "diratime", "nodiratime", "bind", "rbind", "unbindable",
                                           "runbindable", "private", "rprivate", "shared", "rshared", "slave", "rslave", "relatime", "norelatime",
                                           "strictatime", "nostrictatime", "mode", "uid", "gid", "nr_inodes", "nr_blocks", "mpol"]
+                                elements: str
                     maxSwap:
                         description:
                             - The total amount of swap memory (in MiB) a container can use.
@@ -359,12 +365,14 @@ options:
                     - This parameter is not supported for Windows containers.
                 required: False
                 type: list
+                elements: str
             dnsSearchDomains:
                 description:
                     - A list of DNS search domains that are presented to the container.
                     - This parameter is not supported for Windows containers.
                 required: False
                 type: list
+                elements: str
             extraHosts:
                 description:
                     - A list of hostnames and IP address mappings to append to the /etc/hosts file on the container.
@@ -387,6 +395,7 @@ options:
                     - This parameter is not supported for Windows containers.
                 required: False
                 type: list
+                elements: str
             interactive:
                 description:
                     - When I(interactive=True), it allows to deploy containerized applications that require stdin or a tty to be allocated.
@@ -461,12 +470,29 @@ options:
                 description: A list of namespaced kernel parameters to set in the container.
                 required: False
                 type: list
+                elements: dict
+                suboptions:
+                    namespace:
+                        description: The namespaced kernel parameter to set a C(value) for.
+                        type: str
+                    value:
+                        description: The value for the namespaced kernel parameter that's specified in C(namespace).
+                        type: str
             resourceRequirements:
                 description:
                     - The type and amount of a resource to assign to a container.
-                    - The only supported resource is a C(GPU).
+                    - The only supported resources are C(GPU) and C(InferenceAccelerator).
                 required: False
                 type: list
+                elements: dict
+                suboptions:
+                    value:
+                        description: The value for the specified resource type.
+                        type: str
+                    type:
+                        description: The type of resource to assign to a container.
+                        type: str
+                        choices: ['GPU', 'InferenceAccelerator']
     network_mode:
         description:
             - The Docker networking mode to use for the containers in the task.

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -134,12 +134,14 @@ options:
                 Conditions:
                     type: list
                     description: Conditions which must be met for the actions to be applied.
+                    elements: dict
                 Priority:
                     type: int
                     description: The rule priority.
                 Actions:
                     type: list
                     description: Actions to apply if all of the rule's conditions are met.
+                    elements: dict
   name:
     description:
       - The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric

--- a/plugins/modules/rds_option_group.py
+++ b/plugins/modules/rds_option_group.py
@@ -70,6 +70,7 @@ options:
             description: The option settings to include in an option group.
             required: false
             type: list
+            elements: dict
             suboptions:
                 name:
                     description: The name of the option that has settings that you can set.
@@ -111,10 +112,12 @@ options:
             description: A list of C(DBSecurityGroupMembership) name strings used for this option.
             required: false
             type: list
+            elements: str
         vpc_security_group_memberships:
             description: A list of C(VpcSecurityGroupMembership) name strings used for this option.
             required: false
             type: list
+            elements: str
   tags:
     description:
       - A dictionary of key value pairs to assign the option group.


### PR DESCRIPTION
Reviewed-by: Alina Buzachis <None>
Reviewed-by: Jill R <None>
(cherry picked from commit c1d47ddaa20f847c4e36b6410f2a4cfa501112d8)

##### SUMMARY
Manually backport milestone sanity fixes to stable-3.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

- cloudfront_distribution
- ecs_taskdefinition
- elb_application_lb
- rds_option_group
