### PR TITLE
ec2_transit_gateway_vpc_attachment - retry on IncorrectState

### DIFF
--- a/plugins/module_utils/transitgateway.py
+++ b/plugins/module_utils/transitgateway.py
@@ -103,7 +103,23 @@ class TGWAttachmentBoto3Mixin(Boto3Mixin):
         return attachment
 
 
-class TransitGatewayVpcAttachmentManager(TGWAttachmentBoto3Mixin, BaseEc2Manager):
+class BaseTGWManager(BaseEc2Manager):
+
+    @Boto3Mixin.aws_error_handler('connect to AWS')
+    def _create_client(self, client_name='ec2'):
+        if client_name == 'ec2':
+            error_codes = ['IncorrectState']
+        else:
+            error_codes = []
+
+        retry_decorator = AWSRetry.jittered_backoff(
+            catch_extra_error_codes=error_codes,
+        )
+        client = self.module.client(client_name, retry_decorator=retry_decorator)
+        return client
+
+
+class TransitGatewayVpcAttachmentManager(TGWAttachmentBoto3Mixin, BaseTGWManager):
 
     TAG_RESOURCE_TYPE = 'transit-gateway-attachment'
 


### PR DESCRIPTION
##### SUMMARY

Follows on from #1110 - to retry ec2_transit_gateway_vpc_attachment failures

Doing this separately because it's not in the stable-3 branch.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_transit_gateway_vpc_attachment

##### ADDITIONAL INFORMATION
