### PR TITLE
aws_secret - Support purge_tags

### DIFF
--- a/changelogs/fragments/1146-aws_secret-purge_tags.yml
+++ b/changelogs/fragments/1146-aws_secret-purge_tags.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+- aws_secret - tags are no longer removed when the ``tags`` parameter is not set.  To remove all tags set ``tags={}`` (https://github.com/ansible-collections/community.aws/issues/1146).
+minor_changes:
+- aws_secret - addition of the ``purge_tags`` parameter (https://github.com/ansible-collections/community.aws/issues/1146).

--- a/plugins/modules/aws_secret.py
+++ b/plugins/modules/aws_secret.py
@@ -119,12 +119,17 @@ secret:
   type: complex
   contains:
     arn:
-      description: The ARN of the secret
+      description: The ARN of the secret.
       returned: always
       type: str
       sample: arn:aws:secretsmanager:eu-west-1:xxxxxxxxxx:secret:xxxxxxxxxxx
+    description:
+      description: A description of the secret.
+      returned: when the secret has a description
+      type: str
+      sample: An example description
     last_accessed_date:
-      description: The date the secret was last accessed
+      description: The date the secret was last accessed.
       returned: always
       type: str
       sample: '2018-11-20T01:00:00+01:00'
@@ -148,6 +153,29 @@ secret:
       returned: always
       type: dict
       sample: { "dc1ed59b-6d8e-4450-8b41-536dfe4600a9": [ "AWSCURRENT" ] }
+    tags:
+      description:
+        - A list of dictionaries representing the tags associated with the secret in the standard boto3 format.
+      returned: when the secret has tags
+      type: list
+      elements: dict
+      contains:
+        key:
+          description: The name or key of the tag.
+          type: str
+          example: MyTag
+          returned: success
+        value:
+          description: The value of the tag.
+          type: str
+          example: Some value.
+          returned: success
+    tags_dict:
+      description: A dictionary representing the tags associated with the secret.
+      type: dict
+      returned: when the secret has tags
+      example: {'MyTagName': 'Some Value'}
+      version_added: 4.0.0
 '''
 
 from ansible.module_utils._text import to_bytes

--- a/plugins/modules/aws_secret.py
+++ b/plugins/modules/aws_secret.py
@@ -71,6 +71,8 @@ options:
       to match exactly what is defined by I(tags) parameter.
     type: bool
     required: false
+    default: true
+    version_added: 4.0.0
   rotation_lambda:
     description:
     - Specifies the ARN of the Lambda function that can rotate the secret.
@@ -476,8 +478,8 @@ def main():
                     secrets_mgr.untag_secret(secret.name, tags_to_remove)
                     changed = True
         result = camel_dict_to_snake_dict(secrets_mgr.get_secret(secret.name))
-        if result.get('tags', None):
-            result['tags_dict'] = boto3_tag_list_to_ansible_dict(result.get('tags'))
+        if result.get('tags', None) is not None:
+            result['tags_dict'] = boto3_tag_list_to_ansible_dict(result.get('tags', []))
         result.pop("response_metadata")
 
     module.exit_json(changed=changed, secret=result)

--- a/tests/integration/targets/aws_secret/defaults/main.yaml
+++ b/tests/integration/targets/aws_secret/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
 super_secret_string: 'Test12345'
 secret_manager_role: "{{ resource_prefix }}-secrets-manager"
-secret_name: "{{ resource_prefix }}-test-secret-string"
-lambda_name: "{{ resource_prefix }}-hello-world"
+secret_name: "{{ resource_prefix }}-secrets-manager-secret"
+lambda_name: "{{ resource_prefix }}-secrets-manager-secret"

--- a/tests/integration/targets/aws_secret/tasks/basic.yml
+++ b/tests/integration/targets/aws_secret/tasks/basic.yml
@@ -1,5 +1,32 @@
 ---
-- block:
+
+- vars:
+    first_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      'New Key with Spaces': Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+    final_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+  block:
   # ============================================================
   #   Preparation
   # ============================================================
@@ -101,6 +128,7 @@
       state: present
       secret_type: 'string'
       secret: "{{ super_secret_string }}"
+      tags: {}
     register: result
 
   - name: assert correct keys are returned

--- a/tests/integration/targets/aws_secret/tasks/basic.yml
+++ b/tests/integration/targets/aws_secret/tasks/basic.yml
@@ -1,4 +1,23 @@
 ---
+############################################################
+# This Integration test is currently very minimal
+# It would be good if someone would update the tests to run through the standard 4-step checks for
+# all of the module parameters
+#
+# 1) Set Value (Check mode)
+#     - changed is True
+#     - object *NOT* updated
+# 2) Set Value
+#     - changed is True
+#     - object updated
+# 3) Set same Value (Check mode)
+#     - changed is False
+#     - object *NOT* updated
+#     - Tests idemoptency
+# 4) Set same Value
+#     - changed is False
+#     - object *NOT* updated
+#     - Tests idemoptency
 
 - vars:
     first_tags:
@@ -32,25 +51,17 @@
   # ============================================================
   - name: 'Retrieve caller facts'
     aws_caller_info:
-    register: aws_caller_info
+    register: caller_info
+
+  - name: 'Generate the ARN pattern to search for'
+    vars:
+      _caller_info: '{{ caller_info.arn.split(":") }}'
+      _base_arn: 'arn:{{_caller_info[1]}}:secretsmanager:{{ aws_region }}'
+    set_fact:
+      account_arn: '{{_base_arn}}:{{_caller_info[4]}}:secret:'
 
   # ============================================================
-  # Module parameter testing
-  # ============================================================
-  - name: test with no parameters
-    aws_secret:
-    register: result
-    ignore_errors: true
-    check_mode: true
-
-  - name: assert failure when called with no parameters
-    assert:
-      that:
-         - result.failed
-         - 'result.msg.startswith("missing required arguments:")'
-
-  # ============================================================
-  # Creation/Deletion testing
+  # Creation testing
   # ============================================================
   - name: add secret to AWS Secrets Manager
     aws_secret:
@@ -64,10 +75,20 @@
     assert:
       that:
         - result.changed
-        - result.arn is not none
-        - result.name is not none
-        - result.tags is not none
-        - result.version_ids_to_stages is not none
+        - '"arn" in result.secret'
+        # - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.arn.startswith(account_arn)
+        # ARN includes a random string after the name
+        - secret_name in result.secret.arn
+        - result.secret.name == secret_name
+        - result.secret.version_ids_to_stages | length == 1
+
+  - name: save the ARN for later comparison
+    set_fact:
+      secret_arn: '{{ result.secret.arn }}'
 
   - name: no changes to secret
     aws_secret:
@@ -81,9 +102,17 @@
     assert:
       that:
         - not result.changed
-        - result.arn is not none
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.version_ids_to_stages | length == 1
 
-  - name: make change to secret
+  - name: Set secret description
     aws_secret:
       name: "{{ secret_name }}"
       description: 'this is a change to this secret'
@@ -92,36 +121,375 @@
       secret: "{{ super_secret_string }}"
     register: result
 
-  - debug:
-      var: result
-
   - name: assert correct keys are returned
     assert:
       that:
         - result.changed
-        - result.arn is not none
-        - result.name is not none
-        - result.tags is not none
-        - result.version_ids_to_stages is not none
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.version_ids_to_stages | length == 2
 
-  - name: add tags to secret
+  ###############################################################
+  # Tagging
+  ###############################################################
+
+  - name: Set tags (CHECK_MODE)
     aws_secret:
       name: "{{ secret_name }}"
       description: 'this is a change to this secret'
       state: present
       secret_type: 'string'
       secret: "{{ super_secret_string }}"
-      tags:
-        Foo: 'Bar'
-        Test: 'Tag'
+      tags: "{{ first_tags }}"
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is changed
+
+  - name: Set tags
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ first_tags }}"
     register: result
 
   - name: assert correct keys are returned
     assert:
       that:
-        - result.changed
+        - result is changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 4
+        - result.secret.tags_dict == first_tags
+        - result.secret.version_ids_to_stages | length == 2
 
-  - name: remove tags from secret
+  - name: Set tags - idempotency (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ first_tags }}"
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is not changed
+
+  - name: Set tags - idempotency
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ first_tags }}"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is not changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 4
+        - result.secret.tags_dict == first_tags
+        - result.secret.version_ids_to_stages | length == 2
+
+  ###
+
+  - name: Update tags with purge (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ second_tags }}"
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is changed
+
+  - name: Update tags with purge
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ second_tags }}"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 4
+        - result.secret.tags_dict == second_tags
+        - result.secret.version_ids_to_stages | length == 2
+
+  - name: Update tags with purge - idempotency (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ second_tags }}"
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is not changed
+
+  - name: Update tags with purge - idempotency
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ second_tags }}"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is not changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 4
+        - result.secret.tags_dict == second_tags
+        - result.secret.version_ids_to_stages | length == 2
+
+  ###
+
+  - name: Update tags without purge (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ third_tags }}"
+      purge_tags: false
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is changed
+
+  - name: Update tags without purge
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ third_tags }}"
+      purge_tags: false
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 8
+        - result.secret.tags_dict == final_tags
+        - result.secret.version_ids_to_stages | length == 2
+
+  - name: Update tags without purge - idempotency (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ third_tags }}"
+      purge_tags: false
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is not changed
+
+  - name: Update tags without purge - idempotency
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: "{{ third_tags }}"
+      purge_tags: false
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is not changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 8
+        - result.secret.tags_dict == final_tags
+        - result.secret.version_ids_to_stages | length == 2
+
+  ###
+
+  - name: Tags not set - idempotency (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+    register: result
+    check_mode: True
+
+  - name: assert changed
+    assert:
+      that:
+        - result is not changed
+
+  - name: Tags not set - idempotency
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is not changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 8
+        - result.secret.tags_dict == final_tags
+        - result.secret.version_ids_to_stages | length == 2
+
+  ###
+
+  - name: remove all tags from secret (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: {}
+    register: result
+    check_mode: true
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is changed
+
+  - name: remove all tags from secret
     aws_secret:
       name: "{{ secret_name }}"
       description: 'this is a change to this secret'
@@ -134,7 +502,72 @@
   - name: assert correct keys are returned
     assert:
       that:
-        - result.changed
+        - result is changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 0
+        - result.secret.tags_dict | length == 0
+        - result.secret.version_ids_to_stages | length == 2
+
+  - name: remove all tags from secret - idempotency (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: {}
+    register: result
+    check_mode: true
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result is not changed
+
+  - name: remove all tags from secret
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+      tags: {}
+    register: result
+
+  - name: assert correct keys are returned - idempotency
+    assert:
+      that:
+        - result is not changed
+        - '"arn" in result.secret'
+        - '"created_date" in result.secret'
+        - '"description" in result.secret'
+        - '"last_accessed_date" in result.secret'
+        - '"last_changed_date" in result.secret'
+        - '"name" in result.secret'
+        - '"tags" in result.secret'
+        - '"tags_dict" in result.secret'
+        - '"version_ids_to_stages" in result.secret'
+        - result.secret.description == "this is a change to this secret"
+        - result.secret.arn == secret_arn
+        - result.secret.name == secret_name
+        - result.secret.tags | length == 0
+        - result.secret.tags_dict | length == 0
+        - result.secret.version_ids_to_stages | length == 2
+
+  ###############################################################
+  # Resource policy
+  ###############################################################
 
   - name: add resource policy to secret
     aws_secret:
@@ -178,6 +611,10 @@
     assert:
       that:
         - not result.changed
+
+  # ============================================================
+  # Removal testing
+  # ============================================================
 
   - name: remove secret
     aws_secret:

--- a/tests/integration/targets/aws_secret/templates/secret-policy.j2
+++ b/tests/integration/targets/aws_secret/templates/secret-policy.j2
@@ -3,7 +3,7 @@
   "Statement" : [ {
     "Effect" : "Allow",
     "Principal" : {
-      "AWS" : "arn:aws:iam::{{ aws_caller_info.account }}:root"
+      "AWS" : "arn:aws:iam::{{ caller_info.account }}:root"
     },
     "Action" : "secretsmanager:*",
     "Resource" : "*"


### PR DESCRIPTION
##### SUMMARY

aws_secret currently defaults to purging all tags (even if tags isn't specified), this is a little aggressive.

1) Add purge_tags parameter
2) Only purge tags if `tags: {}` is set (rather than when `tags is None`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_secret

##### ADDITIONAL INFORMATION

Related to #1146 