### PR TITLE
lambda_info - refactor to fix bug when querying all lambdas

### DIFF
--- a/changelogs/fragments/1152-lambda_info-bugfix-all-lambdas.yml
+++ b/changelogs/fragments/1152-lambda_info-bugfix-all-lambdas.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lambda_info - fix bug that forces query=config when getting info for all lambdas (https://github.com/ansible-collections/community.aws/pull/1152).

--- a/changelogs/fragments/1152-lambda_info-bugfix-all-lambdas.yml
+++ b/changelogs/fragments/1152-lambda_info-bugfix-all-lambdas.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - lambda_info - fix bug that forces query=config when getting info for all lambdas. Now, if function name is specified, query will default to all.
+  - lambda_info - fix bug that forces query=config when getting info for all lambdas. Now, if function name is specified, query will default to all.  This may have a performance impact when querying a large number of lambdas.
     If function name is not specified, query will default to config (https://github.com/ansible-collections/community.aws/pull/1152).

--- a/changelogs/fragments/1152-lambda_info-bugfix-all-lambdas.yml
+++ b/changelogs/fragments/1152-lambda_info-bugfix-all-lambdas.yml
@@ -1,2 +1,3 @@
 bugfixes:
-  - lambda_info - fix bug that forces query=config when getting info for all lambdas (https://github.com/ansible-collections/community.aws/pull/1152).
+  - lambda_info - fix bug that forces query=config when getting info for all lambdas. Now, if function name is specified, query will default to all.
+    If function name is not specified, query will default to config (https://github.com/ansible-collections/community.aws/pull/1152).

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -154,14 +154,15 @@ def list_lambdas(client, module):
     :return dict:
     """
 
-    # Function name is specified - retrieve info on that function
     function_name = module.params.get('function_name')
     if function_name:
+        # Function name is specified - retrieve info on that function
         function_names = [function_name]
 
-    # Function name is not specified - retrieve all function names
-    all_function_info = _paginate(client, 'list_functions')['Functions']
-    function_names = [function_info['FunctionName'] for function_info in all_function_info]
+    else:
+        # Function name is not specified - retrieve all function names
+        all_function_info = _paginate(client, 'list_functions')['Functions']
+        function_names = [function_info['FunctionName'] for function_info in all_function_info]
 
     query = module.params['query']
     lambdas = dict()
@@ -194,7 +195,6 @@ def list_lambdas(client, module):
 
         elif query == 'tags':
             lambdas[function_name].update(tags_details(client, module, function_name))
-
 
     return lambdas
 
@@ -289,7 +289,7 @@ def version_details(client, module, function_name):
     except is_boto3_error_code('ResourceNotFoundException'):
         lambda_info.update(versions=[])
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
-            module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
+        module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
 
     return camel_dict_to_snake_dict(lambda_info)
 

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -549,11 +549,19 @@
       - result is not failed
 
   always:
-  - name: ensure function is absent at end of test
+
+  - name: ensure functions are absent at end of test
     lambda:
-      name: '{{lambda_function_name}}'
+      name: "{{ item }}"
       state: absent
     ignore_errors: true
+    with_items:
+      - "{{ lambda_function_name }}"
+      - "{{ lambda_function_name }}_1"
+      - "{{ lambda_function_name }}_2"
+      - "{{ lambda_function_name }}_3"
+      - "{{ lambda_function_name }}_4"
+
   - name: ensure role has been removed at end of test
     iam_role:
       name: '{{ lambda_role_name }}'

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -255,6 +255,7 @@
   # Test lambda_info
   - name: lambda_info | Gather all infos for all lambda functions
     lambda_info:
+      query: all
     register: lambda_infos_all
     check_mode: yes
   - name: lambda_info | Assert successfull retrieval of all information
@@ -264,14 +265,50 @@
       - lambda_infos_all.function | length > 0
       - lambda_infos_all.function[lambda_function_name].function_name == lambda_function_name
       - lambda_infos_all.function[lambda_function_name].runtime == "python3.6"
+      - lambda_infos_all.function[lambda_function_name].description == ""
+      - lambda_infos_all.function[lambda_function_name].function_arn is defined
+      - lambda_infos_all.function[lambda_function_name].handler == "mini_lambda.handler"
       - lambda_infos_all.function[lambda_function_name].versions is defined
       - lambda_infos_all.function[lambda_function_name].aliases is defined
       - lambda_infos_all.function[lambda_function_name].policy is defined
       - lambda_infos_all.function[lambda_function_name].mappings is defined
-      - lambda_infos_all.function[lambda_function_name].description == ""
-      - lambda_infos_all.function[lambda_function_name].function_arn is defined
-      - lambda_infos_all.function[lambda_function_name].handler == "mini_lambda.handler"
       - lambda_infos_all.function[lambda_function_name].tags is defined
+
+  - name: lambda_info | Ensure default query value is 'config' when function name omitted
+    lambda_info:
+    register: lambda_infos_query_config
+    check_mode: yes
+  - name: lambda_info | Assert successfull retrieval of all information
+    assert:
+      that:
+      - lambda_infos_query_config is not failed
+      - lambda_infos_query_config.function | length > 0
+      - lambda_infos_query_config.function[lambda_function_name].function_name == lambda_function_name
+      - lambda_infos_query_config.function[lambda_function_name].runtime == "python3.6"
+      - lambda_infos_query_config.function[lambda_function_name].description == ""
+      - lambda_infos_query_config.function[lambda_function_name].function_arn is defined
+      - lambda_infos_query_config.function[lambda_function_name].handler == "mini_lambda.handler"
+      - lambda_infos_query_config.function[lambda_function_name].versions is not defined
+      - lambda_infos_query_config.function[lambda_function_name].aliases is not defined
+      - lambda_infos_query_config.function[lambda_function_name].policy is not defined
+      - lambda_infos_query_config.function[lambda_function_name].mappings is not defined
+      - lambda_infos_query_config.function[lambda_function_name].tags is not defined
+
+  - name: lambda_info | Ensure default query value is 'all' when function name specified
+    lambda_info:
+      name: '{{ lambda_function_name }}'
+    register: lambda_infos_query_all
+  - name: lambda_info | Assert successfull retrieval of all information
+    assert:
+      that:
+      - lambda_infos_query_all is not failed
+      - lambda_infos_query_all.function | length == 1
+      - lambda_infos_query_all.function[lambda_function_name].versions|length > 0
+      - lambda_infos_query_all.function[lambda_function_name].function_name is defined
+      - lambda_infos_query_all.function[lambda_function_name].policy is defined
+      - lambda_infos_query_all.function[lambda_function_name].aliases is defined
+      - lambda_infos_query_all.function[lambda_function_name].mappings is defined
+      - lambda_infos_query_all.function[lambda_function_name].tags is defined
 
   - name: lambda_info | Gather version infos for given lambda function
     lambda_info:

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -253,10 +253,8 @@
       - result.configuration.tracing_config.mode == 'PassThrough'
 
   # Query the Lambda
-  - name: lambda_info | Gather all infos for given lambda function
+  - name: lambda_info | Gather all infos for all lambda functions
     lambda_info:
-      name: '{{ lambda_function_name }}'
-      query: all
     register: lambda_infos_all
     check_mode: yes
   - name: lambda_info | Assert successfull retrieval of all information
@@ -285,6 +283,10 @@
       - lambda_infos_versions is not failed
       - lambda_infos_versions.function[lambda_function_name].versions|length > 0
       - lambda_infos_versions.function[lambda_function_name].function_name is undefined
+      - lambda_infos_versions.function[lambda_function_name].policy is undefined
+      - lambda_infos_versions.function[lambda_function_name].aliases is undefined
+      - lambda_infos_versions.function[lambda_function_name].mappings is undefined
+      - lambda_infos_versions.function[lambda_function_name].tags is undefined
 
   - name: lambda_info | Gather config infos for given lambda function
     lambda_info:
@@ -298,6 +300,10 @@
       - lambda_infos_config.function[lambda_function_name].function_name == lambda_function_name
       - lambda_infos_config.function[lambda_function_name].description is defined
       - lambda_infos_config.function[lambda_function_name].versions is undefined
+      - lambda_infos_config.function[lambda_function_name].policy is undefined
+      - lambda_infos_config.function[lambda_function_name].aliases is undefined
+      - lambda_infos_config.function[lambda_function_name].mappings is undefined
+      - lambda_infos_config.function[lambda_function_name].tags is undefined
 
   - name: lambda_info | Gather policy infos for given lambda function
     lambda_info:
@@ -310,6 +316,10 @@
       - lambda_infos_policy is not failed
       - lambda_infos_policy.function[lambda_function_name].policy is defined
       - lambda_infos_policy.function[lambda_function_name].versions is undefined
+      - lambda_infos_policy.function[lambda_function_name].function_name is undefined
+      - lambda_infos_policy.function[lambda_function_name].aliases is undefined
+      - lambda_infos_policy.function[lambda_function_name].mappings is undefined
+      - lambda_infos_policy.function[lambda_function_name].tags is undefined
 
   - name: lambda_info | Gather aliases infos for given lambda function
     lambda_info:
@@ -321,6 +331,11 @@
       that:
       - lambda_infos_aliases is not failed
       - lambda_infos_aliases.function[lambda_function_name].aliases is defined
+      - lambda_infos_aliases.function[lambda_function_name].versions is undefined
+      - lambda_infos_aliases.function[lambda_function_name].function_name is undefined
+      - lambda_infos_aliases.function[lambda_function_name].policy is undefined
+      - lambda_infos_aliases.function[lambda_function_name].mappings is undefined
+      - lambda_infos_aliases.function[lambda_function_name].tags is undefined
 
   - name: lambda_info | Gather mappings infos for given lambda function
     lambda_info:
@@ -332,6 +347,11 @@
       that:
       - lambda_infos_mappings is not failed
       - lambda_infos_mappings.function[lambda_function_name].mappings is defined
+      - lambda_infos_mappings.function[lambda_function_name].versions is undefined
+      - lambda_infos_mappings.function[lambda_function_name].function_name is undefined
+      - lambda_infos_mappings.function[lambda_function_name].aliases is undefined
+      - lambda_infos_mappings.function[lambda_function_name].policy is undefined
+      - lambda_infos_mappings.function[lambda_function_name].tags is undefined
 
   # More Lambda update tests
   - name: test state=present with all nullable variables explicitly set to null

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -252,7 +252,7 @@
       - result.configuration.runtime == 'python3.6'
       - result.configuration.tracing_config.mode == 'PassThrough'
 
-  # Query the Lambda
+  # Test lambda_info
   - name: lambda_info | Gather all infos for all lambda functions
     lambda_info:
     register: lambda_infos_all
@@ -261,6 +261,7 @@
     assert:
       that:
       - lambda_infos_all is not failed
+      - lambda_infos_all.function | length > 0
       - lambda_infos_all.function[lambda_function_name].function_name == lambda_function_name
       - lambda_infos_all.function[lambda_function_name].runtime == "python3.6"
       - lambda_infos_all.function[lambda_function_name].versions is defined
@@ -281,6 +282,7 @@
     assert:
       that:
       - lambda_infos_versions is not failed
+      - lambda_infos_versions.function | length == 1
       - lambda_infos_versions.function[lambda_function_name].versions|length > 0
       - lambda_infos_versions.function[lambda_function_name].function_name is undefined
       - lambda_infos_versions.function[lambda_function_name].policy is undefined
@@ -297,6 +299,7 @@
     assert:
       that:
       - lambda_infos_config is not failed
+      - lambda_infos_config.function | length == 1
       - lambda_infos_config.function[lambda_function_name].function_name == lambda_function_name
       - lambda_infos_config.function[lambda_function_name].description is defined
       - lambda_infos_config.function[lambda_function_name].versions is undefined
@@ -314,6 +317,7 @@
     assert:
       that:
       - lambda_infos_policy is not failed
+      - lambda_infos_policy.function | length == 1
       - lambda_infos_policy.function[lambda_function_name].policy is defined
       - lambda_infos_policy.function[lambda_function_name].versions is undefined
       - lambda_infos_policy.function[lambda_function_name].function_name is undefined
@@ -330,6 +334,7 @@
     assert:
       that:
       - lambda_infos_aliases is not failed
+      - lambda_infos_aliases.function | length == 1
       - lambda_infos_aliases.function[lambda_function_name].aliases is defined
       - lambda_infos_aliases.function[lambda_function_name].versions is undefined
       - lambda_infos_aliases.function[lambda_function_name].function_name is undefined
@@ -346,6 +351,7 @@
     assert:
       that:
       - lambda_infos_mappings is not failed
+      - lambda_infos_mappings.function | length == 1
       - lambda_infos_mappings.function[lambda_function_name].mappings is defined
       - lambda_infos_mappings.function[lambda_function_name].versions is undefined
       - lambda_infos_mappings.function[lambda_function_name].function_name is undefined


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1558

##### SUMMARY
- Fix bug that forces `query: config` when getting info for all lambdas. Refactored to return the expected info
- Add extra cleanup at end of tests

Fixes #1151 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lambda_info

##### ADDITIONAL INFORMATION
This module also currently returns a dict of dicts (as opposed to a list of dicts), but I wanted to keep the scope of this PR to fixing the bug.
