### PR TITLE
Add changelog for profile becoming mutually exclusive with other access tokens

### DIFF
--- a/changelogs/fragments/151-profile-mutually-exclusive.yml
+++ b/changelogs/fragments/151-profile-mutually-exclusive.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+- community.aws collection - the ``profile`` parameter is now mutually exclusive with the ``aws_access_key``,
+  ``aws_secret_key`` and ``security_token`` parameters (https://github.com/ansible-collections/amazon.aws/pull/834).


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/834

##### SUMMARY

amazon.aws/834 made profile mutually exclusive with the other access token parameters, add a changelog fragment to community.aws since it's a significant change that also affects this collection

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/151-profile-mutually-exclusive.yml

##### ADDITIONAL INFORMATION