### PR TITLE
ec2_lc - remove unused associate_public_ip_address option

### DIFF
--- a/changelogs/fragments/1158-ec2_lc-remove-associate_public_ip_address.yml
+++ b/changelogs/fragments/1158-ec2_lc-remove-associate_public_ip_address.yml
@@ -1,0 +1,2 @@
+removed_features:
+- ec2_lc - the ``associate_public_ip_address`` option has been removed. It has always been ignored by the module (https://github.com/ansible-collections/community.aws/pull/1158).

--- a/plugins/modules/ec2_lc.py
+++ b/plugins/modules/ec2_lc.py
@@ -180,10 +180,6 @@ options:
       - When not set AWS will default to C(default).
     type: str
     choices: ['default', 'dedicated']
-  associate_public_ip_address:
-    description:
-      - The I(associate_public_ip_address) option does nothing and will be removed after 2022-06-01
-    type: bool
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -668,7 +664,6 @@ def main():
         ramdisk_id=dict(),
         instance_profile_name=dict(),
         ebs_optimized=dict(default=False, type='bool'),
-        associate_public_ip_address=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         instance_monitoring=dict(default=False, type='bool'),
         assign_public_ip=dict(type='bool'),
         classic_link_vpc_security_groups=dict(type='list', elements='str'),


### PR DESCRIPTION
##### SUMMARY

The associate_public_ip_address option has always been ignored by ec2_lc, remove it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_lc

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/64230