### PR TITLE
data_pipeline - remove unused version option

### DIFF
--- a/changelogs/fragments/1160-data_pipeline-remove-version.yml
+++ b/changelogs/fragments/1160-data_pipeline-remove-version.yml
@@ -1,0 +1,2 @@
+removed_features:
+- data_pipeline - the ``version`` option has always been ignored and has been removed (https://github.com/ansible-collections/community.aws/pull/1160"

--- a/plugins/modules/data_pipeline.py
+++ b/plugins/modules/data_pipeline.py
@@ -121,10 +121,6 @@ options:
     description:
       - A dict of key:value pair(s) to add to the pipeline.
     type: dict
-  version:
-    description:
-      - The version option has never had any effect and will be removed after 2022-06-01.
-    type: str
 '''
 
 EXAMPLES = r'''
@@ -600,7 +596,6 @@ def create_pipeline(client, module):
 def main():
     argument_spec = dict(
         name=dict(required=True),
-        version=dict(removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         description=dict(required=False, default=''),
         objects=dict(required=False, type='list', default=[], elements='dict'),
         parameters=dict(required=False, type='list', default=[], elements='dict'),


### PR DESCRIPTION
##### SUMMARY

The `version` option has always been ignored and has now been removed.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

data_pipeline

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/64368