### PR TITLE
ecs_ecr - remove deprecated delete_policy option

### DIFF
--- a/changelogs/fragments/1161-ecs_ecr-remove-delete_policy.yml
+++ b/changelogs/fragments/1161-ecs_ecr-remove-delete_policy.yml
@@ -1,0 +1,2 @@
+removed_features:
+- ecs_ecr - The deprecated alias ``delete_policy`` has been removed.  Please use ``purge_policy`` instead (https://github.com/ansible-collections/community.aws/pull/1161).

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -43,11 +43,9 @@ options:
     purge_policy:
         description:
             - If yes, remove the policy from the repository.
-            - Alias C(delete_policy) has been deprecated and will be removed after 2022-06-01.
             - Defaults to C(false).
         required: false
         type: bool
-        aliases: [ delete_policy ]
     image_tag_mutability:
         description:
             - Configure whether repository should be mutable (ie. an already existing tag can be overwritten) or not.
@@ -536,8 +534,7 @@ def main():
         policy=dict(required=False, type='json'),
         image_tag_mutability=dict(required=False, choices=['mutable', 'immutable'],
                                   default='mutable'),
-        purge_policy=dict(required=False, type='bool', aliases=['delete_policy'],
-                          deprecated_aliases=[dict(name='delete_policy', date='2022-06-01', collection_name='community.aws')]),
+        purge_policy=dict(required=False, type='bool'),
         lifecycle_policy=dict(required=False, type='json'),
         purge_lifecycle_policy=dict(required=False, type='bool'),
         scan_on_push=(dict(required=False, type='bool', default=False))

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -124,7 +124,7 @@
     - name: When in check mode, and deleting a policy that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        delete_policy: yes
+        purge_policy: yes
       register: result
       check_mode: yes
 


### PR DESCRIPTION
##### SUMMARY

Remove the deprecated delete_policy option.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ecs_ecr

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/48997