### PR TITLE
Fix issue when creating GSI with global_keys_only

### DIFF
--- a/changelogs/fragments/967-dynamodb_table.yml
+++ b/changelogs/fragments/967-dynamodb_table.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- dynamodb_table - fix an issue when creating secondary indexes with global_keys_only (https://github.com/ansible-collections/community.aws/issues/967).

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -724,7 +724,8 @@ def _generate_index(index, include_throughput=True):
         ProjectionType=index['type'],
     )
     if index['type'] != 'ALL':
-        projection['NonKeyAttributes'] = non_key_attributes
+        if non_key_attributes:
+            projection['NonKeyAttributes'] = non_key_attributes
     else:
         if non_key_attributes:
             module.fail_json(

--- a/tests/integration/targets/dynamodb_table/defaults/main.yml
+++ b/tests/integration/targets/dynamodb_table/defaults/main.yml
@@ -25,6 +25,11 @@ indexes:
     range_key_name: bar
     read_capacity: 5
     write_capacity: 5
+  - name: KeysOnlyIndex
+    type: global_keys_only
+    hash_key_name: create_time
+    read_capacity: 2
+    write_capacity: 2
 
 indexes_pay_per_request:
   - name: NamedIndex
@@ -38,6 +43,9 @@ indexes_pay_per_request:
     type: global_all
     hash_key_name: foo
     range_key_name: bar
+  - name: KeysOnlyIndex
+    type: global_keys_only
+    hash_key_name: create_time
 
 indexes_pay_per_request_bad:
   - name: NamedIndex
@@ -54,6 +62,9 @@ indexes_pay_per_request_bad:
     includes:
       - another_field
       - another_field2
+  - name: KeysOnlyIndex
+    type: global_keys_only
+    hash_key_name: create_time
 
 index_updated:
   - name: NamedIndex

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -466,7 +466,7 @@
         - '"write_capacity" in update_indexes'
         - update_indexes.hash_key_name == table_index
         - update_indexes.hash_key_type == table_index_type
-        - update_indexes.indexes | length == 2
+        - update_indexes.indexes | length == 3
         # - update_indexes.range_key_name == range_index
         # - update_indexes.range_key_type == range_index_type
         - update_indexes.read_capacity == 3
@@ -513,7 +513,7 @@
         - '"write_capacity" in update_indexes'
         - update_indexes.hash_key_name == table_index
         - update_indexes.hash_key_type == table_index_type
-        - update_indexes.indexes | length == 2
+        - update_indexes.indexes | length == 3
         # - update_indexes.range_key_name == range_index
         # - update_indexes.range_key_type == range_index_type
         - update_indexes.read_capacity == 3
@@ -633,7 +633,7 @@
         - '"write_capacity" in create_complex_table'
         - create_complex_table.hash_key_name == table_index
         - create_complex_table.hash_key_type == table_index_type
-        - create_complex_table.indexes | length == 2
+        - create_complex_table.indexes | length == 3
         - create_complex_table.range_key_name == range_index
         - create_complex_table.range_key_type == range_index_type
         - create_complex_table.read_capacity == 3
@@ -701,7 +701,7 @@
         - '"write_capacity" in create_complex_table'
         - create_complex_table.hash_key_name == table_index
         - create_complex_table.hash_key_type == table_index_type
-        - create_complex_table.indexes | length == 2
+        - create_complex_table.indexes | length == 3
         - create_complex_table.range_key_name == range_index
         - create_complex_table.range_key_type == range_index_type
         - create_complex_table.read_capacity == 3
@@ -788,7 +788,7 @@
         - '"write_capacity" in update_index'
         - update_index.hash_key_name == table_index
         - update_index.hash_key_type == table_index_type
-        - update_index.indexes | length == 2
+        - update_index.indexes | length == 3
         - update_index.range_key_name == range_index
         - update_index.range_key_type == range_index_type
         - update_index.read_capacity == 3
@@ -839,7 +839,7 @@
         - '"write_capacity" in update_index'
         - update_index.hash_key_name == table_index
         - update_index.hash_key_type == table_index_type
-        - update_index.indexes | length == 2
+        - update_index.indexes | length == 3
         - update_index.range_key_name == range_index
         - update_index.range_key_type == range_index_type
         - update_index.read_capacity == 3

--- a/tests/integration/targets/dynamodb_table/tasks/test_pay_per_request.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/test_pay_per_request.yml
@@ -115,7 +115,7 @@
       - '"tags" in create_complex_table'
       - create_complex_table.hash_key_name == table_index
       - create_complex_table.hash_key_type == table_index_type
-      - create_complex_table.indexes | length == 2
+      - create_complex_table.indexes | length == 3
       - create_complex_table.table_name == table_name_on_demand_complex
       - create_complex_table.tags == tags_default
 


### PR DESCRIPTION
##### SUMMARY

fixes: #967 

Undocumented requirement on NonKeyAttributes that it should be omitted rather than an empty list.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

dynamodb_table

##### ADDITIONAL INFORMATION

```console (paste below)
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Invalid length for parameter GlobalSecondaryIndexUpdates[0].Create.Projection.NonKeyAttributes, value: 0, valid min length: 1
fatal: [localhost]: FAILED! => {"boto3_version": "1.18.47", "botocore_version": "1.21.47", "changed": false, "msg": "Failed to update table: Parameter validation failed:\nInvalid length for parameter GlobalSecondaryIndexUpdates[0].Create.Projection.NonKeyAttributes, value: 0, valid min length: 1"}
```