### PR TITLE
ec2_metric_alarm - drop deprecated support for symbolic operators

### DIFF
--- a/changelogs/fragments/1164-ec2_metric_alarm-deprecation.yml
+++ b/changelogs/fragments/1164-ec2_metric_alarm-deprecation.yml
@@ -1,0 +1,4 @@
+removed_features:
+- ec2_metric_alarm - support for using the ``<=``, ``<``, ``>`` and ``>=`` operators for comparison has been dropped.
+  Please use ``LessThanOrEqualToThreshold``, ``LessThanThreshold``, ``GreaterThanThreshold`` or
+  ``GreaterThanOrEqualToThreshold`` instead (https://github.com/ansible-collections/amazon.aws/pull/1164).

--- a/plugins/modules/ec2_metric_alarm.py
+++ b/plugins/modules/ec2_metric_alarm.py
@@ -59,7 +59,6 @@ options:
     comparison:
         description:
           - Determines how the threshold value is compared
-          - Symbolic comparison operators have been deprecated, and will be removed after 2022-06-22.
         required: false
         type: str
         choices:
@@ -67,10 +66,6 @@ options:
           - 'GreaterThanThreshold'
           - 'LessThanThreshold'
           - 'LessThanOrEqualToThreshold'
-          - '<='
-          - '<'
-          - '>='
-          - '>'
     threshold:
         description:
           - Sets the min/max bound for triggering the alarm.
@@ -192,7 +187,7 @@ EXAMPLES = r'''
       metric: "StatusCheckFailed_System"
       namespace: "AWS/EC2"
       statistic: "Minimum"
-      comparison: ">="
+      comparison: "GreaterThanOrEqualToThreshold"
       threshold: 1.0
       period: 60
       evaluation_periods: 2
@@ -213,16 +208,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 
 def create_metric_alarm(connection, module, params):
     alarms = connection.describe_alarms(AlarmNames=[params['AlarmName']])
-
-    comparisons = {'<=': 'LessThanOrEqualToThreshold',
-                   '<': 'LessThanThreshold',
-                   '>=': 'GreaterThanOrEqualToThreshold',
-                   '>': 'GreaterThanThreshold'}
-    if params['ComparisonOperator'] in ('<=', '<', '>', '>='):
-        module.deprecate('Using the <=, <, > and >= operators for comparison has been deprecated. Please use LessThanOrEqualToThreshold, '
-                         'LessThanThreshold, GreaterThanThreshold or GreaterThanOrEqualToThreshold instead.',
-                         date='2022-06-01', collection_name='community.aws')
-        params['ComparisonOperator'] = comparisons[params['ComparisonOperator']]
 
     if not isinstance(params['Dimensions'], list):
         fixed_dimensions = []
@@ -314,7 +299,7 @@ def main():
         namespace=dict(type='str'),
         statistic=dict(type='str', choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum']),
         comparison=dict(type='str', choices=['LessThanOrEqualToThreshold', 'LessThanThreshold', 'GreaterThanThreshold',
-                                             'GreaterThanOrEqualToThreshold', '<=', '<', '>', '>=']),
+                                             'GreaterThanOrEqualToThreshold']),
         threshold=dict(type='float'),
         period=dict(type='int'),
         unit=dict(type='str', choices=['Seconds', 'Microseconds', 'Milliseconds', 'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes',

--- a/tests/integration/targets/ec2_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/ec2_metric_alarm/tasks/main.yml
@@ -51,7 +51,7 @@
         namespace: "AWS/EC2"
         treat_missing_data: missing
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 300
         evaluation_periods: 3
@@ -90,7 +90,7 @@
         namespace: "AWS/EC2"
         treat_missing_data: missing
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 300
         evaluation_periods: 3
@@ -138,7 +138,7 @@
         namespace: "AWS/EC2"
         treat_missing_data: missing
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 300
         evaluation_periods: 3
@@ -193,7 +193,7 @@
         namespace: "AWS/EC2"
         treat_missing_data: missing
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 300
         evaluation_periods: 3
@@ -246,7 +246,7 @@
         metric: "CPUUtilization"
         namespace: "AWS/EC2"
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 60
         evaluation_periods: 3
@@ -286,7 +286,7 @@
         metric: "CPUUtilization"
         namespace: "AWS/EC2"
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 60
         evaluation_periods: 3
@@ -385,7 +385,7 @@
         namespace: "AWS/EC2"
         treat_missing_data: missing
         statistic: Average
-        comparison: "<="
+        comparison: "LessThanOrEqualToThreshold"
         threshold: 5.0
         period: 300
         evaluation_periods: 3

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,6 +1,5 @@
 plugins/modules/aws_kms.py pylint:ansible-deprecated-no-version
 plugins/modules/aws_kms_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_metric_alarm.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_policy.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_role.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_user.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

With the migration to boto3 symbolic operators were deprecated.  Remove it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_metric_alarm

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/62669