### PR TITLE
s3_sync - drop unused retries parameter

### DIFF
--- a/changelogs/fragments/1166-s3_sync-retries.yml
+++ b/changelogs/fragments/1166-s3_sync-retries.yml
@@ -1,0 +1,2 @@
+removed_features:
+- s3_sync - remove unused ``retries`` parameter (https://github.com/ansible-collections/community.aws/pull/1166).

--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -124,10 +124,6 @@ options:
     required: false
     default: no
     type: bool
-  retries:
-    description:
-      - The I(retries) option does nothing and will be removed after 2022-06-01
-    type: str
 
 author: Ted Timmons (@tedder)
 extends_documentation_fragment:
@@ -542,7 +538,6 @@ def main():
         file_root=dict(required=True, type='path'),
         permission=dict(required=False, choices=['private', 'public-read', 'public-read-write', 'authenticated-read',
                                                  'aws-exec-read', 'bucket-owner-read', 'bucket-owner-full-control']),
-        retries=dict(required=False, removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         mime_map=dict(required=False, type='dict'),
         exclude=dict(required=False, default=".*"),
         include=dict(required=False, default="*"),


### PR DESCRIPTION
##### SUMMARY

The retries parameter was never used, remove it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

s3_sync

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/63989