### PR TITLE
iam_managed_policy - remove unused fail_on_delete parameter

### DIFF
--- a/changelogs/fragments/1168-iam_managed_policy-fail_on_delete.yml
+++ b/changelogs/fragments/1168-iam_managed_policy-fail_on_delete.yml
@@ -1,0 +1,2 @@
+removed_features:
+- iam_managed_policy - the unused ``fail_on_delete`` parameter has been removed (https://github.com/ansible-collections/community.aws/pull/1168)

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -44,10 +44,6 @@ options:
     default: present
     choices: [ "present", "absent" ]
     type: str
-  fail_on_delete:
-    description:
-    - The I(fail_on_delete) option does nothing and will be removed after 2022-06-01
-    type: bool
 
 author: "Dan Kozlowski (@dkhenry)"
 extends_documentation_fragment:
@@ -345,7 +341,6 @@ def main():
         policy=dict(type='json'),
         make_default=dict(type='bool', default=True),
         only_version=dict(type='bool', default=False),
-        fail_on_delete=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='community.aws'),
         state=dict(default='present', choices=['present', 'absent']),
     )
 


### PR DESCRIPTION
##### SUMMARY

remove unused fail_on_delete parameter

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_managed_policy

##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/pull/63961