### PR TITLE
ecs_ecr -- Return repository policy if it exists, even if we did not …

### DIFF
--- a/changelogs/fragments/1171-ecs_ecr_pull_repo_policy.yml
+++ b/changelogs/fragments/1171-ecs_ecr_pull_repo_policy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ecs_ecr - Will now return repository permission policy if it exists, even if we did not create or modify it. (https://github.com/ansible-collections/community.aws/pull/1171).

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -172,6 +172,7 @@ policy:
     type: dict
     description: The existing, created or updated repository policy
     returned: "when state == 'present'"
+    version_added: 4.0.0
 repository:
     type: dict
     description: The created or updated repository

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -168,6 +168,10 @@ name:
     type: str
     description: The name of the repository
     returned: "when state == 'absent'"
+policy:
+    type: dict
+    description: The existing, created or updated repository policy
+    returned: "when state == 'present'"
 repository:
     type: dict
     description: The created or updated repository
@@ -493,6 +497,11 @@ def run(ecr, params):
                     # policy is.
                     result['policy'] = policy_text
                     raise
+
+            else:
+                original_policy = ecr.get_repository_policy(registry_id, name)
+                if original_policy:
+                    result['policy'] = original_policy
 
             original_scan_on_push = ecr.get_repository(registry_id, name)
             if original_scan_on_push is not None:

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -167,16 +167,16 @@ created:
 name:
     type: str
     description: The name of the repository
-    returned: "when state == 'absent'"
+    returned: I(state=absent)
 policy:
     type: dict
     description: The existing, created or updated repository policy.
-    returned: "when state == 'present'"
+    returned: I(state=present)
     version_added: 4.0.0
 repository:
     type: dict
     description: The created or updated repository
-    returned: "when state == 'present'"
+    returned: I(state=present)
     sample:
         createdAt: '2017-01-17T08:41:32-06:00'
         registryId: '999999999999'

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -170,7 +170,7 @@ name:
     returned: "when state == 'absent'"
 policy:
     type: dict
-    description: The existing, created or updated repository policy
+    description: The existing, created or updated repository policy.
     returned: "when state == 'present'"
     version_added: 4.0.0
 repository:

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -56,11 +56,7 @@
 
     - name: When pulling an existing repository that has no existing policy
       ecs_ecr:
-<<<<<<< HEAD
         name: '{{ ecr_name }}'
-=======
-        name: {{ ecr_name }}'
->>>>>>> 8bb68d3 (Add integration tests for pulling and printing policy)
       register: result
       
     - name: it should return the repo but without a policy and not create or change

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -56,7 +56,7 @@
 
     - name: When pulling an existing repository that has no existing policy
       ecs_ecr:
-        name: {{ ecr_name }}'
+        name: '{{ ecr_name }}'
       register: result
       
     - name: it should return the repo but without a policy and not create or change
@@ -134,7 +134,7 @@
 
     - name: When pulling an existing repository that has an existing policy
       ecs_ecr:
-        name: {{ ecr_name }}'
+        name: '{{ ecr_name }}'
       register: result
       
     - name: it should return the policy but not create or change

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -134,7 +134,11 @@
 
     - name: When pulling an existing repository that has an existing policy
       ecs_ecr:
+<<<<<<< HEAD
         name: '{{ ecr_name }}'
+=======
+        name: {{ ecr_name }}'
+>>>>>>> 08e485e (Add integration tests for pulling and printing policy)
       register: result
       
     - name: it should return the policy but not create or change

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -54,6 +54,18 @@
         that:
           - result.repository.imageTagMutability == "MUTABLE"
 
+    - name: When pulling an existing repository that has no existing policy
+      ecs_ecr:
+        name: {{ ecr_name }}'
+      register: result
+      
+    - name: it should return the repo but without a policy and not create or change
+      assert:
+        that:
+          - result.repository
+          - not result.policy
+          - not result.created
+          - not result.changed
 
     - name: When creating a repository that already exists in check mode
       ecs_ecr:
@@ -120,6 +132,17 @@
           - result is changed
           - not result.created
 
+    - name: When pulling an existing repository that has an existing policy
+      ecs_ecr:
+        name: {{ ecr_name }}'
+      register: result
+      
+    - name: it should return the policy but not create or change
+      assert:
+        that:
+          - result.policy
+          - not result.created
+          - not result.changed
 
     - name: When in check mode, and deleting a policy that exists
       ecs_ecr:

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -56,7 +56,11 @@
 
     - name: When pulling an existing repository that has no existing policy
       ecs_ecr:
+<<<<<<< HEAD
         name: '{{ ecr_name }}'
+=======
+        name: {{ ecr_name }}'
+>>>>>>> 8bb68d3 (Add integration tests for pulling and printing policy)
       register: result
       
     - name: it should return the repo but without a policy and not create or change

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -134,11 +134,7 @@
 
     - name: When pulling an existing repository that has an existing policy
       ecs_ecr:
-<<<<<<< HEAD
         name: '{{ ecr_name }}'
-=======
-        name: {{ ecr_name }}'
->>>>>>> 08e485e (Add integration tests for pulling and printing policy)
       register: result
       
     - name: it should return the policy but not create or change


### PR DESCRIPTION
Return repository policy if it exists, even if we did not create or modify it.

##### SUMMARY
Existing behavior will only print the ECR repo (permissions) policy if we just created/edited that policy. There is no way to just pull the existing policy and use it in a subsequent task.

New behavior will print the existing ECR repo policy information if it exists, even if we did not just create/edit that policy.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_ecr -- run function

##### ADDITIONAL INFORMATION
Given the scenario that my ECR repo already exists and already has a permissions policy on it. I would like to use ansible to retrieve that policy.
Today this module will only return the policy as part of the return object if we are telling the module to create or edit the policy.
After merging, the module will create the policy if it was defined, or update the policy if needed, and if neither of those were defined (else) we will check for an existing permissions policy and add it to the return object.
```
Given the example tasks:
- name: Pull the existing permissions policy for the ECR repo.
      community.aws.ecs_ecr:
        region: "{{ AWS_REGION }}"
        aws_access_key: "{{ survey_access_key_id }}"
        aws_secret_key: "{{ survey_secret_access_key }}"
        aws_security_token: "{{ survey_session_token }}"
        validate_certs: False
        name: 'example/nginx'
      register: ecr_repo_info

    - name: debug
      debug:
        msg: "{{ ecr_repo_info }}"

Here is the current behavior:
ASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": false,
        "created": false,
        "failed": false,
        "repository": {
            "createdAt": "2022-05-19T11:15:49-05:00",
            "encryptionConfiguration": {
                "encryptionType": "AES256"
            },
            "imageScanningConfiguration": {
                "scanOnPush": false
            },
            "imageTagMutability": "MUTABLE",
            "registryId": "12345",
            "repositoryArn": "arn:aws:ecr:us-east-1:123456789:repository/example/nginx",
            "repositoryName": "example/nginx",
            "repositoryUri": "123456789.dkr.ecr.us-east-1.amazonaws.com/example/nginx"
        },
        "state": "present"
    }
}

And here is the post-merge output:
ASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": false,
        "created": false,
        "failed": false,
        "policy": {
            "Statement": [
                {
                    "Action": [
                        "ecr:GetDownloadUrlForLayer",
                        "ecr:BatchGetImage",
                        "ecr:BatchCheckLayerAvailability",
                        "ecr:ListImages",
                        "ecr:DescribeImages",
                        "ecr:DescribeRepositories"
                    ],
                    "Effect": "Allow",
                    "Principal": {
                        "AWS": "arn:aws:iam::12345678:root"
                    },
                    "Sid": "Allow managed accounts to access this repo."
                }
            ],
            "Version": "2008-10-17"
        },
        "repository": {
            "createdAt": "2022-05-19T11:15:49-05:00",
            "encryptionConfiguration": {
                "encryptionType": "AES256"
            },
            "imageScanningConfiguration": {
                "scanOnPush": false
            },
            "imageTagMutability": "MUTABLE",
            "registryId": "12345",
            "repositoryArn": "arn:aws:ecr:us-east-1:123456789:repository/example/nginx",
            "repositoryName": "example/nginx",
            "repositoryUri": "123456789.dkr.ecr.us-east-1.amazonaws.com/example/nginx"
        },
        "state": "present"
    }
}
```