### PR TITLE
elb_instance - remove ec2_elbs fact

### DIFF
--- a/changelogs/fragments/1173-elb_instance-ec2_elbs.yml
+++ b/changelogs/fragments/1173-elb_instance-ec2_elbs.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- elb_instance - the ``ec2_elbs`` fact has been removed, ``updated_elbs`` has been added the return values and includes the same information (https://github.com/ansible-collections/community.aws/pull/1173).

--- a/plugins/modules/elb_instance.py
+++ b/plugins/modules/elb_instance.py
@@ -55,8 +55,8 @@ options:
     default: 0
     type: int
 notes:
-- The ec2_elb fact currently set by this module has been deprecated and will no
-  longer be set after release 4.0.0 of the collection.
+- The ec2_elbs fact previously set by this module was deprecated in release 2.1.0 and since release
+  4.0.0 is no longer set.
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -388,13 +388,8 @@ def main():
     elif module.params['state'] == 'absent':
         elb_man.deregister(wait, timeout)
 
-    # XXX We're not an _fact module we shouldn't be returning a fact and poluting
-    # the namespace
-    ansible_facts = {'ec2_elbs': [lb['LoadBalancerName'] for lb in elb_man.lbs]}
-
     module.exit_json(
         changed=elb_man.changed,
-        ansible_facts=ansible_facts,
         updated_elbs=list(elb_man.updated_elbs),
     )
 

--- a/tests/integration/targets/elb_instance/tasks/manage_asgs.yml
+++ b/tests/integration/targets/elb_instance/tasks/manage_asgs.yml
@@ -30,11 +30,6 @@
     - '"updated_elbs" in remove_instance'
     - elb_name_1 in remove_instance.updated_elbs
     - elb_name_2 in remove_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in remove_instance'
-    - '"ec2_elbs" in remove_instance.ansible_facts'
-    - elb_name_1 in remove_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in remove_instance.ansible_facts.ec2_elbs
     # Check the real state didn't change
     - instance_asg in elb_info_1.elbs[0].instances_inservice
     - instance_asg in elb_info_2.elbs[0].instances_inservice
@@ -60,11 +55,6 @@
     - '"updated_elbs" in remove_instance'
     - elb_name_1 in remove_instance.updated_elbs
     - elb_name_2 in remove_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in remove_instance'
-    - '"ec2_elbs" in remove_instance.ansible_facts'
-    - elb_name_1 in remove_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in remove_instance.ansible_facts.ec2_elbs
     # Check the real state
     - instance_asg not in elb_info_1.elbs[0].instances_inservice
     - instance_asg not in elb_info_2.elbs[0].instances_inservice

--- a/tests/integration/targets/elb_instance/tasks/manage_instances.yml
+++ b/tests/integration/targets/elb_instance/tasks/manage_instances.yml
@@ -31,11 +31,6 @@
     - '"updated_elbs" in add_instance'
     - elb_name_1 in add_instance.updated_elbs
     - elb_name_2 in add_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in add_instance'
-    - '"ec2_elbs" in add_instance.ansible_facts'
-    - elb_name_1 in add_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in add_instance.ansible_facts.ec2_elbs
     # Check the real state didn't change
     - instance_a not in elb_info_1.elbs[0].instances_inservice
     - instance_a not in elb_info_2.elbs[0].instances_inservice
@@ -64,11 +59,6 @@
     - '"updated_elbs" in add_instance'
     - elb_name_1 in add_instance.updated_elbs
     - elb_name_2 in add_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in add_instance'
-    - '"ec2_elbs" in add_instance.ansible_facts'
-    - elb_name_1 in add_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in add_instance.ansible_facts.ec2_elbs
     # Check the real state
     - instance_a in elb_info_1.elbs[0].instances_inservice
     - instance_a in elb_info_2.elbs[0].instances_inservice
@@ -280,11 +270,6 @@
     - '"updated_elbs" in remove_instance'
     - elb_name_1 in remove_instance.updated_elbs
     - elb_name_2 in remove_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in remove_instance'
-    - '"ec2_elbs" in remove_instance.ansible_facts'
-    - elb_name_1 in remove_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in remove_instance.ansible_facts.ec2_elbs
     # Check the real state didn't change
     - instance_a in elb_info_1.elbs[0].instances_inservice
     - instance_a in elb_info_2.elbs[0].instances_inservice
@@ -313,11 +298,6 @@
     - '"updated_elbs" in remove_instance'
     - elb_name_1 in remove_instance.updated_elbs
     - elb_name_2 in remove_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in remove_instance'
-    - '"ec2_elbs" in remove_instance.ansible_facts'
-    - elb_name_1 in remove_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in remove_instance.ansible_facts.ec2_elbs
     # Check the real state
     - instance_a not in elb_info_1.elbs[0].instances_inservice
     - instance_a not in elb_info_2.elbs[0].instances_inservice
@@ -397,11 +377,6 @@
     - '"updated_elbs" in add_instance'
     - elb_name_1 not in add_instance.updated_elbs
     - elb_name_2 in add_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in add_instance'
-    - '"ec2_elbs" in add_instance.ansible_facts'
-    - elb_name_1 not in add_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in add_instance.ansible_facts.ec2_elbs
 
 - name: 'Remove an instance without specifying ELBs (check_mode)'
   elb_instance:
@@ -425,11 +400,6 @@
     - '"updated_elbs" in remove_instance'
     - elb_name_1 not in remove_instance.updated_elbs
     - elb_name_2 in remove_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in remove_instance'
-    - '"ec2_elbs" in remove_instance.ansible_facts'
-    - elb_name_1 not in remove_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in remove_instance.ansible_facts.ec2_elbs
     # Check the real state didn't change
     - instance_b not in elb_info_1.elbs[0].instances_inservice
     - instance_b in elb_info_2.elbs[0].instances_inservice
@@ -455,11 +425,6 @@
     - '"updated_elbs" in remove_instance'
     - elb_name_1 not in remove_instance.updated_elbs
     - elb_name_2 in remove_instance.updated_elbs
-    # It really shouldn't be returning a fact here
-    - '"ansible_facts" in remove_instance'
-    - '"ec2_elbs" in remove_instance.ansible_facts'
-    - elb_name_1 not in remove_instance.ansible_facts.ec2_elbs
-    - elb_name_2 in remove_instance.ansible_facts.ec2_elbs
     # Check the real state
     - instance_b not in elb_info_1.elbs[0].instances_inservice
     - instance_b not in elb_info_2.elbs[0].instances_inservice


### PR DESCRIPTION
##### SUMMARY

The ec2_elbs fact was deprecated when we migrated to boto3, remove it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

elb_instance

##### ADDITIONAL INFORMATION

See also: #773