### PR TITLE
Add changelog fragment for amazon.aws/825

### DIFF
--- a/changelogs/fragments/817-skip_purge_aws.yaml
+++ b/changelogs/fragments/817-skip_purge_aws.yaml
@@ -1,0 +1,2 @@
+breaking_changes:
+- Tags beginning with ``aws:`` will not be removed when purging tags, these tags are reserved by Amazon and may not be updated or deleted (https://github.com/ansible-collections/amazon.aws/issues/817).


### PR DESCRIPTION
##### SUMMARY

With https://github.com/ansible-collections/amazon.aws/pull/825 we now ignore aws: tags when purging.

Since affects both amazon.aws and community.aws add a changelog note to community.aws

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

changelogs/fragments/817-skip_purge_aws.yaml

##### ADDITIONAL INFORMATION

See also:
https://github.com/ansible-collections/amazon.aws/pull/825
https://github.com/ansible-collections/amazon.aws/issues/817
 #1146