### PR TITLE
ecs_service -- Capacity provider strategy

### DIFF
--- a/changelogs/fragments/1181-ecs_service_capacity_provider_strategy
+++ b/changelogs/fragments/1181-ecs_service_capacity_provider_strategy
@@ -1,2 +1,0 @@
-minor_changes:
-  - ecs_service -- Now allows for a capacity_provider_strategy to be utilized when creating/updating a service.

--- a/changelogs/fragments/1181-ecs_service_capacity_provider_strategy
+++ b/changelogs/fragments/1181-ecs_service_capacity_provider_strategy
@@ -1,0 +1,2 @@
+minor_changes:
+  - ecs_service -- Now allows for a capacity_provider_strategy to be utilized when creating/updating a service.

--- a/changelogs/fragments/1181-ecs_service_capacity_provider_strategy.yml
+++ b/changelogs/fragments/1181-ecs_service_capacity_provider_strategy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ecs_service -- Now allows for a capacity_provider_strategy to be utilized when creating/updating a service.

--- a/changelogs/fragments/1181-ecs_service_capacity_provider_strategy.yml
+++ b/changelogs/fragments/1181-ecs_service_capacity_provider_strategy.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ecs_service -- Now allows for a capacity_provider_strategy to be utilized when creating/updating a service.
+  - ecs_service - Now allows for a ``capacity_provider_strategy`` to be utilized when creating/updating a service (https://github.com/ansible-collections/community.aws/pull/1181).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -162,7 +162,7 @@ options:
     capacity_provider_strategy:
         version_added: 4.0.0
         description:
-          - The capacity provider strategy to use with your service.
+          - The capacity provider strategy to use with your service. You can specify a maximum of 6 providers per strategy.
         required: false
         type: list
         elements: dict

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -755,10 +755,15 @@ def main():
         platform_version=dict(required=False, type='str'),
         service_registries=dict(required=False, type='list', default=[], elements='dict'),
         scheduling_strategy=dict(required=False, choices=['DAEMON', 'REPLICA']),
-        capacity_provider_strategy=dict(required=False, type='list', default=[], elements='dict', options=dict(
-            capacity_provider=dict(type='str'),
-            weight=dict(type='int'),
-            base=dict(type='int')
+        capacity_provider_strategy=dict(
+            required=False,
+            type='list',
+            default=[],
+            elements='dict',
+            options=dict(
+                capacity_provider=dict(type='str'),
+                weight=dict(type='int'),
+                base=dict(type='int')
             )
         )
     )

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -674,6 +674,8 @@ class EcsServiceManager:
             params['networkConfiguration'] = network_configuration
         if force_new_deployment:
             params['forceNewDeployment'] = force_new_deployment
+        if capacity_provider_strategy:
+            params['capacityProviderStrategy'] = capacity_provider_strategy
         if health_check_grace_period_seconds is not None:
             params['healthCheckGracePeriodSeconds'] = health_check_grace_period_seconds
         # desired count is not required if scheduling strategy is daemon

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -160,6 +160,7 @@ options:
         choices: ["EC2", "FARGATE"]
         type: str
     capacity_provider_strategy:
+        version_added: 4.0.0
         description:
           - The capacity provider strategy to use with your service.
         required: false

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -769,6 +769,9 @@ def main():
         if module.params['desired_count'] is None:
             module.fail_json(msg='state is present, scheduling_strategy is REPLICA; missing desired_count')
 
+    if len(module.params['capacity_provider_strategy']) > 6:
+        module.fail_json(msg='AWS allows a maximum of six capacity providers in the strategy.')
+
     service_mgr = EcsServiceManager(module)
     if module.params['network_configuration']:
         network_configuration = service_mgr.format_network_configuration(module.params['network_configuration'])

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -290,6 +290,7 @@ service:
     type: complex
     contains:
         capacityProviderStrategy:
+            version_added: 4.0.0
             description: The capacity provider strategy to use with your service.
             returned: always
             type: complex


### PR DESCRIPTION
##### SUMMARY
Fixes #1137
Per request, allow for the user to provide a capacity_provider_strategy when creating or updating an ECS service. This capacity_provider_strategy is a list of 1-6 dictionaries. The new capacity_provider_strategy is mutually exclusive with launch_type and an existing service cannot be changed from one to the other.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_service

##### ADDITIONAL INFORMATION
The new parameter is optional and non-default. If neither launch_type or capacity_provider_strategy are provided, the new service will default to EC2 launch_type. The module handles the mutually exclusivity and also catches and fails cleanly when trying to change an existing service from launch_type to capacity_provider_strategy or vice versa.
Tested pretty thoroughly against ansible 2.9.27. Updated parameters, examples, and return objects provided.

Before merge the module will just ignore the capacity_provider_strategy and default to EC2 launch_type.
After merge the module will handle either launch_type or capacity_provider_strategy and create/update the service as necessary.

```
- community.aws.ecs_service:
    state: present
    name: test-service
    cluster: test-cluster
    task_definition: test-task-definition
    desired_count: 1
    capacity_provider_strategy:
      - capacity_provider: test-capacity-provider-1
        weight: 1
        base: 0
```