### PR TITLE
Tagging - remove default empty dict where purge_tags default is True

### DIFF
--- a/changelogs/fragments/1183-tagging.yml
+++ b/changelogs/fragments/1183-tagging.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- efs - the default value for ``tags`` has been updated, to remove all tags the ``tags`` parameter must be explicitly set to the empty dict ``{}`` (https://github.com/ansible-collections/community.aws/pull/1183).
+- ec2_transit_gateway - the default value for ``tags`` has been updated, to remove all tags the ``tags`` parameter must be explicitly set to the empty dict ``{}`` (https://github.com/ansible-collections/community.aws/pull/1183).
+- eks_fargate_profile - the default value for ``tags`` has been updated, to remove all tags the ``tags`` parameter must be explicitly set to the empty dict ``{}`` (https://github.com/ansible-collections/community.aws/pull/1183).
+- elb_target_group - explicitly setting the ``tags`` parameter to the empty dict ``{}`` will now remove all tags unles ``purge_tags`` is explicitly set to ``False`` (https://github.com/ansible-collections/community.aws/pull/1183).
+- ec2_transit_gateway - code updated to use common ``ensure_ec2_tags`` helper (https://github.com/ansible-collections/community.aws/pull/1183).

--- a/plugins/modules/efs.py
+++ b/plugins/modules/efs.py
@@ -28,12 +28,6 @@ options:
               required if you want to use a non-default CMK. If this parameter is not specified, the default CMK for
               Amazon EFS is used. The key id can be Key ID, Key ID ARN, Key Alias or Key Alias ARN.
         type: str
-    purge_tags:
-        description:
-            - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter. If the I(tags) parameter
-              is not set then tags will not be modified.
-        type: bool
-        default: true
     state:
         description:
             - Allows to create, search and destroy Amazon EFS file system.
@@ -107,8 +101,9 @@ options:
         version_added: 2.1.0
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+    - amazon.aws.aws
+    - amazon.aws.ec2
+    - amazon.aws.tags
 
 '''
 
@@ -725,7 +720,7 @@ def main():
         purge_tags=dict(default=True, type='bool'),
         id=dict(required=False, type='str', default=None),
         name=dict(required=False, type='str', default=None),
-        tags=dict(required=False, type="dict", default={}),
+        tags=dict(required=False, type="dict", aliases=['resource_tags']),
         targets=dict(required=False, type="list", default=[], elements='dict'),
         performance_mode=dict(required=False, type='str', choices=["general_purpose", "max_io"], default="general_purpose"),
         transition_to_ia=dict(required=False, type='str', choices=["None", "7", "14", "30", "60", "90"], default=None),

--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -12,10 +12,11 @@ module: elb_target_group
 version_added: 1.0.0
 short_description: Manage a target group for an Application or Network load balancer
 description:
-    - Manage an AWS Elastic Load Balancer target group. See
-      U(https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) or
-      U(https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html) for details.
-author: "Rob White (@wimnat)"
+  - Manage an AWS Elastic Load Balancer target group. See
+    U(https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) or
+    U(https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html) for details.
+author:
+  - "Rob White (@wimnat)"
 options:
   deregistration_delay_timeout:
     description:
@@ -88,13 +89,6 @@ options:
     required: false
     choices: [ 'http', 'https', 'tcp', 'tls', 'udp', 'tcp_udp', 'HTTP', 'HTTPS', 'TCP', 'TLS', 'UDP', 'TCP_UDP']
     type: str
-  purge_tags:
-    description:
-      - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter. If the tag parameter is not set then
-        tags will not be modified.
-    required: false
-    default: yes
-    type: bool
   state:
     description:
       - Create or destroy the target group.
@@ -143,11 +137,6 @@ options:
       - Requires the I(health_check_protocol) parameter to be set.
     required: false
     type: str
-  tags:
-    description:
-      - A dictionary of one or more tags to assign to the target group.
-    required: false
-    type: dict
   target_type:
     description:
       - The type of target that you must specify when registering targets with this target group. The possible values are
@@ -208,8 +197,9 @@ options:
     default: 200
     type: int
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 
 notes:
   - Once a target group has been created, only its health check can then be modified using subsequent calls
@@ -857,7 +847,7 @@ def create_or_update_target_group(connection, module):
         changed = True
 
     # Tags - only need to play with tags if tags parameter has been set to something
-    if tags:
+    if tags is not None:
         # Get tags
         current_tags = get_target_group_tags(connection, module, target_group['TargetGroupArn'])
 
@@ -931,7 +921,7 @@ def main():
         load_balancing_algorithm_type=dict(type='str', choices=['round_robin', 'least_outstanding_requests']),
         state=dict(required=True, choices=['present', 'absent']),
         successful_response_codes=dict(),
-        tags=dict(default={}, type='dict'),
+        tags=dict(type='dict', aliases=['resource_tags']),
         target_type=dict(choices=['instance', 'ip', 'lambda', 'alb']),
         targets=dict(type='list', elements='dict'),
         unhealthy_threshold_count=dict(type='int'),


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/844

##### SUMMARY

- Move modules over to the new tagging fragment
- Update modules to remove default tags of `{}` and use `None` instead, so that purging tags only happens if someone explicitly passes the tags parameter

##### ISSUE TYPE

- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME

plugins/modules/ec2_transit_gateway.py
plugins/modules/efs.py
plugins/modules/eks_fargate_profile.py
plugins/modules/elb_target_group.py

##### ADDITIONAL INFORMATION
