### PR TITLE
Tagging - Add simple deprecations for purge_tags=False

### DIFF
--- a/changelogs/fragments/1185-tagging.yml
+++ b/changelogs/fragments/1185-tagging.yml
@@ -1,0 +1,10 @@
+minor_changes:
+- aws_acm - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1185).
+- route53_health_check - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1185).
+- route53_zone - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1185).
+- sqs_queue - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1185).
+deprecated_features:
+- aws_acm - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True``.
+- route53_health_check - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True``.
+- route53_zone - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True``.
+- sqs_queue - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True``.

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -86,21 +86,14 @@ options:
       - Will default to C(3) if not specified on creation.
     choices: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
     type: int
-  tags:
-    description:
-      - A hash/dictionary of tags to set on the health check.
-    type: dict
-    version_added: 2.1.0
-  purge_tags:
-    description:
-      - Delete any tags not specified in I(tags).
-    default: false
-    type: bool
-    version_added: 2.1.0
-author: "zimbatm (@zimbatm)"
+author:
+  - "zimbatm (@zimbatm)"
+notes:
+  - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags.deprecated_purge
 '''
 
 EXAMPLES = '''
@@ -432,8 +425,8 @@ def main():
         string_match=dict(),
         request_interval=dict(type='int', choices=[10, 30], default=30),
         failure_threshold=dict(type='int', choices=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
-        tags=dict(type='dict'),
-        purge_tags=dict(type='bool', default=False),
+        tags=dict(type='dict', aliases=['resource_tags']),
+        purge_tags=dict(type='bool'),
     )
 
     args_one_of = [
@@ -453,6 +446,14 @@ def main():
         required_if=args_if,
         supports_check_mode=True,
     )
+
+    if module.params.get('purge_tags') is None:
+        module.deprecate(
+            'The purge_tags parameter currently defaults to False.'
+            ' For consistency across the collection, this default value'
+            ' will change to True in release 5.0.0.',
+            version='5.0.0', collection_name='community.aws')
+        module.params['purge_tags'] = False
 
     state_in = module.params.get('state')
     ip_addr_in = module.params.get('ip_address')

--- a/plugins/modules/route53_zone.py
+++ b/plugins/modules/route53_zone.py
@@ -46,23 +46,14 @@ options:
             - The reusable delegation set ID to be associated with the zone.
             - Note that you can't associate a reusable delegation set with a private hosted zone.
         type: str
-    tags:
-        description:
-            - A hash/dictionary of tags to add to the new instance or to add/remove from an existing one.
-        type: dict
-        version_added: 2.1.0
-    purge_tags:
-        description:
-            - Delete any tags not specified in the task that are on the zone.
-              This means you have to specify all the desired tags on each task affecting a zone.
-        default: false
-        type: bool
-        version_added: 2.1.0
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
-author: "Christopher Troup (@minichate)"
+    - amazon.aws.aws
+    - amazon.aws.ec2
+    - amazon.aws.tags.deprecated_purge
+notes:
+    - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
+author:
+    - "Christopher Troup (@minichate)"
 '''
 
 EXAMPLES = r'''
@@ -445,8 +436,8 @@ def main():
         comment=dict(default=''),
         hosted_zone_id=dict(),
         delegation_set_id=dict(),
-        tags=dict(type='dict'),
-        purge_tags=dict(type='bool', default=False),
+        tags=dict(type='dict', aliases=['resource_tags']),
+        purge_tags=dict(type='bool'),
     )
 
     mutually_exclusive = [
@@ -459,6 +450,14 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
+
+    if module.params.get('purge_tags') is None:
+        module.deprecate(
+            'The purge_tags parameter currently defaults to False.'
+            ' For consistency across the collection, this default value'
+            ' will change to True in release 5.0.0.',
+            version='5.0.0', collection_name='community.aws')
+        module.params['purge_tags'] = False
 
     zone_in = module.params.get('zone').lower()
     state = module.params.get('state').lower()


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/844

##### SUMMARY

Deprecate the use of purge_tags=False as a default

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_acm.py
plugins/modules/route53_health_check.py
plugins/modules/route53_zone.py
plugins/modules/sqs_queue.py

##### ADDITIONAL INFORMATION
