### PR TITLE
ecs_service and ecs_service_info: add name and service aliases

### DIFF
--- a/changelogs/fragments/0001-ecs-service-aliases.yml
+++ b/changelogs/fragments/0001-ecs-service-aliases.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ecs_service - add ``service`` alias to address the ecs service name with the same parameter as the ecs_service_info module is doing (https://github.com/ansible-collections/community.aws/pull/1187).
+- ecs_service_info - add ``name`` alias to address the ecs service name with the same parameter as the ecs_service module is doing (https://github.com/ansible-collections/community.aws/pull/1187).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -34,6 +34,7 @@ options:
           - The name of the service.
         required: true
         type: str
+        aliases: ['service']
     cluster:
         description:
           - The name of the cluster in which the service exists.
@@ -662,7 +663,7 @@ class EcsServiceManager:
 def main():
     argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent', 'deleting']),
-        name=dict(required=True, type='str'),
+        name=dict(required=True, type='str', aliases=['service']),
         cluster=dict(required=False, type='str'),
         task_definition=dict(required=False, type='str'),
         load_balancers=dict(required=False, default=[], type='list', elements='dict'),

--- a/plugins/modules/ecs_service_info.py
+++ b/plugins/modules/ecs_service_info.py
@@ -40,6 +40,7 @@ options:
         required: false
         type: list
         elements: str
+        aliases: ['name']
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -214,7 +215,7 @@ def main():
         details=dict(type='bool', default=False),
         events=dict(type='bool', default=True),
         cluster=dict(),
-        service=dict(type='list', elements='str')
+        service=dict(type='list', elements='str', aliases=['name'])
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)


### PR DESCRIPTION
##### SUMMARY

while `ecs_service` is using `name` for the service name parameter, `ecs_service_info` is using `service` for the same purpose.  
this PR adds just aliases to both modules, to use the same parameter to address the ecs service name.

ref https://github.com/ansible-collections/community.aws/issues/1142

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
ecs_service  
ecs_service_info

