### PR TITLE
ec2_vpc_nacl - Add support for purge_tags

### DIFF
--- a/changelogs/fragments/1189-ec2_vpc_nacl-tagging.yml
+++ b/changelogs/fragments/1189-ec2_vpc_nacl-tagging.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- ec2_vpc_nacl - add support for ``purge_tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1189).
+- ec2_vpc_nacl - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1189).
+- ec2_vpc_nacl - the default value for ``tags`` has been updated, to remove all tags the ``tags`` parameter must be explicitly set to the empty dict ``{}`` and ``purge_tags`` to ``True`` (https://github.com/ansible-collections/community.aws/pull/1189).

--- a/tests/integration/targets/ec2_vpc_nacl/aliases
+++ b/tests/integration/targets/ec2_vpc_nacl/aliases
@@ -1,6 +1,3 @@
-# https://github.com/ansible-collections/community.aws/issues/153
-unstable
-
 cloud/aws
 
 ec2_vpc_nacl_info

--- a/tests/integration/targets/ec2_vpc_nacl/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+vpc_name: '{{ resource_prefix }}-ec2-vpc-nacl'
+nacl_name: '{{ resource_prefix }}-ec2-vpc-nacl'
+subnet_name: '{{ resource_prefix }}-ec2-vpc-nacl'
+vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
+subnet_1: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+subnet_2: '10.{{ 256 | random(seed=resource_prefix) }}.2.0/24'
+subnet_3: '10.{{ 256 | random(seed=resource_prefix) }}.3.0/24'
+subnet_4: '10.{{ 256 | random(seed=resource_prefix) }}.4.0/24'
+
+vpc_ipv6_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.5.0/25'
+vpc_ipv6_name: '{{ vpc_name }}-ipv6'

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml
@@ -1,162 +1,158 @@
 # ============================================================
+- block:
+  - name: create ingress and egress rules using subnet IDs
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags:
+        Created_by: "Ansible test {{ resource_prefix }}"
+      ingress:
+        - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+        - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+        - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+      egress:
+        - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+      state: 'present'
+    register: nacl
 
-- name: create ingress and egress rules using subnet IDs
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    tags:
-      Created_by: "Ansible test {{ resource_prefix }}"
-    ingress:
-      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
-      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-      - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
-    egress:
-      - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
-    state: 'present'
-  register: nacl
+  - name: assert the network acl was created
+    assert:
+      that:
+        - nacl.changed
+        - nacl.nacl_id.startswith('acl-')
 
-- name: assert the network acl was created
-  assert:
-    that:
-      - nacl.changed
-      - nacl.nacl_id.startswith('acl-')
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_facts
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: assert the nacl has the correct attributes
+    assert:
+      that:
+        - nacl_facts.nacls | length == 1
+        - nacl_facts.nacls[0].ingress | length == 3
+        - nacl_facts.nacls[0].egress | length == 1
 
-- name: assert the nacl has the correct attributes
-  assert:
-    that:
-      - nacl_facts.nacls | length == 1
-      - nacl_facts.nacls[0].ingress | length == 3
-      - nacl_facts.nacls[0].egress | length == 1
+  # ============================================================
 
-# ============================================================
+  - name: remove an ingress rule
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags:
+        Created_by: "Ansible test {{ resource_prefix }}"
+      ingress:
+        - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+        - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+      egress:
+        - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+      state: 'present'
+    register: nacl
 
-- name: remove an ingress rule
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    tags:
-      Created_by: "Ansible test {{ resource_prefix }}"
-    ingress:
-      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
-      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-    egress:
-      - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
-    state: 'present'
-  register: nacl
+  - name: assert the network acl changed
+    assert:
+      that:
+        - nacl.changed
+        - nacl.nacl_id.startswith('acl-')
 
-- name: assert the network acl changed
-  assert:
-    that:
-      - nacl.changed
-      - nacl.nacl_id.startswith('acl-')
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_facts
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: assert the nacl has the correct attributes
+    assert:
+      that:
+        - nacl_facts.nacls | length == 1
+        - nacl_facts.nacls[0].ingress | length == 2
+        - nacl_facts.nacls[0].egress | length == 1
 
-- name: assert the nacl has the correct attributes
-  assert:
-    that:
-      - nacl_facts.nacls | length == 1
-      - nacl_facts.nacls[0].ingress | length == 2
-      - nacl_facts.nacls[0].egress | length == 1
+  # ============================================================
 
-# ============================================================
+  - name: remove the egress rule
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags:
+        Created_by: "Ansible test {{ resource_prefix }}"
+      ingress:
+        - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+        - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+      egress: []
+      state: 'present'
+    register: nacl
 
-- name: remove the egress rule
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    tags:
-      Created_by: "Ansible test {{ resource_prefix }}"
-    ingress:
-      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
-      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-    egress: []
-    state: 'present'
-  register: nacl
+  - name: assert the network acl changed
+    assert:
+      that:
+        - nacl.changed
+        - nacl.nacl_id.startswith('acl-')
 
-- name: assert the network acl changed
-  assert:
-    that:
-      - nacl.changed
-      - nacl.nacl_id.startswith('acl-')
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_facts
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: assert the nacl has the correct attributes
+    assert:
+      that:
+        - nacl_facts.nacls | length == 1
+        - nacl_facts.nacls[0].ingress | length == 2
+        - nacl_facts.nacls[0].egress | length == 0
 
-- name: assert the nacl has the correct attributes
-  assert:
-    that:
-      - nacl_facts.nacls | length == 1
-      - nacl_facts.nacls[0].ingress | length == 2
-      - nacl_facts.nacls[0].egress | length == 0
+  # ============================================================
 
-# ============================================================
+  - name: add egress rules
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags:
+        Created_by: "Ansible test {{ resource_prefix }}"
+      ingress:
+        - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+        - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+      egress:
+        - [100, 'tcp', 'allow', '10.0.0.0/24', null, null, 22, 22]
+        - [200, 'udp', 'allow', '10.0.0.0/24', null, null, 22, 22]
+      state: 'present'
+    register: nacl
 
-- name: add egress rules
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    tags:
-      Created_by: "Ansible test {{ resource_prefix }}"
-    ingress:
-      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
-      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-    egress:
-      - [100, 'tcp', 'allow', '10.0.0.0/24', null, null, 22, 22]
-      - [200, 'udp', 'allow', '10.0.0.0/24', null, null, 22, 22]
-    state: 'present'
-  register: nacl
+  - name: assert the network acl changed
+    assert:
+      that:
+        - nacl.changed
+        - nacl.nacl_id.startswith('acl-')
 
-- name: assert the network acl changed
-  assert:
-    that:
-      - nacl.changed
-      - nacl.nacl_id.startswith('acl-')
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_facts
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: assert the nacl has the correct attributes
+    assert:
+      that:
+        - nacl_facts.nacls | length == 1
+        - nacl_facts.nacls[0].ingress | length == 2
+        - nacl_facts.nacls[0].egress | length == 2
 
-- name: assert the nacl has the correct attributes
-  assert:
-    that:
-      - nacl_facts.nacls | length == 1
-      - nacl_facts.nacls[0].ingress | length == 2
-      - nacl_facts.nacls[0].egress | length == 2
+  # ============================================================
 
-# ============================================================
+  - name: remove the network ACL
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      state: absent
+    register: nacl
 
-- name: remove the network ACL
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    state: absent
-  register: nacl
-  until: nacl is success
-  ignore_errors: yes
-  retries: 5
-  delay: 5
-
-- name: assert nacl was removed
-  assert:
-    that:
-      - nacl.changed
+  - name: assert nacl was removed
+    assert:
+      that:
+        - nacl.changed

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
@@ -1,39 +1,13 @@
 - block:
-    - name: create a VPC
-      ec2_vpc_net:
-        cidr_block: 10.230.231.0/24
-        name: "{{ resource_prefix }}-ipv6"
-        state: present
-        ipv6_cidr: yes
-      register: vpc_result
-
-    - set_fact:
-        vpc_ipv6_cidr: "{{ vpc_result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block }}"
-
-    # ============================================================
-    - name: create subnet with IPv6 (expected changed=true)
-      ec2_vpc_subnet:
-        cidr: 10.230.231.0/26
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
-        state: present
-        tags:
-          Name: "{{ resource_prefix }}-ipv6-subnet-1"
-      register: vpc_subnet_ipv6
-
-    - name: assert creation with IPv6 happened (expected changed=true)
-      assert:
-        that:
-           - "vpc_subnet_ipv6.subnet.ipv6_cidr_block == '{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}'"
 
     # ============================================================
 
     - name: create ingress and egress rules using subnet names
       ec2_vpc_nacl:
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        name: "{{ resource_prefix }}-acl"
+        vpc_id: "{{ vpc_ipv6_id }}"
+        name: "{{ nacl_name }}"
         subnets:
-          - "{{ resource_prefix }}-ipv6-subnet-1"
+          - "{{ subnet_name }}-ipv6"
         tags:
           Created_by: "Ansible test {{ resource_prefix }}"
         ingress:
@@ -53,10 +27,10 @@
 
     - name: add ipv6 entries
       ec2_vpc_nacl:
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        name: "{{ resource_prefix }}-acl"
+        vpc_id: "{{ vpc_ipv6_id }}"
+        name: "{{ nacl_name }}"
         subnets:
-          - "{{ resource_prefix }}-ipv6-subnet-1"
+          - "{{ subnet_name }}-ipv6"
         tags:
           Created_by: "Ansible test {{ resource_prefix }}"
         ingress:
@@ -91,10 +65,10 @@
 
     - name: purge ingress entries
       ec2_vpc_nacl:
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        name: "{{ resource_prefix }}-acl"
+        vpc_id: "{{ vpc_ipv6_id }}"
+        name: "{{ nacl_name }}"
         subnets:
-          - "{{ resource_prefix }}-ipv6-subnet-1"
+          - "{{ subnet_name }}-ipv6"
         tags:
           Created_by: "Ansible test {{ resource_prefix }}"
         ingress: []
@@ -111,10 +85,10 @@
 
     - name: purge egress entries
       ec2_vpc_nacl:
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        name: "{{ resource_prefix }}-acl"
+        vpc_id: "{{ vpc_ipv6_id }}"
+        name: "{{ nacl_name }}"
         subnets:
-          - "{{ resource_prefix }}-ipv6-subnet-1"
+          - "{{ subnet_name }}-ipv6"
         tags:
           Created_by: "Ansible test {{ resource_prefix }}"
         ingress: []
@@ -139,54 +113,12 @@
           - nacl_facts.nacls[0].ingress | length == 0
           - nacl_facts.nacls[0].egress | length == 0
 
-    # ============================================================
-    - name: remove subnet ipv6 cidr (expected changed=true)
-      ec2_vpc_subnet:
-        cidr: 10.230.231.0/26
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        state: absent
-      register: vpc_remove_ipv6_cidr
-
-    - name: assert subnet ipv6 cidr removed (expected changed=true)
-      assert:
-        that:
-           - 'vpc_remove_ipv6_cidr.changed'
-
   always:
-
-    ################################################
-    # TEARDOWN STARTS HERE
-    ################################################
 
     - name: remove network ACL
       ec2_vpc_nacl:
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        name: "{{ resource_prefix }}-acl"
+        vpc_id: "{{ vpc_ipv6_id }}"
+        name: "{{ nacl_name }}"
         state: absent
       register: removed_acl
-      until: removed_acl is success
-      retries: 5
-      delay: 5
-      ignore_errors: yes
-
-    - name: tidy up subnet
-      ec2_vpc_subnet:
-        cidr: 10.230.231.0/26
-        vpc_id: "{{ vpc_result.vpc.id }}"
-        state: absent
-      register: removed_subnet
-      until: removed_subnet is success
-      retries: 5
-      delay: 5
-      ignore_errors: yes
-
-    - name: tidy up VPC
-      ec2_vpc_net:
-        name: "{{ resource_prefix }}-ipv6"
-        state: absent
-        cidr_block: 10.230.231.0/24
-      register: removed_vpc
-      until: removed_vpc is success
-      retries: 5
-      delay: 5
       ignore_errors: yes

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/main.yml
@@ -63,55 +63,75 @@
 
     - name: create a VPC
       ec2_vpc_net:
-        cidr_block: 10.230.230.0/24
-        name: "{{ resource_prefix }}"
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ vpc_name }}"
         state: present
       register: vpc
+
+    - name: Save VPC ID for later
+      set_fact:
+        vpc_id: "{{ vpc.vpc.id }}"
 
     - name: create subnets
       ec2_vpc_subnet:
         cidr: "{{ item.cidr }}"
         az: "{{ item.az }}"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc_id: "{{ vpc_id }}"
         state: present
         tags:
           Name: "{{ item.name }}"
       with_items:
-        - cidr: 10.230.230.0/26
+        - cidr: "{{ subnet_1 }}"
           az: "{{ az_one }}"
-          name: "{{ resource_prefix }}-subnet-1"
-        - cidr: 10.230.230.64/26
+          name: "{{ subnet_name }}-1"
+        - cidr: "{{ subnet_2 }}"
           az: "{{ az_two }}"
-          name: "{{ resource_prefix }}-subnet-2"
-        - cidr: 10.230.230.128/26
+          name: "{{ subnet_name }}-2"
+        - cidr: "{{ subnet_3 }}"
           az: "{{ az_one }}"
-          name: "{{ resource_prefix }}-subnet-3"
-        - cidr: 10.230.230.192/26
+          name: "{{ subnet_name }}-3"
+        - cidr: "{{ subnet_4 }}"
           az: "{{ az_two }}"
-          name: "{{ resource_prefix }}-subnet-4"
+          name: "{{ subnet_name }}-4"
       register: subnets
+
+    - name: set helpful facts about subnets
+      set_fact:
+        subnet_ids: "{{ subnets | community.general.json_query('results[*].subnet.id') }}"
+        subnet_names: "{{ subnets | community.general.json_query('results[*].subnet.tags.Name') }}"
+
+    - name: create VPC for IPv6 tests
+      ec2_vpc_net:
+        cidr_block: "{{ vpc_ipv6_cidr }}"
+        name: "{{ vpc_ipv6_name }}"
+        state: present
+        ipv6_cidr: yes
+      register: vpc_result
+    - set_fact:
+        vpc_ipv6_id: "{{ vpc_result.vpc.id }}"
+        vpc_ipv6_cidr_v6: "{{ _ipv6_cidr }}"
+        subnet_ipv6: "{{ _ipv6_cidr | regex_replace('::/56', '::/64') }}"
+      vars:
+        _ipv6_cidr: "{{ vpc_result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block }}"
+
+    - name: create subnet with IPv6
+      ec2_vpc_subnet:
+        cidr: "{{ vpc_ipv6_cidr }}"
+        vpc_id: "{{ vpc_ipv6_id }}"
+        ipv6_cidr: "{{ subnet_ipv6 }}"
+        state: present
+        tags:
+          Name: "{{ subnet_name }}-ipv6"
 
     # ============================================================
 
     - include_tasks: tasks/subnet_ids.yml
-      vars:
-        vpc_id: "{{ vpc.vpc.id }}"
-        subnet_ids: "{{ subnets | community.general.json_query('results[*].subnet.id') }}"
 
     - include_tasks: tasks/subnet_names.yml
-      vars:
-        vpc_id: "{{ vpc.vpc.id }}"
-        subnet_names: "{{ subnets | community.general.json_query('results[*].subnet.tags.Name') }}"
 
     - include_tasks: tasks/tags.yml
-      vars:
-        vpc_id: "{{ vpc.vpc.id }}"
-        subnet_ids: "{{ subnets | community.general.json_query('results[*].subnet.id') }}"
 
     - include_tasks: tasks/ingress_and_egress.yml
-      vars:
-        vpc_id: "{{ vpc.vpc.id }}"
-        subnet_ids: "{{ subnets | community.general.json_query('results[*].subnet.id') }}"
 
     - include_tasks: tasks/ipv6.yml
 
@@ -121,52 +141,35 @@
 
     - name: remove network ACL
       ec2_vpc_nacl:
-        vpc_id: "{{ vpc.vpc.id }}"
-        name: "{{ resource_prefix }}-acl"
+        vpc_id: "{{ vpc_id }}"
+        name: "{{ nacl_name }}"
         state: absent
       register: removed_acl
-      until: removed_acl is success
-      retries: 5
-      delay: 5
       ignore_errors: yes
 
     - name: remove subnets
       ec2_vpc_subnet:
         cidr: "{{ item.cidr }}"
-        az: "{{ aws_region}}{{ item.az }}"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc_id: "{{ item.vpc_id | default(vpc_id) }}"
         state: absent
-        tags:
-          Public: "{{ item.public | string }}"
-          Name: "{{ item.public | ternary('public', 'private') }}-{{ item.az }}"
       with_items:
-        - cidr: 10.230.230.0/26
-          az: "a"
-          public: "True"
-        - cidr: 10.230.230.64/26
-          az: "b"
-          public: "True"
-        - cidr: 10.230.230.128/26
-          az: "a"
-          public: "False"
-        - cidr: 10.230.230.192/26
-          az: "b"
-          public: "False"
+        - cidr: "{{ subnet_1 }}"
+        - cidr: "{{ subnet_2 }}"
+        - cidr: "{{ subnet_3 }}"
+        - cidr: "{{ subnet_4 }}"
+        - cidr: "{{ vpc_ipv6_cidr }}"
+          vpc_id: "{{ vpc_ipv6_id }}"
       ignore_errors: yes
       register: removed_subnets
-      until: removed_subnets is success
-      retries: 5
-      delay: 5
 
-    - name: remove the VPC
+    - name: remove the VPCs
       ec2_vpc_net:
-        cidr_block: 10.230.230.0/24
-        name: "{{ resource_prefix }}"
+        vpc_id: "{{ item }}"
         state: absent
       ignore_errors: yes
       register: removed_vpc
-      until: removed_vpc is success
-      retries: 5
-      delay: 5
+      with_items:
+        - '{{ vpc_id }}'
+        - '{{ vpc_ipv6_id }}'
 
     # ============================================================

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml
@@ -3,7 +3,7 @@
 - name: create ingress and egress rules using subnet IDs
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
@@ -40,14 +40,14 @@
       - nacl_facts.nacls[0].subnets | sort == subnet_ids | sort
       - nacl_facts.nacls[0].ingress | length == 3
       - nacl_facts.nacls[0].egress | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+      - nacl_facts.nacls[0].tags.Name == nacl_name
 
 # ============================================================
 
 - name: test idempotence
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
@@ -83,7 +83,7 @@
 - name: remove a subnet from the network ACL
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     subnets:
       - "{{ subnet_ids[0] }}"
       - "{{ subnet_ids[1] }}"
@@ -121,20 +121,16 @@
       - subnet_ids[3] not in nacl_facts.nacls[0].subnets
       - nacl_facts.nacls[0].ingress | length == 3
       - nacl_facts.nacls[0].egress | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+      - nacl_facts.nacls[0].tags.Name == nacl_name
 
 # ============================================================
 
 - name: remove the network ACL
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     state: absent
   register: nacl
-  until: nacl is success
-  ignore_errors: yes
-  retries: 5
-  delay: 5
 
 - name: assert nacl was removed
   assert:
@@ -144,14 +140,9 @@
 - name: re-remove the network ACL by name (test idempotency)
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     state: absent
   register: nacl
-  until: nacl is success
-  ignore_errors: yes
-  retries: 5
-  delay: 5
-
 - name: assert nacl was removed
   assert:
     that:
@@ -163,10 +154,6 @@
     nacl_id: "{{ nacl_id }}"
     state: absent
   register: nacl
-  until: nacl is success
-  ignore_errors: yes
-  retries: 5
-  delay: 5
 
 - name: assert nacl was removed
   assert:

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/subnet_names.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/subnet_names.yml
@@ -3,7 +3,7 @@
 - name: create ingress and egress rules using subnet names
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     subnets: "{{ subnet_names }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
@@ -39,14 +39,14 @@
       - nacl_facts.nacls[0].subnets | length == 4
       - nacl_facts.nacls[0].ingress | length == 3
       - nacl_facts.nacls[0].egress | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+      - nacl_facts.nacls[0].tags.Name == nacl_name
 
 # ============================================================
 
 - name: test idempotence
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     subnets: "{{ subnet_names }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
@@ -82,7 +82,7 @@
 - name: remove a subnet from the network ACL
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     subnets:
       - "{{ subnet_names[0] }}"
       - "{{ subnet_names[1] }}"
@@ -119,20 +119,16 @@
       - nacl_facts.nacls[0].subnets | length == 3
       - nacl_facts.nacls[0].ingress | length == 3
       - nacl_facts.nacls[0].egress | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+      - nacl_facts.nacls[0].tags.Name == nacl_name
 
 # ============================================================
 
 - name: remove the network ACL
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
+    name: "{{ nacl_name }}"
     state: absent
   register: nacl
-  until: nacl is success
-  ignore_errors: yes
-  retries: 5
-  delay: 5
 
 - name: assert nacl was removed
   assert:

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/tags.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/tags.yml
@@ -1,117 +1,445 @@
-# ============================================================
+- vars:
+    first_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      'New Key with Spaces': Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+    final_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    name_tags:
+      Name: '{{ nacl_name }}'
+  block:
 
-- name: create a network ACL using subnet IDs
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    state: 'present'
-  register: nacl
+  # ============================================================
 
-- name: assert the network acl was created
-  assert:
-    that:
-      - nacl.changed
-      - nacl.nacl_id.startswith('acl-')
+  - name: create a network ACL using subnet IDs
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      state: 'present'
+    register: nacl
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: assert the network acl was created
+    assert:
+      that:
+        - nacl.changed
+        - nacl.nacl_id.startswith('acl-')
 
-- name: assert the nacl has the correct attributes
-  assert:
-    that:
-      - nacl_facts.nacls[0].tags | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+  - name: Store NACL ID
+    set_fact:
+      nacl_id: '{{ nacl.nacl_id }}'
 
-# ============================================================
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl_id }}"
+    register: nacl_info
 
-- name: add a tag
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    tags:
-      Created_by: "Ansible test {{ resource_prefix }}"
-    state: 'present'
-  register: nacl
+  - name: assert the nacl has the correct attributes
+    assert:
+      that:
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == name_tags
 
-- name: assert the network acl changed
-  assert:
-    that:
-      - nacl.changed
+  # ============================================================
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: (check) add tags
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ first_tags }}"
+      state: 'present'
+    register: nacl
+    check_mode: True
 
-- name: assert the facts are the same as before
-  assert:
-    that:
-      - nacl_facts.nacls[0].tags | length == 2
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
-      - "'{{ nacl_facts.nacls[0].tags.Created_by }}' == 'Ansible test {{ resource_prefix }}'"
+  - name: assert would change
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
 
-- name: get network ACL facts by filter
-  ec2_vpc_nacl_info:
-    filters:
-      "tag:Created_by": "Ansible test {{ resource_prefix }}"
-  register: nacl_facts
+  - name: add tags
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ first_tags }}"
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
 
-- name: assert the facts are the same as before
-  assert:
-    that:
-      - nacl_facts.nacls | length == 1
-      - nacl_facts.nacls[0].tags | length == 2
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
-      - "'{{ nacl_facts.nacls[0].tags.Created_by }}' == 'Ansible test {{ resource_prefix }}'"
+  - name: verify the tags were added
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( first_tags | combine(name_tags) )
 
-# ============================================================
+  - name: (check) add tags - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ first_tags }}"
+      state: 'present'
+    register: nacl
+    check_mode: True
 
-- name: remove a tag
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_ids }}"
-    state: 'present'
-  register: nacl
+  - name: assert would not change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
 
-- name: assert the network acl was created
-  assert:
-    that:
-      - nacl.changed
-      - nacl.nacl_id.startswith('acl-')
+  - name: add tags - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ first_tags }}"
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
 
-- name: get network ACL facts
-  ec2_vpc_nacl_info:
-    nacl_ids:
-      - "{{ nacl.nacl_id }}"
-  register: nacl_facts
+  - name: verify no change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( first_tags | combine(name_tags) )
 
-- name: assert the nacl has the correct attributes
-  assert:
-    that:
-      - nacl_facts.nacls[0].tags | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+  # ============================================================
 
-# ============================================================
+  - name: get network ACL facts by filter
+    ec2_vpc_nacl_info:
+      filters:
+        "tag:Name": "{{ nacl_name }}"
+    register: nacl_info
 
-- name: remove the network ACL
-  ec2_vpc_nacl:
-    vpc_id: "{{ vpc_id }}"
-    name: "{{ resource_prefix }}-acl"
-    state: absent
-  register: nacl
-  until: nacl is success
-  ignore_errors: yes
-  retries: 5
-  delay: 5
+  - name: assert the facts are the same as before
+    assert:
+      that:
+        - nacl_info.nacls | length == 1
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
 
-- name: assert nacl was removed
-  assert:
-    that:
-      - nacl.changed
+  # ============================================================
+
+  - name: (check) modify tags with purge
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ second_tags }}"
+      state: 'present'
+    register: nacl
+    check_mode: True
+
+  - name: assert would change
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+
+  - name: modify tags with purge
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ second_tags }}"
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( second_tags | combine(name_tags) )
+
+  - name: (check) modify tags with purge - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ second_tags }}"
+      state: 'present'
+    register: nacl
+    check_mode: True
+
+  - name: assert would not change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+
+  - name: modify tags with purge - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ second_tags }}"
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify no change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( second_tags | combine(name_tags) )
+
+  # ============================================================
+
+  - name: (check) modify tags without purge
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ third_tags }}"
+      state: 'present'
+      purge_tags: False
+    register: nacl
+    check_mode: True
+
+  - name: assert would change
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+
+  - name: modify tags without purge
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ third_tags }}"
+      state: 'present'
+      purge_tags: False
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( final_tags | combine(name_tags) )
+
+  - name: (check) modify tags without purge - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ third_tags }}"
+      state: 'present'
+      purge_tags: False
+    register: nacl
+    check_mode: True
+
+  - name: assert would not change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+
+  - name: modify tags without purge - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: "{{ third_tags }}"
+      state: 'present'
+      purge_tags: False
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify no change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( final_tags | combine(name_tags) )
+
+  # ============================================================
+
+  - name: (check) No change to tags without setting tags
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      state: 'present'
+    register: nacl
+    check_mode: True
+
+  - name: assert would change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+
+  - name: No change to tags without setting tags
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == ( final_tags | combine(name_tags) )
+
+  # ============================================================
+
+  - name: (check) remove non name tags
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: {}
+      state: 'present'
+    register: nacl
+    check_mode: True
+
+  - name: assert would change
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+
+  - name: remove non name tags
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: {}
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - nacl is changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == name_tags
+
+  - name: (check) remove non name tags - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: {}
+      state: 'present'
+    register: nacl
+    check_mode: True
+
+  - name: assert would not change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+
+  - name: remove non name tags - IDEMPOTENCY
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      subnets: "{{ subnet_ids }}"
+      tags: {}
+      state: 'present'
+    register: nacl
+  - name: get network ACL facts
+    ec2_vpc_nacl_info:
+      nacl_ids:
+        - "{{ nacl.nacl_id }}"
+    register: nacl_info
+
+  - name: verify no change
+    assert:
+      that:
+        - nacl is not changed
+        - nacl.nacl_id == nacl_id
+        - nacl_info.nacls[0].nacl_id == nacl_id
+        - nacl_info.nacls[0].tags == name_tags
+
+  # ============================================================
+
+  always:
+  - name: remove the network ACL
+    ec2_vpc_nacl:
+      vpc_id: "{{ vpc_id }}"
+      name: "{{ nacl_name }}"
+      state: absent
+    register: nacl
+
+  - name: assert nacl was removed
+    assert:
+      that:
+        - nacl.changed


### PR DESCRIPTION
##### SUMMARY

- Add support to ec2_vpc_nacl for purge_tags
- Use ec2 helper for tagging
- Use TaggingSpecifications on creation

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_nacl

##### ADDITIONAL INFORMATION

- [x] Changelog
- [x] Integration tests