### PR TITLE
sns_topic - Fix bug when used in GovCloud - issue 836

### DIFF
--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -365,9 +365,11 @@ class SnsTopicManager(object):
     def _create_topic(self):
         attributes = {'FifoTopic': 'false'}
         tags = []
+        endpoint = self.module.region
 
         if self.topic_type == 'fifo':
-            attributes['FifoTopic'] = 'true'
+            if "us-gov" not in endpoint:
+                attributes['FifoTopic'] = 'true'
             if not self.name.endswith('.fifo'):
                 self.name = self.name + '.fifo'
 

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -366,6 +366,7 @@ class SnsTopicManager(object):
         self.attributes_set = []
 
     def _create_topic(self):
+        attributes = {}
         tags = []
 
         # NOTE: Never set FifoTopic = False. Some regions (including GovCloud)

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -28,8 +28,8 @@ options:
     description:
       - The type of topic that should be created. Either Standard for FIFO (first-in, first-out).
       - Some regions, including GovCloud regions do not support FIFO topics.
-      - Use a default value of  'standard' or omit the option if the region
-      - does not support FIFO topics.
+        Use a default value of  'standard' or omit the option if the region
+        does not support FIFO topics.
     choices: ["standard", "fifo"]
     default: 'standard'
     type: str

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -372,7 +372,7 @@ class SnsTopicManager(object):
         # NOTE: Never set FifoTopic = False. Some regions (including GovCloud)
         # don't support the attribute being set, even to False.
         if self.topic_type == 'fifo':
-            attributes = {'FifoTopic': 'true'}
+            attributes['FifoTopic'] = 'true'
             if not self.name.endswith('.fifo'):
                 self.name = self.name + '.fifo'
 


### PR DESCRIPTION
##### SUMMARY
Add region detection to skip usage of FIFO topics when using GovCloud regions
Fixes #836

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.aws.sns_topic`
