### PR TITLE
rds_instance - fix sporadic test failure in processor features

### DIFF
--- a/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_processor.yml
+++ b/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_processor.yml
@@ -102,13 +102,18 @@
           apply_immediately: true
         register: result
 
+      # Check if processor features either are pending or already changed
       - assert:
           that:
             - not result.changed
-            - 'result.pending_modified_values.processor_features.coreCount == "{{ modified_processor_features.coreCount }}"
-                or result.processor_features.coreCount == "{{ modified_processor_features.coreCount }}"'
-            - 'result.pending_modified_values.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore }}"
-                or result.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore }}"'
+            - '(result.pending_modified_values.processor_features.coreCount is defined and
+               result.pending_modified_values.processor_features.coreCount == "{{ modified_processor_features.coreCount }}") or
+               (result.processor_features.coreCount is defined and
+               result.processor_features.coreCount == "{{ modified_processor_features.coreCount }}")'
+            - '(result.pending_modified_values.processor_features.threadsPerCore is defined and
+               result.pending_modified_values.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore }}") or
+               (result.processor_features.threadsPerCore is defined and
+               result.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore }}")'
 
     always:
 


### PR DESCRIPTION
##### SUMMARY
Seen a few failures in CI testing when professor features are actually applied and not pending (in `pending_modified_values`)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rds_instance

##### ADDITIONAL INFORMATION
when processor features are applied and not pending:
```
2022-06-01 22:24:33.960215 | controller |     "pending_modified_values": {},
2022-06-01 22:24:33.960221 | controller |     "performance_insights_enabled": false,
2022-06-01 22:24:33.960227 | controller |     "preferred_backup_window": "06:49-07:19",
2022-06-01 22:24:33.960234 | controller |     "preferred_maintenance_window": "thu:06:19-thu:06:49",
2022-06-01 22:24:33.960239 | controller |     "processor_features": {
2022-06-01 22:24:33.960245 | controller |         "coreCount": "4",
2022-06-01 22:24:33.960252 | controller |         "threadsPerCore": "2"
2022-06-01 22:24:33.960258 | controller |     },
```
```paste below
2022-06-01 22:24:45.612919 | controller | TASK [rds_instance : assert] ***************************************************
2022-06-01 22:24:45.613111 | controller | task path: /home/zuul/.ansible/collections/ansible_collections/community/aws/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_processor.yml:105
2022-06-01 22:24:45.613324 | controller | fatal: [processor]: FAILED! => {
2022-06-01 22:24:45.613339 | controller |     "msg": "The conditional check 'result.pending_modified_values.processor_features.coreCount == \"4\" or result.processor_features.coreCount == \"4\"' failed. The error was: error while evaluating conditional (result.pending_modified_values.processor_features.coreCount == \"4\" or result.processor_features.coreCount == \"4\"): 'dict object' has no attribute 'processor_features'"
2022-06-01 22:24:45.613347 | controller | }
```
