### PR TITLE
ec2_customer_gateway: fix bgp_asn documentation inconsistency

### DIFF
--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -23,7 +23,8 @@ notes:
 options:
   bgp_asn:
     description:
-      - Border Gateway Protocol (BGP) Autonomous System Number (ASN), required when I(state=present).
+      - Border Gateway Protocol (BGP) Autonomous System Number (ASN).
+      - Defaults to 65000 if not specified when I(state=present).
     type: int
   ip_address:
     description:

--- a/plugins/modules/ec2_customer_gateway.py
+++ b/plugins/modules/ec2_customer_gateway.py
@@ -24,7 +24,7 @@ options:
   bgp_asn:
     description:
       - Border Gateway Protocol (BGP) Autonomous System Number (ASN).
-      - Defaults to 65000 if not specified when I(state=present).
+      - Defaults to C(65000) if not specified when I(state=present).
     type: int
   ip_address:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1075 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_customer_gateway

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->


While current documentation for the parameter states that
`Border Gateway Protocol (BGP) Autonomous System Number (ASN), required when I(state=present).`,
 according to [ boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_customer_gateway), `bgp_asn` defaults to 65000.


