### PR TITLE
Tagging - ec2_snapshot_copy

### DIFF
--- a/changelogs/fragments/1201-tagging-ec2_snapshot_copy.yml
+++ b/changelogs/fragments/1201-tagging-ec2_snapshot_copy.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_snapshot_copy - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1201).
+- ec2_snapshot_copy - updated to pass tags as part of the copy API call rather than tagging the snapshot after creation (https://github.com/ansible-collections/community.aws/pull/1201).


### PR DESCRIPTION
##### SUMMARY

- Add the "resource_tags" alias, for consistency with other modules
- minor docs clean-up
- Use TagSpecification on creation rather than making a separate API call to tag the resource after creation.

Does *not* add purge_tags, since the module performs a one-shot action rather than managing the resources.

##### ISSUE TYPE

- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME

ec2_snapshot_copy

##### ADDITIONAL INFORMATION

Since we don't have a tags-only fragment, I've not switched this over to using a fragment.  If I find more modules with a similar use-case I'll try to find a standard fragment we can use.
