### PR TITLE
lambda - Add support for purge_tags

### DIFF
--- a/changelogs/fragments/1202-tagging-lambda.yml
+++ b/changelogs/fragments/1202-tagging-lambda.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- lambda - fix bug where the lambda module was modifying tags in check mode (https://github.com/ansible-collections/community.aws/pull/1202).
+- lambda - fix bug where tag keys were mangled in the return values (https://github.com/ansible-collections/community.aws/pull/1202).
+minor_changes:
+- lambda - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1202).
+- lambda - the behavior for ``tags`` has been updated, to remove all tags the ``tags`` parameter must be explicitly set to the empty dict ``{}`` and ``purge_tags`` to ``True`` (https://github.com/ansible-collections/community.aws/pull/1202).

--- a/tests/integration/targets/lambda/defaults/main.yml
+++ b/tests/integration/targets/lambda/defaults/main.yml
@@ -4,3 +4,6 @@
 # we hash the resource_prefix to get a shorter, unique string
 lambda_function_name: '{{ tiny_prefix }}'
 lambda_role_name: 'ansible-test-{{ tiny_prefix }}-lambda'
+
+lambda_python_runtime: 'python3.9'
+lambda_python_handler: 'mini_lambda.handler'

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -59,7 +59,7 @@
   - name: test with no role or handler
     lambda:
       name: ansible-testing-fake-should-not-be-created
-      runtime: python3.6
+      runtime: '{{ lambda_python_runtime }}'
     register: result
     ignore_errors: true
   - name: assert failure when called with no parameters
@@ -83,7 +83,7 @@
   - name: test state=present with security group but no vpc
     lambda:
       name: '{{ lambda_function_name }}'
-      runtime: 'python3.6'
+      runtime: '{{ lambda_python_runtime }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
       handler: '{{ omit }}'
@@ -106,8 +106,8 @@
   - name: test state=present - upload the lambda (check mode)
     lambda:
       name: '{{ lambda_function_name }}'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
     register: result
@@ -120,8 +120,8 @@
   - name: test state=present - upload the lambda
     lambda:
       name: '{{ lambda_function_name }}'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
     register: result
@@ -130,6 +130,8 @@
       that:
       - result.changed
       - result.configuration.tracing_config.mode == "PassThrough"
+
+  - include_tasks: 'tagging.yml'
 
   # Test basic operation of Uploaded lambda
   - name: test lambda works (check mode)
@@ -163,7 +165,7 @@
       name: '{{lambda_function_name}}'
       runtime: nodejs14.x
       tracing_mode: Active
-      handler: mini_lambda.handler
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       tags:
         CamelCase: 'ACamelCaseValue'
@@ -182,7 +184,7 @@
       name: '{{lambda_function_name}}'
       runtime: nodejs14.x
       tracing_mode: Active
-      handler: mini_lambda.handler
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       tags:
         CamelCase: 'ACamelCaseValue'
@@ -202,7 +204,7 @@
       name: '{{lambda_function_name}}'
       runtime: nodejs14.x
       tracing_mode: Active
-      handler: mini_lambda.handler
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       tags:
         CamelCase: 'ACamelCaseValue'
@@ -221,7 +223,7 @@
       name: '{{lambda_function_name}}'
       runtime: nodejs14.x
       tracing_mode: Active
-      handler: mini_lambda.handler
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       tags:
         CamelCase: 'ACamelCaseValue'
@@ -239,9 +241,9 @@
   - name: reset config updates for the following tests
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: python3.6
+      runtime: '{{ lambda_python_runtime }}'
       tracing_mode: PassThrough
-      handler: mini_lambda.handler
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
     register: result
   - name: assert that reset succeeded
@@ -249,7 +251,7 @@
       that:
       - result is not failed
       - result.changed == True
-      - result.configuration.runtime == 'python3.6'
+      - result.configuration.runtime == lambda_python_runtime
       - result.configuration.tracing_config.mode == 'PassThrough'
 
   # Test lambda_info
@@ -264,10 +266,10 @@
       - lambda_infos_all is not failed
       - lambda_infos_all.function | length > 0
       - lambda_infos_all.function[lambda_function_name].function_name == lambda_function_name
-      - lambda_infos_all.function[lambda_function_name].runtime == "python3.6"
+      - lambda_infos_all.function[lambda_function_name].runtime == lambda_python_runtime
       - lambda_infos_all.function[lambda_function_name].description == ""
       - lambda_infos_all.function[lambda_function_name].function_arn is defined
-      - lambda_infos_all.function[lambda_function_name].handler == "mini_lambda.handler"
+      - lambda_infos_all.function[lambda_function_name].handler == lambda_python_handler
       - lambda_infos_all.function[lambda_function_name].versions is defined
       - lambda_infos_all.function[lambda_function_name].aliases is defined
       - lambda_infos_all.function[lambda_function_name].policy is defined
@@ -284,10 +286,10 @@
       - lambda_infos_query_config is not failed
       - lambda_infos_query_config.function | length > 0
       - lambda_infos_query_config.function[lambda_function_name].function_name == lambda_function_name
-      - lambda_infos_query_config.function[lambda_function_name].runtime == "python3.6"
+      - lambda_infos_query_config.function[lambda_function_name].runtime == lambda_python_runtime
       - lambda_infos_query_config.function[lambda_function_name].description == ""
       - lambda_infos_query_config.function[lambda_function_name].function_arn is defined
-      - lambda_infos_query_config.function[lambda_function_name].handler == "mini_lambda.handler"
+      - lambda_infos_query_config.function[lambda_function_name].handler == lambda_python_handler
       - lambda_infos_query_config.function[lambda_function_name].versions is not defined
       - lambda_infos_query_config.function[lambda_function_name].aliases is not defined
       - lambda_infos_query_config.function[lambda_function_name].policy is not defined
@@ -400,10 +402,10 @@
   - name: test state=present with all nullable variables explicitly set to null
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: python3.6
+      runtime: '{{ lambda_python_runtime }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
-      handler: mini_lambda.handler
+      handler: '{{ lambda_python_handler }}'
       description: null
       vpc_subnet_ids: null
       vpc_security_group_ids: null
@@ -419,8 +421,8 @@
   - name: test putting an environment variable changes lambda (check mode)
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
       environment_variables:
@@ -436,8 +438,8 @@
   - name: test putting an environment variable changes lambda
     lambda:
       name: '{{lambda_function_name}}'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
       environment_variables:
@@ -517,8 +519,8 @@
   - name: parallel lambda creation 1/4
     lambda:
       name: '{{lambda_function_name}}_1'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
     async: 1000
@@ -526,8 +528,8 @@
   - name: parallel lambda creation 2/4
     lambda:
       name: '{{lambda_function_name}}_2'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
     async: 1000
@@ -535,8 +537,8 @@
   - name: parallel lambda creation 3/4
     lambda:
       name: '{{lambda_function_name}}_3'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
     async: 1000
@@ -544,8 +546,8 @@
   - name: parallel lambda creation 4/4
     lambda:
       name: '{{lambda_function_name}}_4'
-      runtime: python3.6
-      handler: mini_lambda.handler
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{zip_res.dest}}'
     register: result

--- a/tests/integration/targets/lambda/tasks/tagging.yml
+++ b/tests/integration/targets/lambda/tasks/tagging.yml
@@ -1,0 +1,246 @@
+- name: Tests relating to tagging lambda
+  vars:
+    first_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      'New Key with Spaces': Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+    final_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+  # Mandatory settings
+  module_defaults:
+    lambda:
+      runtime: '{{ lambda_python_runtime }}'
+      handler: '{{ lambda_python_handler }}'
+      role: '{{ lambda_role_name }}'
+  block:
+
+  ###
+
+  - name: test adding tags to lambda (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ first_tags }}'
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test adding tags to lambda
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ first_tags }}'
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == first_tags
+
+  - name: test adding tags to lambda - idempotency (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ first_tags }}'
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test adding tags to lambda - idempotency
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ first_tags }}'
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == first_tags
+
+  ###
+
+  - name: test updating tags with purge on lambda (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ second_tags }}'
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test updating tags with purge on lambda
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ second_tags }}'
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == second_tags
+
+  - name: test updating tags with purge on lambda - idempotency (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ second_tags }}'
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test updating tags with purge on lambda - idempotency
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ second_tags }}'
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == second_tags
+
+  ###
+
+  - name: test updating tags without purge on lambda (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test updating tags without purge on lambda
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == final_tags
+
+  - name: test updating tags without purge on lambda - idempotency (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test updating tags without purge on lambda - idempotency
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == final_tags
+
+  ###
+
+  - name: test no tags param lambda (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+    register: update_result
+    check_mode: yes
+  - name: assert no change
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == final_tags
+
+
+  - name: test no tags param lambda
+    lambda:
+      name: '{{ lambda_function_name }}'
+    register: update_result
+  - name: assert no change
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == final_tags
+
+  ###
+
+  - name: test removing tags from lambda (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: {}
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test removing tags from lambda
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: {}
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == {}
+
+  - name: test removing tags from lambda - idempotency (check mode)
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: {}
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test removing tags from lambda - idempotency
+    lambda:
+      name: '{{ lambda_function_name }}'
+      tags: {}
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == {}


### PR DESCRIPTION
##### SUMMARY

- Use tagging fragment
- Add purge_tags
- Add resource_tags alias to tags
- fix bug with returned tag names getting snake cased
- fix bug where the lambda module was modifying tags in check mode
- Tweak tagging to require an explicit `tags: {}` to remove tags

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME

lambda

##### ADDITIONAL INFORMATION
