### PR TITLE
wafv2_ip_set - add support for updating tags

### DIFF
--- a/changelogs/fragments/1205-tagging-wafv2_ip_set.yml
+++ b/changelogs/fragments/1205-tagging-wafv2_ip_set.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- wafv2_ip_set - Added support for ``purge_tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1205).
+- wafv2_ip_set - Added support for updating tags (https://github.com/ansible-collections/community.aws/pull/1205).
+- wafv2_ip_set - Added support for returning tags (https://github.com/ansible-collections/community.aws/pull/1205).
+- wafv2_ip_set_info - Added support for returning tags (https://github.com/ansible-collections/community.aws/pull/1205).

--- a/plugins/modules/wafv2_ip_set_info.py
+++ b/plugins/modules/wafv2_ip_set_info.py
@@ -77,6 +77,7 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import describe_wafv2_tags
 
 
 def list_ip_sets(wafv2, scope, fail_json_aws, Nextmarker=None):
@@ -93,7 +94,7 @@ def list_ip_sets(wafv2, scope, fail_json_aws, Nextmarker=None):
         if response.get('NextMarker'):
             response['IPSets'] += list_ip_sets(wafv2, scope, fail_json_aws, Nextmarker=response.get('NextMarker')).get('IPSets')
     except (BotoCoreError, ClientError) as e:
-        fail_json_aws(e, msg="Failed to list wafv2 ip set.")
+        fail_json_aws(e, msg="Failed to list wafv2 ip set")
     return response
 
 
@@ -105,7 +106,7 @@ def get_ip_set(wafv2, name, scope, id, fail_json_aws):
             Id=id
         )
     except (BotoCoreError, ClientError) as e:
-        fail_json_aws(e, msg="Failed to get wafv2 ip set.")
+        fail_json_aws(e, msg="Failed to get wafv2 ip set")
     return response
 
 
@@ -134,13 +135,14 @@ def main():
     for item in response.get('IPSets'):
         if item.get('Name') == name:
             id = item.get('Id')
+            arn = item.get('ARN')
 
     retval = {}
     existing_set = None
     if id:
         existing_set = get_ip_set(wafv2, name, scope, id, module.fail_json_aws)
         retval = camel_dict_to_snake_dict(existing_set.get('IPSet'))
-
+        retval['tags'] = describe_wafv2_tags(wafv2, arn, module.fail_json_aws) or {}
     module.exit_json(**retval)
 
 

--- a/tests/integration/targets/wafv2_ip_set/tasks/main.yml
+++ b/tests/integration/targets/wafv2_ip_set/tasks/main.yml
@@ -5,7 +5,6 @@
       aws_secret_key: "{{ aws_secret_key }}"
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
-
   block:
     - name: check_mode create ip set
       wafv2_ip_set:
@@ -176,6 +175,8 @@
       assert:
         that:
           - out.addresses | count == 1
+
+    - include_tasks: 'tagging.yml'
 
     - name: delete ip set
       wafv2_ip_set:

--- a/tests/integration/targets/wafv2_ip_set/tasks/tagging.yml
+++ b/tests/integration/targets/wafv2_ip_set/tasks/tagging.yml
@@ -1,0 +1,256 @@
+- name: Tests relating to tagging wavf2_ip_sets
+  vars:
+    first_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      'New Key with Spaces': Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+    final_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+  # Mandatory settings
+  module_defaults:
+    community.aws.wafv2_ip_set:
+      name: '{{ ip_set_name }}'
+      state: present
+      scope: REGIONAL
+      ip_address_version: IPV4
+      purge_addresses: no
+      addresses: []
+    community.aws.wafv2_ip_set_info:
+      name: '{{ ip_set_name }}'
+      scope: REGIONAL
+  block:
+
+  ###
+
+  - name: test adding tags to wafv2_ip_set (check mode)
+    wafv2_ip_set:
+      tags: '{{ first_tags }}'
+      purge_tags: True
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test adding tags to wafv2_ip_set
+    wafv2_ip_set:
+      tags: '{{ first_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == first_tags
+
+  - name: test adding tags to wafv2_ip_set - idempotency (check mode)
+    wafv2_ip_set:
+      tags: '{{ first_tags }}'
+      purge_tags: True
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test adding tags to wafv2_ip_set - idempotency
+    wafv2_ip_set:
+      tags: '{{ first_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == first_tags
+
+  ###
+
+  - name: test updating tags with purge on wafv2_ip_set (check mode)
+    wafv2_ip_set:
+      tags: '{{ second_tags }}'
+      purge_tags: True
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test updating tags with purge on wafv2_ip_set
+    wafv2_ip_set:
+      tags: '{{ second_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == second_tags
+
+  - name: test updating tags with purge on wafv2_ip_set - idempotency (check mode)
+    wafv2_ip_set:
+      tags: '{{ second_tags }}'
+      purge_tags: True
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test updating tags with purge on wafv2_ip_set - idempotency
+    wafv2_ip_set:
+      tags: '{{ second_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == second_tags
+
+  ###
+
+  - name: test updating tags without purge on wafv2_ip_set (check mode)
+    wafv2_ip_set:
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test updating tags without purge on wafv2_ip_set
+    wafv2_ip_set:
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == final_tags
+
+  - name: test updating tags without purge on wafv2_ip_set - idempotency (check mode)
+    wafv2_ip_set:
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test updating tags without purge on wafv2_ip_set - idempotency
+    wafv2_ip_set:
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == final_tags
+
+  ###
+
+  - name: test that wafv2_ip_set_info returns the tags
+    wafv2_ip_set_info:
+    register: tag_info
+  - name: assert tags present
+    assert:
+      that:
+      - tag_info.tags == final_tags
+
+  ###
+
+  - name: test no tags param wafv2_ip_set (check mode)
+    wafv2_ip_set: {}
+    register: update_result
+    check_mode: yes
+  - name: assert no change
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == final_tags
+
+
+  - name: test no tags param wafv2_ip_set
+    wafv2_ip_set: {}
+    register: update_result
+  - name: assert no change
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == final_tags
+
+  ###
+
+  - name: test removing tags from wafv2_ip_set (check mode)
+    wafv2_ip_set:
+      tags: {}
+      purge_tags: True
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+
+  - name: test removing tags from wafv2_ip_set
+    wafv2_ip_set:
+      tags: {}
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.tags == {}
+
+  - name: test removing tags from wafv2_ip_set - idempotency (check mode)
+    wafv2_ip_set:
+      tags: {}
+      purge_tags: True
+    register: update_result
+    check_mode: yes
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+
+  - name: test removing tags from wafv2_ip_set - idempotency
+    wafv2_ip_set:
+      tags: {}
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.tags == {}


### PR DESCRIPTION
##### SUMMARY

- Added support for purge_tags
- Added tags to return values
- Added support for updating tags
- Moved to common docs_fragment for tagging

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

plugins/module_utils/wafv2.py
plugins/modules/wafv2_ip_set.py
plugins/modules/wafv2_ip_set_info.py

##### ADDITIONAL INFORMATION

Depends on : https://github.com/mattclay/aws-terminator/pull/213