### PR TITLE
aws_ssm (connection plugin): read until the true end of stdout

### DIFF
--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -435,7 +435,7 @@ class Connection(ConnectionBase):
                     stdout = ''
                 continue
             if begin:
-                if line.startswith(mark_end):
+                if line.startswith(mark_end) or mark_end in line:
                     display.vvvv(u"POST_PROCESS: {0}".format(to_text(stdout)), host=self.host)
                     returncode, stdout = self._post_process(stdout, mark_begin)
                     break

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -435,7 +435,7 @@ class Connection(ConnectionBase):
                     stdout = ''
                 continue
             if begin:
-                if mark_end in line:
+                if line.startswith(mark_end):
                     display.vvvv(u"POST_PROCESS: {0}".format(to_text(stdout)), host=self.host)
                     returncode, stdout = self._post_process(stdout, mark_begin)
                     break

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -435,7 +435,7 @@ class Connection(ConnectionBase):
                     stdout = ''
                 continue
             if begin:
-                if line.startswith(mark_end) or mark_end in line:
+                if mark_end in line and not "echo {0}".format(mark_end) in line:
                     display.vvvv(u"POST_PROCESS: {0}".format(to_text(stdout)), host=self.host)
                     returncode, stdout = self._post_process(stdout, mark_begin)
                     break


### PR DESCRIPTION
##### SUMMARY

I was trying to use aws ssm connection for an ansible playbook. I faced this issue:
```
<i-XXX> POST_PROCESS: echo ~admin
echo $'\n'$?
<i-XXX> ssm_retry: attempt: 0, caught exception(invalid literal for int() with base 10: "echo $'\\n'$?") from cmd (echo ~admin...), pausing for 0 seconds
```
I added some debug to the code and saw that stdout was processed until it sees `mark_end`. Problem is that `stty -echo` is not yet flushed (ie. executed in the pty) when we write to stdin `echo <mark_end>`. So the output parsing is stopped before anything was really executed.

##### ISSUE TYPE
- Bugfix Pull Request
- 
##### COMPONENT NAME
aws_ssm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
