### PR TITLE
ecs_* - fix idempotence bug in ecs_service and dont require ``cluster``

### DIFF
--- a/changelogs/fragments/1212-ecs_service-fix-broken-change-detect.yml
+++ b/changelogs/fragments/1212-ecs_service-fix-broken-change-detect.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ecs_service - fix broken change detect of ``health_check_grace_period_seconds`` parameter when not specified (https://github.com/ansible-collections/community.aws/pull/1212).
+  - ecs_service - use default cluster name of ``default`` when not input (https://github.com/ansible-collections/community.aws/pull/1212).
+  - ecs_task - dont require ``cluster`` and use name of ``default`` when not input (https://github.com/ansible-collections/community.aws/pull/1212).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -38,8 +38,10 @@ options:
     cluster:
         description:
           - The name of the cluster in which the service exists.
+          - If not specified, the cluster name will be C(default).
         required: false
         type: str
+        default: 'default'
     task_definition:
         description:
           - The task definition the service will run.
@@ -608,8 +610,9 @@ class EcsServiceManager:
         if expected['task_definition'] != existing['taskDefinition'].split('/')[-1]:
             return False
 
-        if expected.get('health_check_grace_period_seconds') != existing.get('healthCheckGracePeriodSeconds'):
-            return False
+        if expected.get('health_check_grace_period_seconds'):
+            if expected.get('health_check_grace_period_seconds') != existing.get('healthCheckGracePeriodSeconds'):
+                return False
 
         if (expected['load_balancers'] or []) != existing['loadBalancers']:
             return False
@@ -717,7 +720,7 @@ def main():
     argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent', 'deleting']),
         name=dict(required=True, type='str', aliases=['service']),
-        cluster=dict(required=False, type='str'),
+        cluster=dict(required=False, type='str', default='default'),
         task_definition=dict(required=False, type='str'),
         load_balancers=dict(required=False, default=[], type='list', elements='dict'),
         desired_count=dict(required=False, type='int'),

--- a/plugins/modules/ecs_task.py
+++ b/plugins/modules/ecs_task.py
@@ -28,8 +28,10 @@ options:
     cluster:
         description:
             - The name of the cluster to run the task on.
-        required: True
+            - If not specified, the cluster name will be C(default).
+        required: False
         type: str
+        default: 'default'
     task_definition:
         description:
             - The task definition to start, run or stop.
@@ -342,7 +344,7 @@ class EcsExecManager:
 def main():
     argument_spec = dict(
         operation=dict(required=True, choices=['run', 'start', 'stop']),
-        cluster=dict(required=True, type='str'),  # R S P
+        cluster=dict(required=False, type='str', default='default'),  # R S P
         task_definition=dict(required=False, type='str'),  # R* S*
         overrides=dict(required=False, type='dict'),  # R S
         count=dict(required=False, type='int'),  # R


### PR DESCRIPTION
##### SUMMARY
- Don't require `cluster` param and use cluster name 'default' when not specified (see [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.create_cluster)).
- Fix bug when comparing `health_check_grace_period_seconds` when not input by user.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ecs_service
- ecs_task

##### ADDITIONAL INFORMATION
Split up from #1209 to backport to stable-2
