### PR TITLE
ecs_service - document circuit breaker feature

### DIFF
--- a/changelogs/fragments/1215-ecs-service-deployment-circuit-breaker-support.yml
+++ b/changelogs/fragments/1215-ecs-service-deployment-circuit-breaker-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_service - ``deployment_circuit_breaker`` has been added as a supported feature (https://github.com/ansible-collections/community.aws/pull/1215).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -464,32 +464,6 @@ ansible_facts:
                     description: The Amazon Resource Name (ARN) of the of the cluster that hosts the service.
                     returned: always
                     type: str
-                deploymentConfiguration:
-                    description: dictionary of deploymentConfiguration
-                    returned: always
-                    type: complex
-                    contains:
-                        deploymentCircuitBreaker:
-                            description: dictionary of deploymentCircuitBreaker
-                            returned: always
-                            type: complex
-                            contains:
-                                enable:
-                                    description: The state of the circuit breaker feature.
-                                    returned: always
-                                    type: bool
-                                rollback:
-                                    description: The state of the rollback feature of the circuit breaker.
-                                    returned: always
-                                    type: bool
-                        maximumPercent:
-                            description: Upper limit on the number of tasks in a service that are allowed in the RUNNING or PENDING state during a deployment.
-                            returned: always
-                            type: int
-                        minimumHealthyPercent:
-                            description: A lower limit on the number of tasks in a service that must remain in the RUNNING state during a deployment.
-                            returned: always
-                            type: int
                 desiredCount:
                     description: The desired number of instantiations of the task definition to keep running on the service.
                     returned: always
@@ -555,6 +529,19 @@ ansible_facts:
                             description: minimumHealthyPercent param
                             returned: always
                             type: int
+                        deploymentCircuitBreaker:
+                            description: dictionary of deploymentCircuitBreaker
+                            returned: always
+                            type: complex
+                            contains:
+                                enable:
+                                    description: The state of the circuit breaker feature.
+                                    returned: always
+                                    type: bool
+                                rollback:
+                                    description: The state of the rollback feature of the circuit breaker.
+                                    returned: always
+                                    type: bool
                 events:
                     description: list of service events
                     returned: always

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -101,6 +101,16 @@ options:
           minimum_healthy_percent:
             type: int
             description: A lower limit on the number of tasks in a service that must remain in the RUNNING state during a deployment.
+          deployment_circuit_breaker:
+            type: dict
+            description: The deployment circuit breaker determines whether a service deployment will fail if the service can't reach a steady state.
+            suboptions:
+              enable:
+                type: bool
+                description: If enabled, a service deployment will transition to a failed state and stop launching new tasks.
+              rollback:
+                type: bool
+                description: If enabled, ECS will roll back your service to the last completed deployment after a failure.
     placement_constraints:
         description:
           - The placement constraints for the tasks in the service.
@@ -272,6 +282,18 @@ EXAMPLES = r'''
       - type: binpack
         field: memory
 
+# With deployment circuit breaker (added in version 4.0)
+- community.aws.ecs_service:
+    state: present
+    name: test-service
+    cluster: test-cluster
+    task_definition: test-task-definition
+    desired_count: 3
+    deployment_configuration:
+      deployment_circuit_breaker:
+        enable: True
+        rollback: True
+
 # With capacity_provider_strategy (added in version 4.0)
 - community.aws.ecs_service:
     state: present
@@ -378,6 +400,19 @@ service:
                     description: minimumHealthyPercent param
                     returned: always
                     type: int
+                deploymentCircuitBreaker:
+                    description: dictionary of deploymentCircuitBreaker
+                    returned: always
+                    type: complex
+                    contains:
+                        enable:
+                            description: The state of the circuit breaker feature.
+                            returned: always
+                            type: bool
+                        rollback:
+                            description: The state of the rollback feature of the circuit breaker.
+                            returned: always
+                            type: bool
         events:
             description: list of service events
             returned: always
@@ -429,6 +464,32 @@ ansible_facts:
                     description: The Amazon Resource Name (ARN) of the of the cluster that hosts the service.
                     returned: always
                     type: str
+                deploymentConfiguration:
+                    description: dictionary of deploymentConfiguration
+                    returned: always
+                    type: complex
+                    contains:
+                        deploymentCircuitBreaker:
+                            description: dictionary of deploymentCircuitBreaker
+                            returned: always
+                            type: complex
+                            contains:
+                                enable:
+                                    description: The state of the circuit breaker feature.
+                                    returned: always
+                                    type: bool
+                                rollback:
+                                    description: The state of the rollback feature of the circuit breaker.
+                                    returned: always
+                                    type: bool
+                        maximumPercent:
+                            description: Upper limit on the number of tasks in a service that are allowed in the RUNNING or PENDING state during a deployment.
+                            returned: always
+                            type: int
+                        minimumHealthyPercent:
+                            description: A lower limit on the number of tasks in a service that must remain in the RUNNING state during a deployment.
+                            returned: always
+                            type: int
                 desiredCount:
                     description: The desired number of instantiations of the task definition to keep running on the service.
                     returned: always
@@ -535,7 +596,8 @@ import time
 
 DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
     'maximum_percent': 'int',
-    'minimum_healthy_percent': 'int'
+    'minimum_healthy_percent': 'int',
+    'deployment_circuit_breaker': 'dict'
 }
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -584,7 +584,7 @@ import time
 DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
     'maximum_percent': 'int',
     'minimum_healthy_percent': 'int',
-    'deployment_circuit_breaker': 'dict'
+    'deployment_circuit_breaker': 'dict',
 }
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/tests/integration/targets/ecs_cluster/defaults/main.yml
+++ b/tests/integration/targets/ecs_cluster/defaults/main.yml
@@ -24,9 +24,9 @@ ecs_task_containers:
 ecs_service_deployment_configuration:
   minimum_healthy_percent: 0
   maximum_percent: 100
-    deployment_circuit_breaker:
-      enable: true
-      rollback: true
+  deployment_circuit_breaker:
+    enable: true
+    rollback: true
 ecs_service_placement_strategy:
   - type: binpack
     field: memory

--- a/tests/integration/targets/ecs_cluster/defaults/main.yml
+++ b/tests/integration/targets/ecs_cluster/defaults/main.yml
@@ -24,6 +24,9 @@ ecs_task_containers:
 ecs_service_deployment_configuration:
   minimum_healthy_percent: 0
   maximum_percent: 100
+    deployment_circuit_breaker:
+      enable: true
+      rollback: true
 ecs_service_placement_strategy:
   - type: binpack
     field: memory

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -236,6 +236,13 @@
         that:
           - ecs_service.changed
 
+    - name: check that ECS service was created with deployment_circuit_breaker
+      assert:
+        that:
+          - ecs_service.service.deploymentCircuitBreaker
+          - ecs_service.service.deploymentCircuitBreaker.enable
+          - ecs_service.service.deploymentCircuitBreaker.rollback
+
     - name: create same ECS service definition (should not change)
       ecs_service:
         state: present


### PR DESCRIPTION
##### SUMMARY
Fixes #921 
This feature works with the existing code, so this was mainly adding documentation, examples, and an integration test.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_service

##### ADDITIONAL INFORMATION
The deployment circuit breaker is part of the deployment configuration dictionary, which is already snake<=>camel cased. Thus the existing code was handling 99% of the feature, we just added some type validation, documentation, examples, and an integration test.

```
- community.aws.ecs_service:
    state: present
    name: test-service
    cluster: test-cluster
    task_definition: test-task-definition
    desired_count: 3
    deployment_configuration:
      deployment_circuit_breaker:
        enable: True
        rollback: True
```
