### PR TITLE
backport-2: ecs_service deployment_circuit_breaker

### DIFF
--- a/changelogs/fragments/1215-ecs-service-deployment-circuit-breaker-support.yml
+++ b/changelogs/fragments/1215-ecs-service-deployment-circuit-breaker-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_service - ``deployment_circuit_breaker`` has been added as a supported feature (https://github.com/ansible-collections/community.aws/pull/1215).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -101,6 +101,16 @@ options:
           minimum_healthy_percent:
             type: int
             description: A lower limit on the number of tasks in a service that must remain in the RUNNING state during a deployment.
+          deployment_circuit_breaker:
+            type: dict
+            description: The deployment circuit breaker determines whether a service deployment will fail if the service can't reach a steady state.
+            suboptions:
+              enable:
+                type: bool
+                description: If enabled, a service deployment will transition to a failed state and stop launching new tasks.
+              rollback:
+                type: bool
+                description: If enabled, ECS will roll back your service to the last completed deployment after a failure.
     placement_constraints:
         description:
           - The placement constraints for the tasks in the service.
@@ -328,6 +338,19 @@ service:
                     description: minimumHealthyPercent param
                     returned: always
                     type: int
+                deploymentCircuitBreaker:
+                    description: dictionary of deploymentCircuitBreaker
+                    returned: always
+                    type: complex
+                    contains:
+                        enable:
+                            description: The state of the circuit breaker feature.
+                            returned: always
+                            type: bool
+                        rollback:
+                            description: The state of the rollback feature of the circuit breaker.
+                            returned: always
+                            type: bool
         events:
             description: list of service events
             returned: always
@@ -444,6 +467,19 @@ ansible_facts:
                             description: minimumHealthyPercent param
                             returned: always
                             type: int
+                        deploymentCircuitBreaker:
+                            description: dictionary of deploymentCircuitBreaker
+                            returned: always
+                            type: complex
+                            contains:
+                                enable:
+                                    description: The state of the circuit breaker feature.
+                                    returned: always
+                                    type: bool
+                                rollback:
+                                    description: The state of the rollback feature of the circuit breaker.
+                                    returned: always
+                                    type: bool
                 events:
                     description: list of service events
                     returned: always
@@ -485,7 +521,8 @@ import time
 
 DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
     'maximum_percent': 'int',
-    'minimum_healthy_percent': 'int'
+    'minimum_healthy_percent': 'int',
+    'deployment_circuit_breaker': 'dict',
 }
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule

--- a/tests/integration/targets/ecs_cluster/defaults/main.yml
+++ b/tests/integration/targets/ecs_cluster/defaults/main.yml
@@ -24,6 +24,9 @@ ecs_task_containers:
 ecs_service_deployment_configuration:
   minimum_healthy_percent: 0
   maximum_percent: 100
+  deployment_circuit_breaker:
+    enable: true
+    rollback: true
 ecs_service_placement_strategy:
   - type: binpack
     field: memory

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -236,6 +236,13 @@
         that:
           - ecs_service.changed
 
+    - name: check that ECS service was created with deployment_circuit_breaker
+      assert:
+        that:
+          - ecs_service.service.deploymentCircuitBreaker
+          - ecs_service.service.deploymentCircuitBreaker.enable
+          - ecs_service.service.deploymentCircuitBreaker.rollback
+
     - name: create same ECS service definition (should not change)
       ecs_service:
         state: present

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -225,23 +225,21 @@
         role: "ecsServiceRole"
       register: ecs_service
 
-    - name: check that placement constraint has been applied
-      assert:
-        that:
-          - ecs_service.changed
-          - "ecs_service.service.placementConstraints[0].type == 'distinctInstance'"
-
     - name: check that ECS service creation changed
       assert:
         that:
           - ecs_service.changed
 
+    - name: check that placement constraint has been applied
+      assert:
+        that:
+          - "ecs_service.service.placementConstraints[0].type == 'distinctInstance'"
+  
     - name: check that ECS service was created with deployment_circuit_breaker
       assert:
         that:
-          - ecs_service.service.deploymentCircuitBreaker
-          - ecs_service.service.deploymentCircuitBreaker.enable
-          - ecs_service.service.deploymentCircuitBreaker.rollback
+          - ecs_service.service.deploymentConfiguration.deploymentCircuitBreaker.enable
+          - ecs_service.service.deploymentConfiguration.deploymentCircuitBreaker.rollback
 
     - name: create same ECS service definition (should not change)
       ecs_service:


### PR DESCRIPTION
##### SUMMARY
manual backport of
  * https://github.com/ansible-collections/community.aws/pull/1215
  * https://github.com/ansible-collections/community.aws/pull/1217

there is no `version_added`, because the module already supports this feature. it was just undocumented.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
ecs_service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
