### PR TITLE
ec2_vpc_vgw - Add support for purge_tags

### DIFF
--- a/changelogs/fragments/1232-ec2_vpc_vgw-purge_tags.yml
+++ b/changelogs/fragments/1232-ec2_vpc_vgw-purge_tags.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- ec2_vpc_vgw - add support for ``purge_tags`` parameter (https://github.com/ansible-collections/community.aws/pull/1232).
+- ec2_vpc_vgw - the default behaviour for ``tags`` has been updated, to remove all tags the ``tags`` parameter must be explicitly set to the empty dict ``{}`` and ``purge_tags`` to ``True`` (https://github.com/ansible-collections/community.aws/pull/1232).
+- ec2_vpc_vgw - updated to set tags as part of VGW creation instead of tagging the VGW after creation (https://github.com/ansible-collections/community.aws/pull/1232).
+- ec2_vpc_vgw_info - added ``resource_tags`` to the return values (https://github.com/ansible-collections/community.aws/pull/1232).

--- a/tests/integration/targets/ec2_vpc_vgw/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_vgw/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+vpc_name: '{{ resource_prefix }}-ec2-vpc-vgw'
+vgw_name: '{{ resource_prefix }}-ec2-vpc-vgw'
+subnet_name: '{{ resource_prefix }}-ec2-vpc-vgw'
+vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
+subnet_1: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+subnet_2: '10.{{ 256 | random(seed=resource_prefix) }}.2.0/24'
+subnet_3: '10.{{ 256 | random(seed=resource_prefix) }}.3.0/24'
+subnet_4: '10.{{ 256 | random(seed=resource_prefix) }}.4.0/24'
+
+vpc_ipv6_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.5.0/25'
+vpc_ipv6_name: '{{ vpc_name }}-ipv6'

--- a/tests/integration/targets/ec2_vpc_vgw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_vgw/tasks/main.yml
@@ -15,12 +15,11 @@
 
     - name: create a VPC
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc-{{ item }}"
+        name: "{{ vpc_name }}-{{ item }}"
         state: present
-        cidr_block: "10.0.0.0/26"
+        cidr_block: "{{ vpc_cidr }}"
         tags:
-          Name: "{{ resource_prefix }}-vpc-{{ item }}"
-          Description: "Created by ansible-test"
+          Description: "Created by ansible-test for IGW tests"
       register: vpc_result
       loop: [1, 2]
 
@@ -36,87 +35,51 @@
       ec2_vpc_vgw:
         state: present
         vpc_id: '{{ vpc_id_1 }}'
-        name: "{{ resource_prefix }}-vgw"
+        name: "{{ vgw_name }}"
       register: vgw
+
+    - name: use set fact for vgw ids
+      set_fact:
+        vgw_id: '{{ vgw.vgw.id }}'
 
     - assert:
         that:
           - vgw.changed
-          - "{{ vgw.vgw.vpc_id == vpc_id_1 }}"
-          - '"{{ vgw.vgw.tags.Name }}" == "{{ resource_prefix }}-vgw"'
+          - vgw.vgw.vpc_id == vpc_id_1
+          - vgw.vgw.tags.Name == vgw_name
 
     - name: test idempotence
       ec2_vpc_vgw:
         state: present
         vpc_id: '{{ vpc_id_1 }}'
-        name: "{{ resource_prefix }}-vgw"
+        name: "{{ vgw_name }}"
       register: vgw
 
     - assert:
         that:
           - not vgw.changed
+          - vgw.vgw.id == vgw_id
 
     # ============================================================
     - name: attach vpn gateway to the other VPC
       ec2_vpc_vgw:
         state: present
         vpc_id: '{{ vpc_id_2 }}'
-        name: "{{ resource_prefix }}-vgw"
+        name: "{{ vgw_name }}"
       register: vgw
 
     - assert:
         that:
           - vgw.changed
-          - "{{ vgw.vgw.vpc_id == vpc_id_2 }}"
+          - vgw.vgw.id == vgw_id
+          - vgw.vgw.vpc_id == vpc_id_2
 
     # ============================================================
-    - name: add tags to the VGW
-      ec2_vpc_vgw:
-        state: present
-        vpc_id: '{{ vpc_id_2 }}'
-        name: "{{ resource_prefix }}-vgw"
-        tags:
-          created_by: ec2_vpc_vgw integration tests
-      register: vgw
 
-    - assert:
-        that:
-          - vgw.changed
-          - vgw.vgw.tags | length == 2
-          - "'created_by' in vgw.vgw.tags"
-
-    - name: test idempotence
-      ec2_vpc_vgw:
-        state: present
-        vpc_id: '{{ vpc_id_2 }}'
-        name: "{{ resource_prefix }}-vgw"
-        tags:
-          created_by: ec2_vpc_vgw integration tests
-      register: vgw
-
-    - assert:
-        that:
-          - not vgw.changed
-
-    # ============================================================
-    - name: remove tags from the VGW
-      ec2_vpc_vgw:
-        state: present
-        vpc_id: '{{ vpc_id_2 }}'
-        name: "{{ resource_prefix }}-vgw"
-      register: vgw
-
-    - assert:
-        that:
-          - vgw.changed
-          - vgw.vgw.tags | length == 1
-          - '"{{ vgw.vgw.tags.Name }}" == "{{ resource_prefix }}-vgw"'
-
-    # ============================================================
     - name: detach vpn gateway
       ec2_vpc_vgw:
         state: present
-        name: "{{ resource_prefix }}-vgw"
+        name: "{{ vgw_name }}"
       register: vgw
 
     - assert:
@@ -127,7 +90,7 @@
     - name: test idempotence
       ec2_vpc_vgw:
         state: present
-        name: "{{ resource_prefix }}-vgw"
+        name: "{{ vgw_name }}"
       register: vgw
 
     - assert:
@@ -135,6 +98,30 @@
           - not vgw.changed
 
     # ============================================================
+
+    - include_tasks: 'tags.yml'
+
+    # ============================================================
+
+    - name: delete vpn gateway
+      ec2_vpc_vgw:
+        state: absent
+        name: "{{ vgw_name }}"
+      register: vgw
+
+    - assert:
+        that:
+          - vgw.changed
+
+    - name: test idempotence
+      ec2_vpc_vgw:
+        state: absent
+        name: "{{ vgw_name }}"
+      register: vgw
+
+    - assert:
+        that:
+          - not vgw.changed
 
   always:
 
@@ -148,9 +135,9 @@
 
     - name: delete vpc
       ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc-{{ item }}"
+        name: "{{ vpc_name }}-{{ item }}"
         state: absent
-        cidr_block: "10.0.0.0/26"
+        cidr_block: "{{ vpc_cidr }}"
       loop: [1, 2]
       register: result
       retries: 10

--- a/tests/integration/targets/ec2_vpc_vgw/tasks/tags.yml
+++ b/tests/integration/targets/ec2_vpc_vgw/tasks/tags.yml
@@ -1,0 +1,333 @@
+- vars:
+    first_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      'New Key with Spaces': Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+    final_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    name_tags:
+      Name: '{{ vgw_name }}'
+  module_defaults:
+    ec2_vpc_vgw:
+      name: '{{ vgw_name }}'
+    ec2_vpc_vgw_info:
+      vpn_gateway_ids: ['{{ vgw_id }}']
+  block:
+
+  # ============================================================
+
+#  - name: (check) add tags
+#    ec2_vpc_vgw:
+#      tags: '{{ first_tags }}'
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would change
+#    assert:
+#      that:
+#        - tag_vgw is changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: add tags
+    ec2_vpc_vgw:
+      tags: '{{ first_tags }}'
+      state: 'present'
+    register: tag_vgw
+
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info: {}
+    register: tag_vgw_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - tag_vgw is changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( first_tags | combine(name_tags) )
+
+#  - name: (check) add tags - IDEMPOTENCY
+#    ec2_vpc_vgw:
+#      tags: '{{ first_tags }}'
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would not change
+#    assert:
+#      that:
+#        - tag_vgw is not changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: add tags - IDEMPOTENCY
+    ec2_vpc_vgw:
+      tags: '{{ first_tags }}'
+      state: 'present'
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info: {}
+    register: tag_vgw_info
+
+  - name: verify no change
+    assert:
+      that:
+        - tag_vgw is not changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( first_tags | combine(name_tags) )
+
+  # ============================================================
+
+  - name: get VPC VGW facts by filter
+    ec2_vpc_vgw_info:
+      filters:
+        'tag:Name': '{{ vgw_name }}'
+      vpn_gateway_ids: '{{ omit }}'
+    register: tag_vgw_info
+
+  - name: assert the facts are the same as before
+    assert:
+      that:
+        - tag_vgw_info.virtual_gateways | length == 1
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+
+  # ============================================================
+
+#  - name: (check) modify tags with purge
+#    ec2_vpc_vgw:
+#      tags: '{{ second_tags }}'
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would change
+#    assert:
+#      that:
+#        - tag_vgw is changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: modify tags with purge
+    ec2_vpc_vgw:
+      tags: '{{ second_tags }}'
+      state: 'present'
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - tag_vgw is changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( second_tags | combine(name_tags) )
+
+#  - name: (check) modify tags with purge - IDEMPOTENCY
+#    ec2_vpc_vgw:
+#      tags: '{{ second_tags }}'
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would not change
+#    assert:
+#      that:
+#        - tag_vgw is not changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: modify tags with purge - IDEMPOTENCY
+    ec2_vpc_vgw:
+      tags: '{{ second_tags }}'
+      state: 'present'
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify no change
+    assert:
+      that:
+        - tag_vgw is not changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( second_tags | combine(name_tags) )
+
+  # ============================================================
+
+#  - name: (check) modify tags without purge
+#    ec2_vpc_vgw:
+#      tags: '{{ third_tags }}'
+#      state: 'present'
+#      purge_tags: False
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would change
+#    assert:
+#      that:
+#        - tag_vgw is changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: modify tags without purge
+    ec2_vpc_vgw:
+      tags: '{{ third_tags }}'
+      state: 'present'
+      purge_tags: False
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - tag_vgw is changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( final_tags | combine(name_tags) )
+
+#  - name: (check) modify tags without purge - IDEMPOTENCY
+#    ec2_vpc_vgw:
+#      tags: '{{ third_tags }}'
+#      state: 'present'
+#      purge_tags: False
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would not change
+#    assert:
+#      that:
+#        - tag_vgw is not changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: modify tags without purge - IDEMPOTENCY
+    ec2_vpc_vgw:
+      tags: '{{ third_tags }}'
+      state: 'present'
+      purge_tags: False
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify no change
+    assert:
+      that:
+        - tag_vgw is not changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( final_tags | combine(name_tags) )
+
+  # ============================================================
+
+#  - name: (check) No change to tags without setting tags
+#    ec2_vpc_vgw:
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would change
+#    assert:
+#      that:
+#        - tag_vgw is not changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: No change to tags without setting tags
+    ec2_vpc_vgw:
+      state: 'present'
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - tag_vgw is not changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == ( final_tags | combine(name_tags) )
+
+  # ============================================================
+
+#  - name: (check) remove non name tags
+#    ec2_vpc_vgw:
+#      tags: {}
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would change
+#    assert:
+#      that:
+#        - tag_vgw is changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: remove non name tags
+    ec2_vpc_vgw:
+      tags: {}
+      state: 'present'
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify the tags were added
+    assert:
+      that:
+        - tag_vgw is changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == name_tags
+
+#  - name: (check) remove non name tags - IDEMPOTENCY
+#    ec2_vpc_vgw:
+#      tags: {}
+#      state: 'present'
+#    register: tag_vgw
+#    check_mode: True
+#
+#  - name: assert would not change
+#    assert:
+#      that:
+#        - tag_vgw is not changed
+#        - tag_vgw.vgw.id == vgw_id
+
+  - name: remove non name tags - IDEMPOTENCY
+    ec2_vpc_vgw:
+      tags: {}
+      state: 'present'
+    register: tag_vgw
+  - name: get VPC VGW facts
+    ec2_vpc_vgw_info:
+    register: tag_vgw_info
+
+  - name: verify no change
+    assert:
+      that:
+        - tag_vgw is not changed
+        - tag_vgw.vgw.id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].vpn_gateway_id == vgw_id
+        - tag_vgw_info.virtual_gateways[0].resource_tags == name_tags


### PR DESCRIPTION
##### SUMMARY

- Adds support for purge_tags to ec2_vpc_vgw
- Updates behaviour so that tags must be explicitly set to {} to remove tags
- Updates ec2_vpc_vgw to pass tags as part of the VGW creation rather than tagging the VGW after creation.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_vgw
ec2_vpc_vgw_info

##### ADDITIONAL INFORMATION

- [x] return docs
- [x] changelog