### PR TITLE
cloudwatchlogs_log_group - Tagging support

### DIFF
--- a/changelogs/fragments/1233-cloudwatchlogs_log_group-tagging.yml
+++ b/changelogs/fragments/1233-cloudwatchlogs_log_group-tagging.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- cloudwatchlogs_log_group - now consistently returns the values as defined in the return documentation (https://github.com/ansible-collections/community.aws/pull/1233).
+- cloudwatchlogs_log_group - adds support for updating tags (https://github.com/ansible-collections/community.aws/pull/1233).
+- cloudwatchlogs_log_group - adds support for returning tags (https://github.com/ansible-collections/community.aws/pull/1233).
+- cloudwatchlogs_log_group_info - adds support for returning tags (https://github.com/ansible-collections/community.aws/pull/1233).

--- a/tests/integration/targets/cloudwatchlogs_log_group/aliases
+++ b/tests/integration/targets/cloudwatchlogs_log_group/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+
+cloudwatchlogs_log_group_info

--- a/tests/integration/targets/cloudwatchlogs_log_group/defaults/main.yml
+++ b/tests/integration/targets/cloudwatchlogs_log_group/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+log_group_name: '{{ resource_prefix }}/integrationtest'
+filter_name: '{{ resource_prefix }}/AnsibleTest'

--- a/tests/integration/targets/cloudwatchlogs_log_group/meta/main.yml
+++ b/tests/integration/targets/cloudwatchlogs_log_group/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/cloudwatchlogs_log_group/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchlogs_log_group/tasks/main.yml
@@ -1,0 +1,117 @@
+---
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+
+  block:
+  - name: create cloudwatch log group for integration test
+    cloudwatchlogs_log_group:
+      state: present
+      log_group_name: '{{ log_group_name }}'
+      retention: 1
+      tags:
+        CamelCase: Value
+        snake_case: value
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - '"log_groups" in result'
+      - result.log_groups | length == 1
+      - '"log_group_name" in log_group'
+      - '"creation_time" in log_group'
+      - '"retention_in_days" in log_group'
+      - '"metric_filter_count" in log_group'
+      - '"arn" in log_group'
+      - '"stored_bytes" in log_group'
+      # - '"kms_key_id" in log_group'
+      # pre-4.0.0 upgrade compatability
+      - '"log_group_name" in result'
+      - '"creation_time" in result'
+      - '"retention_in_days" in result'
+      - '"metric_filter_count" in result'
+      - '"arn" in result'
+      - '"stored_bytes" in result'
+      # - '"kms_key_id" in result'
+      - '"CamelCase" in log_group.tags'
+      - '"snake_case" in log_group.tags'
+    vars:
+      log_group: '{{ result.log_groups[0] }}'
+
+  - name: create cloudwatch log group for integration test (idempotent)
+    cloudwatchlogs_log_group:
+      state: present
+      log_group_name: '{{ log_group_name }}'
+      retention: 1
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+      - '"log_groups" in result'
+      - result.log_groups | length == 1
+    vars:
+      log_group: '{{ result.log_groups[0] }}'
+
+  - name: describe all log groups
+    cloudwatchlogs_log_group_info: {}
+    register: result
+
+  - assert:
+      that:
+      - '"log_groups" in result'
+      - result.log_groups | length >= 1
+
+  - name: describe log group
+    cloudwatchlogs_log_group_info:
+      log_group_name: '{{ log_group_name }}'
+    register: result
+
+  - assert:
+      that:
+      - '"log_groups" in result'
+      - result.log_groups | length == 1
+    vars:
+      log_group: '{{ result.log_groups[0] }}'
+
+  - name: delete cloudwatch log group for integration test
+    cloudwatchlogs_log_group:
+      state: absent
+      log_group_name: '{{ log_group_name }}'
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: delete cloudwatch log group for integration test (idempotent)
+    cloudwatchlogs_log_group:
+      state: absent
+      log_group_name: '{{ log_group_name }}'
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+
+  - name: describe missing log group
+    cloudwatchlogs_log_group_info:
+      log_group_name: '{{ log_group_name }}'
+    register: result
+
+  - assert:
+      that:
+      - '"log_groups" in result'
+      - result.log_groups | length == 0
+
+  always:
+
+  - name: delete cloudwatch log group for integration test
+    cloudwatchlogs_log_group:
+      state: absent
+      log_group_name: '{{ log_group_name }}'
+    ignore_errors: true

--- a/tests/integration/targets/cloudwatchlogs_log_group/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchlogs_log_group/tasks/main.yml
@@ -75,8 +75,18 @@
       that:
       - '"log_groups" in result'
       - result.log_groups | length == 1
+      - '"log_group_name" in log_group'
+      - '"creation_time" in log_group'
+      - '"retention_in_days" in log_group'
+      - '"metric_filter_count" in log_group'
+      - '"arn" in log_group'
+      - '"stored_bytes" in log_group'
+      # - '"kms_key_id" in log_group'
+      - '"tags" in log_group'
     vars:
       log_group: '{{ result.log_groups[0] }}'
+
+  - include_tasks: 'tags.yml'
 
   - name: delete cloudwatch log group for integration test
     cloudwatchlogs_log_group:

--- a/tests/integration/targets/cloudwatchlogs_log_group/tasks/tags.yml
+++ b/tests/integration/targets/cloudwatchlogs_log_group/tasks/tags.yml
@@ -1,0 +1,250 @@
+- name: Tests relating to setting tags on cloudwatchlogs_log_group
+  vars:
+    first_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      'New Key with Spaces': Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+    final_tags:
+      'Key with Spaces': Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      'New Key with Spaces': Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+  # Mandatory settings
+  module_defaults:
+    community.aws.cloudwatchlogs_log_group:
+      state: present
+      log_group_name: '{{ log_group_name }}'
+    community.aws.cloudwatchlogs_log_group_info:
+      log_group_name: '{{ log_group_name }}'
+  block:
+
+#  - name: test adding tags to cloudwatchlogs_log_group (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: '{{ first_tags }}'
+#      purge_tags: True
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is changed
+
+  - name: test adding tags to cloudwatchlogs_log_group
+    cloudwatchlogs_log_group:
+      tags: '{{ first_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.log_groups[0].tags == first_tags
+
+#  - name: test adding tags to cloudwatchlogs_log_group - idempotency (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: '{{ first_tags }}'
+#      purge_tags: True
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is not changed
+
+  - name: test adding tags to cloudwatchlogs_log_group - idempotency
+    cloudwatchlogs_log_group:
+      tags: '{{ first_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.log_groups[0].tags == first_tags
+
+  ###
+
+#  - name: test updating tags with purge on cloudwatchlogs_log_group (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: '{{ second_tags }}'
+#      purge_tags: True
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is changed
+
+  - name: test updating tags with purge on cloudwatchlogs_log_group
+    cloudwatchlogs_log_group:
+      tags: '{{ second_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.log_groups[0].tags == second_tags
+
+#  - name: test updating tags with purge on cloudwatchlogs_log_group - idempotency (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: '{{ second_tags }}'
+#      purge_tags: True
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is not changed
+
+  - name: test updating tags with purge on cloudwatchlogs_log_group - idempotency
+    cloudwatchlogs_log_group:
+      tags: '{{ second_tags }}'
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.log_groups[0].tags == second_tags
+
+  ###
+
+#  - name: test updating tags without purge on cloudwatchlogs_log_group (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: '{{ third_tags }}'
+#      purge_tags: False
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is changed
+
+  - name: test updating tags without purge on cloudwatchlogs_log_group
+    cloudwatchlogs_log_group:
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.log_groups[0].tags == final_tags
+
+#  - name: test updating tags without purge on cloudwatchlogs_log_group - idempotency (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: '{{ third_tags }}'
+#      purge_tags: False
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is not changed
+
+  - name: test updating tags without purge on cloudwatchlogs_log_group - idempotency
+    cloudwatchlogs_log_group:
+      tags: '{{ third_tags }}'
+      purge_tags: False
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.log_groups[0].tags == final_tags
+
+  ###
+
+  - name: test that cloudwatchlogs_log_group_info returns the tags
+    cloudwatchlogs_log_group_info:
+    register: tag_info
+  - name: assert tags present
+    assert:
+      that:
+      - tag_info.log_groups | length == 1
+      - tag_info.log_groups[0].tags == final_tags
+
+  ###
+
+#  - name: test no tags param cloudwatchlogs_log_group (check mode)
+#    cloudwatchlogs_log_group: {}
+#    register: update_result
+#    check_mode: yes
+#  - name: assert no change
+#    assert:
+#      that:
+#      - update_result is not changed
+#      - update_result.log_groups[0].tags == final_tags
+#
+
+  - name: test no tags param cloudwatchlogs_log_group
+    cloudwatchlogs_log_group: {}
+    register: update_result
+  - name: assert no change
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.log_groups[0].tags == final_tags
+
+  ###
+
+#  - name: test removing tags from cloudwatchlogs_log_group (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: {}
+#      purge_tags: True
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is changed
+
+  - name: test removing tags from cloudwatchlogs_log_group
+    cloudwatchlogs_log_group:
+      tags: {}
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is changed
+      - update_result.log_groups[0].tags == {}
+
+#  - name: test removing tags from cloudwatchlogs_log_group - idempotency (check mode)
+#    cloudwatchlogs_log_group:
+#      tags: {}
+#      purge_tags: True
+#    register: update_result
+#    check_mode: yes
+#  - name: assert that update succeeded
+#    assert:
+#      that:
+#      - update_result is not changed
+
+  - name: test removing tags from cloudwatchlogs_log_group - idempotency
+    cloudwatchlogs_log_group:
+      tags: {}
+      purge_tags: True
+    register: update_result
+  - name: assert that update succeeded
+    assert:
+      that:
+      - update_result is not changed
+      - update_result.log_groups[0].tags == {}

--- a/tests/integration/targets/legacy_missing_tests/aliases
+++ b/tests/integration/targets/legacy_missing_tests/aliases
@@ -16,7 +16,6 @@ cloudfront_info
 cloudfront_invalidation
 cloudfront_origin_access_identity
 cloudwatchevent_rule
-cloudwatchlogs_log_group_info
 data_pipeline
 dynamodb_ttl
 ec2_ami_copy
@@ -24,7 +23,6 @@ ec2_asg_lifecycle_hook
 ec2_customer_gateway
 ec2_customer_gateway_info
 ec2_snapshot_copy
-ec2_vpc_vgw_info
 ec2_win_password
 ecs_attribute
 elasticache_info


### PR DESCRIPTION
##### SUMMARY

- Ensure cloudwatchlogs_log_group returns values defined in RETURN docs
- Add support for updating tags (including purge_tags)
- split cloudwatchlogs_log_group tests
- Add some basic integration tests for cloudwatchlogs_log_group_info

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

cloudwatchlogs_log_group
cloudwatchlogs_log_group_info

##### ADDITIONAL INFORMATION
