### PR TITLE
route53_info: Add snake_cased return key,values and a deprecation message

### DIFF
--- a/changelogs/fragments/1236-route53_info-add-snake_case-return-values.yml
+++ b/changelogs/fragments/1236-route53_info-add-snake_case-return-values.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - route53_info - The CamelCase return values for ```HostedZones```, ```ResourceRecordSets```, and ```HealthChecks```
+    have been deprecated, in the future release you must use snake_case return values ```hosted_zones```, ```resource_record_sets```,
+    and ```health_checks``` instead respectively".

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -213,6 +213,7 @@ from ansible.module_utils._text import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 # Split out paginator to allow for the backoff decorator to function
@@ -270,10 +271,17 @@ def list_hosted_zones():
         params['DelegationSetId'] = module.params.get('delegation_set_id')
 
     zones = _paginated_result('list_hosted_zones', **params)['HostedZones']
+    snaked_zones = [camel_dict_to_snake_dict(zone) for zone in zones]
+
+    module.deprecate("The 'CamelCase' return values with key 'HostedZones' and 'list' are deprecated and \
+                    will be replaced by 'snake_case' return values with key 'hosted_zones'. \
+                    Both case values are returned for now.",
+                     date='2025-01-01', collection_name='community.aws')
 
     return {
         "HostedZones": zones,
         "list": zones,
+        "hosted_zones": snaked_zones,
     }
 
 
@@ -367,10 +375,17 @@ def list_health_checks():
         )
 
     health_checks = _paginated_result('list_health_checks', **params)['HealthChecks']
+    snaked_health_checks = [camel_dict_to_snake_dict(health_check) for health_check in health_checks]
+
+    module.deprecate("The 'CamelCase' return values with key 'HealthChecks' and 'list' are deprecated and \
+                    will be replaced by 'snake_case' return values with key 'health_checks'. \
+                    Both case values are returned for now.",
+                     date='2025-01-01', collection_name='community.aws')
 
     return {
         "HealthChecks": health_checks,
         "list": health_checks,
+        "health_checks": snaked_health_checks,
     }
 
 
@@ -399,10 +414,17 @@ def record_sets_details():
         )
 
     record_sets = _paginated_result('list_resource_record_sets', **params)['ResourceRecordSets']
+    snaked_record_sets = [camel_dict_to_snake_dict(record_set) for record_set in record_sets]
+
+    module.deprecate("The 'CamelCase' return values with key 'ResourceRecordSets' and 'list' are deprecated and \
+                    will be replaced by 'snake_case' return values with key 'resource_record_sets'. \
+                    Both case values are returned for now.",
+                     date='2025-01-01', collection_name='community.aws')
 
     return {
         "ResourceRecordSets": record_sets,
         "list": record_sets,
+        "resource_record_sets": snaked_record_sets,
     }
 
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1564

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add snake_case return values and a deprecation message for existing CamelCase return values.

Route53_info currently returns CamelCase values, to have uniformity along all *_info modules in terms of return values, it should return snake_case values instead.

Proposed change should make addition of snake_case return values and the deprecation message provides time for users to upgrade their playbooks to avoid breaking existing playbooks due to the proposed change.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This PR is relation to the initiative for [having updated developer guidelines for *_info modules](https://github.com/ansible-collections/amazon.aws/pull/865) specifically related to guidelines for [deprecating return values](https://github.com/ansible-collections/amazon.aws/pull/865/files#diff-585495ebfa2b72a06ce8ceadb092aedda13bc6332539373dd15b32a0ec897eecR591-R605).
