### PR TITLE
Re-enable and update integration tests for aws_ssm_parameter_store

### DIFF
--- a/changelogs/fragments/1241-aws_ssm_parameter_store.yml
+++ b/changelogs/fragments/1241-aws_ssm_parameter_store.yml
@@ -1,2 +1,4 @@
 bugfixes:
 - aws_ssm_parameter_store - fix exception when description was set without value (https://github.com/ansible-collections/community.aws/pull/1241).
+minor_changes:
+- aws_ssm_parameter_store - add parameter_metadata to the returned values (https://github.com/ansible-collections/community.aws/pull/1241).

--- a/changelogs/fragments/1241-aws_ssm_parameter_store.yml
+++ b/changelogs/fragments/1241-aws_ssm_parameter_store.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_ssm_parameter_store - fix exception when description was set without value (https://github.com/ansible-collections/community.aws/pull/1241).

--- a/tests/integration/targets/aws_ssm_parameter_store/aliases
+++ b/tests/integration/targets/aws_ssm_parameter_store/aliases
@@ -1,2 +1,1 @@
 cloud/aws
-disabled

--- a/tests/integration/targets/aws_ssm_parameter_store/defaults/main.yml
+++ b/tests/integration/targets/aws_ssm_parameter_store/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-# defaults file for aws_lambda test
-ssm_key_prefix: '{{resource_prefix}}'
+ssm_key_prefix: '{{ resource_prefix }}'

--- a/tests/integration/targets/aws_ssm_parameter_store/tasks/main.yml
+++ b/tests/integration/targets/aws_ssm_parameter_store/tasks/main.yml
@@ -42,6 +42,22 @@
      that:
       - result is changed
       - lookup_value == simple_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == simple_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   - name: Create key/value pair in aws parameter store - idempotency
     aws_ssm_parameter_store:
@@ -57,6 +73,22 @@
      that:
       - result is not changed
       - lookup_value == simple_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == simple_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   # ============================================================
   # Update description
@@ -74,6 +106,22 @@
      that:
       - result is changed
       - lookup_value == simple_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      #- result.parameter_metadata.description == updated_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   - name: Update description - idempotency
     aws_ssm_parameter_store:
@@ -88,6 +136,29 @@
      that:
       - result is not changed
       - lookup_value == simple_value
+      - lookup_value == simple_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == updated_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
+    # 2022-06-20:
+    # There's a quirk in the AWS API that it doesn't seem to return updates to
+    # the metadata until there's a change in the value of the parameter.  The
+    # change has been made (as we'll see below) but we can't properly determine
+    # idempotency
+    ignore_errors: True
 
   # ============================================================
   # Update value
@@ -105,6 +176,22 @@
      that:
       - result is changed
       - lookup_value == updated_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == updated_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   - name: Update key/value pair in aws parameter store - idempotency
     aws_ssm_parameter_store:
@@ -119,21 +206,22 @@
      that:
       - result is not changed
       - lookup_value == updated_value
-
-  # ============================================================
-  # Because we have no mechanism for viewing the description, test that passing
-  # new value and description doesn't result in a change
-
-  - name: Test no change to description
-    aws_ssm_parameter_store:
-      name: '{{ simple_name }}'
-      value: '{{ updated_value }}'
-      description: '{{ updated_description }}'
-    register: result
-
-  - assert:
-     that:
-      - result is not changed
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == updated_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   # ============================================================
   # Complex update
@@ -152,6 +240,22 @@
      that:
       - result is changed
       - lookup_value == simple_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == simple_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   - name: Complex update to key/value pair in aws parameter store - idempotency
     aws_ssm_parameter_store:
@@ -167,17 +271,33 @@
      that:
       - result is not changed
       - lookup_value == simple_value
+      - '"parameter_metadata" in result'
+      - '"data_type" in result.parameter_metadata'
+      - '"description" in result.parameter_metadata'
+      - '"last_modified_date" in result.parameter_metadata'
+      - '"last_modified_user" in result.parameter_metadata'
+      - '"name" in result.parameter_metadata'
+      - '"policies" in result.parameter_metadata'
+      - '"tier" in result.parameter_metadata'
+      - '"type" in result.parameter_metadata'
+      - '"version" in result.parameter_metadata'
+      - result.parameter_metadata.data_type == 'text'
+      - result.parameter_metadata.description == simple_description
+      - result.parameter_metadata.name == simple_name
+      - result.parameter_metadata.policies | length == 0
+      - result.parameter_metadata.tier == 'Standard'
+      - result.parameter_metadata.type == 'String'
 
   # ============================================================
   # Delete
 
-  - name: Create key/value pair in aws parameter store
+  - name: Delete key/value pair in aws parameter store
     aws_ssm_parameter_store:
       name: '{{ simple_name }}'
       state: absent
     register: result
 
-  - name: Lookup a single key
+  - name: Lookup a single (missing) key
     set_fact:
       lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
     register: info_result
@@ -187,7 +307,7 @@
       - result is changed
       - info_result is failed
 
-  - name: Create key/value pair in aws parameter store - idempotency
+  - name: Delete key/value pair in aws parameter store - idempotency
     aws_ssm_parameter_store:
       name: '{{ simple_name }}'
       state: absent

--- a/tests/integration/targets/aws_ssm_parameter_store/tasks/main.yml
+++ b/tests/integration/targets/aws_ssm_parameter_store/tasks/main.yml
@@ -1,123 +1,208 @@
 ---
-#
-#  Author: Michael De La Rue
-#  based on aws_lambda test cases
+- set_fact:
+    # As a lookup plugin we don't have access to module_defaults
+    connection_args:
+      region: "{{ aws_region }}"
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      aws_security_token: "{{ security_token | default(omit) }}"
+  no_log: True
 
-- name: 'aws_ssm_parameter_store integration tests'
+- name: 'aws_ssm lookup plugin integration tests'
   collections:
-    - amazon.aws
+  - amazon.aws
   module_defaults:
     group/aws:
       aws_access_key: '{{ aws_access_key }}'
       aws_secret_key: '{{ aws_secret_key }}'
       security_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  vars:
+    simple_name: '/{{ ssm_key_prefix }}/Simple'
+    simple_description: 'This is a simple example'
+    simple_value: 'A simple VALue'
+    updated_description: 'This is an updated example'
+    updated_value: 'A simple VALue **UPDATED**'
   block:
 
-    # ============================================================
-    - name: Create or update key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/Hello"
-        description: "This is your first key"
-        value: "World"
+  # ============================================================
+  # Create
 
-    - name: Check that parameter was stored correctly
-      assert:
-       that:
-        - "'{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/Hello', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
+  - name: Create key/value pair in aws parameter store
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      description: '{{ simple_description }}'
+      value: '{{ simple_value }}'
+    register: result
 
-    # ============================================================
-    - name: Create or update key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/path/wonvar"
-        description: "This is your first key"
-        value: "won value"
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is changed
+      - lookup_value == simple_value
 
-    - name: Create or update key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/path/toovar"
-        description: "This is your first key"
-        value: "too value"
+  - name: Create key/value pair in aws parameter store - idempotency
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      description: '{{ simple_description }}'
+      value: '{{ simple_value }}'
+    register: result
 
-    - name: Create or update key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/path/tree/treevar"
-        description: "This is your first key"
-        value: "tree value"
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is not changed
+      - lookup_value == simple_value
 
-    # ============================================================
-    - name: Create or update key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/deeppath/wondir/samevar"
-        description: "This is your first key"
-        value: "won value"
+  # ============================================================
+  # Update description
 
-    - name: Create or update key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/deeppath/toodir/samevar"
-        description: "This is your first key"
-        value: "too value"
+  - name: Update description
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      description: '{{ updated_description }}'
+    register: result
 
-    # ============================================================
-    - name: debug the lookup
-      debug:
-       msg: "{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True )}}'"
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is changed
+      - lookup_value == simple_value
 
-    - name: Check that parameter path is stored and retrieved
-      assert:
-       that:
-        - "'{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true ) | to_json }}' == '{\"toovar\": \"too value\", \"wonvar\": \"won value\"}'"
+  - name: Update description - idempotency
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      description: '{{ updated_description }}'
+    register: result
 
-    # ============================================================
-    - name: Returns empty value in case we don't find a named parameter and default filter works
-      assert:
-       that:
-        - "'{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == ''"
-        - "'{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token ) | default('I_can_has_default', true)}}' == 'I_can_has_default'"
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is not changed
+      - lookup_value == simple_value
 
-    # ============================================================
-    - name: Handle multiple paths with one that doesn't exist - default to full names.
-      assert:
-       that:
-        - "'{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/path', '/' ~ ssm_key_prefix ~ '/dont_create_this_path_you_will_break_the_ansible_tests', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True ) | to_json }}' in ( '[{\"/' ~ ssm_key_prefix ~ '/path/toovar\": \"too value\", \"/' ~ ssm_key_prefix ~ '/path/wonvar\": \"won value\"}, {}]',  '[{\"/' ~ ssm_key_prefix ~ '/path/wonvar\": \"won value\", \"/' ~ ssm_key_prefix ~ '/path/toovar\": \"too value\"}, {}]' )"
+  # ============================================================
+  # Update value
 
+  - name: Update key/value pair in aws parameter store
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      value: '{{ updated_value }}'
+    register: result
 
-    # ============================================================
-    # this may be a bit of a nasty test case;  we should perhaps accept _either_ value that was stored
-    # in the two variables named 'samevar'
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is changed
+      - lookup_value == updated_value
 
-    - name: Handle multiple paths with one that doesn't exist - shortnames - including overlap.
-      assert:
-       that:
-        - "'{{lookup('amazon.aws.aws_ssm', '/' ~ ssm_key_prefix ~ '/path', '/' ~ ssm_key_prefix ~ '/dont_create_this_path_you_will_break_the_ansible_tests', '/' ~ ssm_key_prefix ~ '/deeppath', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true, recursive=true ) | to_json }}' == '[{\"toovar\": \"too value\", \"treevar\": \"tree value\", \"wonvar\": \"won value\"}, {}, {\"samevar\": \"won value\"}]'"
+  - name: Update key/value pair in aws parameter store - idempotency
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      value: '{{ updated_value }}'
+    register: result
 
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is not changed
+      - lookup_value == updated_value
 
-    # ============================================================
-    - name: Delete key/value pair in aws parameter store
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/Hello"
-        state: absent
+  # ============================================================
+  # Because we have no mechanism for viewing the description, test that passing
+  # new value and description doesn't result in a change
 
-    # ============================================================
-    - name: Attempt delete key/value pair in aws parameter store again
-      aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/Hello"
-        state: absent
-      register: result
+  - name: Test no change to description
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      value: '{{ updated_value }}'
+      description: '{{ updated_description }}'
+    register: result
 
-    - name: assert that changed is False since parameter should be deleted
-      assert:
-        that:
-          - result.changed == False
+  - assert:
+     that:
+      - result is not changed
+
+  # ============================================================
+  # Complex update
+
+  - name: Complex update to key/value pair in aws parameter store
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      value: '{{ simple_value }}'
+      description: '{{ simple_description }}'
+    register: result
+
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is changed
+      - lookup_value == simple_value
+
+  - name: Complex update to key/value pair in aws parameter store - idempotency
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      value: '{{ simple_value }}'
+      description: '{{ simple_description }}'
+    register: result
+
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+  - assert:
+     that:
+      - result is not changed
+      - lookup_value == simple_value
+
+  # ============================================================
+  # Delete
+
+  - name: Create key/value pair in aws parameter store
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      state: absent
+    register: result
+
+  - name: Lookup a single key
+    set_fact:
+      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+    register: info_result
+    ignore_errors: true
+  - assert:
+     that:
+      - result is changed
+      - info_result is failed
+
+  - name: Create key/value pair in aws parameter store - idempotency
+    aws_ssm_parameter_store:
+      name: '{{ simple_name }}'
+      state: absent
+    register: result
+
+  - assert:
+     that:
+      - result is not changed
+
   always:
-    # ============================================================
-    - name: Delete remaining key/value pairs in aws parameter store
-      aws_ssm_parameter_store:
-        name: "{{item}}"
-        state: absent
-      with_items:
-        - "/{{ssm_key_prefix}}/Hello"
-        - "/{{ssm_key_prefix}}/path/wonvar"
-        - "/{{ssm_key_prefix}}/path/toovar"
-        - "/{{ssm_key_prefix}}/path/tree/treevar"
-        - "/{{ssm_key_prefix}}/deeppath/wondir/samevar"
+  # ============================================================
+  - name: Delete remaining key/value pairs in aws parameter store
+    aws_ssm_parameter_store:
+      name: "{{item}}"
+      state: absent
+    ignore_errors: True
+    with_items:
+      - '{{ simple_name }}'


### PR DESCRIPTION
##### SUMMARY

- Fixes exception when description was updated within passing value.
- Rewrite and enable integration tests for module
- Add some return values

While the integration tests don't include coverage for the more complex options for aws_ssm_parameter_store these have never existed.  Having **something** enabled gives future module developers something to build upon.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_ssm_parameter_store

##### ADDITIONAL INFORMATION



Exception:
```
TASK [aws_ssm_parameter_store : Update description] ****************************
task path: /root/ansible_collections/community/aws/tests/output/.tmp/integration/aws_ssm_parameter_store-071mpr89-ÅÑŚÌβŁÈ/tests/integration/targets/aws_ssm_parameter_store/tasks/main.yml:64
Using module file /root/ansible_collections/community/aws/plugins/modules/aws_ssm_parameter_store.py
Pipelining is enabled.
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c 'ANSIBLE_DEBUG_BOTOCORE_LOGS=True /usr/bin/python3.10 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_aws_ssm_parameter_store_payload_13s3_ao3/ansible_aws_ssm_parameter_store_payload.zip/ansible_collections/community/aws/plugins/modules/aws_ssm_parameter_store.py", line 160, in update_parameter
  File "/usr/local/lib/python3.10/dist-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.10/dist-packages/botocore/client.py", line 648, in _make_api_call
    request_dict = self._convert_to_request_dict(
  File "/usr/local/lib/python3.10/dist-packages/botocore/client.py", line 696, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
  File "/usr/local/lib/python3.10/dist-packages/botocore/validate.py", line 293, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Value, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
fatal: [testhost]: FAILED! => {
    "boto3_version": "1.17.0",
    "botocore_version": "1.20.0",
    "changed": false,
    "invocation": {
        "module_args": {
            "aws_access_key": "ASIA6CCDWXDOM4BEFFL4",
            "aws_ca_bundle": null,
            "aws_config": null,
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "debug_botocore_endpoint_logs": true,
            "decryption": true,
            "description": "This is an updated example",
            "ec2_url": null,
            "key_id": "alias/aws/ssm",
            "name": "/ansible-test-12184966-mchappel/Simple",
            "overwrite_value": "changed",
            "profile": null,
            "region": "us-east-1",
            "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present",
            "string_type": "String",
            "tier": "Standard",
            "validate_certs": true,
            "value": null
        }
    },
    "msg": "setting parameter: Parameter validation failed:\nInvalid type for parameter Value, value: None, type: <class 'NoneType'>, valid types: <class 'str'>",
    "resource_actions": [
        "ssm:GetParameter"
    ]
}
```