### PR TITLE
Prepare 2.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ community.aws Release Notes
 .. contents:: Topics
 
 
+v2.6.1
+======
+
+Release Summary
+---------------
+
+- Bump collection from 2.6.0 to 2.6.1 due to a publishing error with 2.6.0.  This release supersedes 2.6.0 entirely, users should skip 2.6.0.
+
 v2.6.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1641,3 +1641,11 @@ releases:
     - 1215-ecs-service-deployment-circuit-breaker-support.yml
     - 2.6.0.yml
     release_date: '2022-06-22'
+  2.6.1:
+    changes:
+      release_summary:
+      - Bump collection from 2.6.0 to 2.6.1 due to a publishing error with 2.6.0.  This
+        release supersedes 2.6.0 entirely, users should skip 2.6.0.
+    fragments:
+    - 261_increase.yml
+    release_date: '2022-06-22'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: community
 name: aws
-version: 2.6.0
+version: 2.6.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
##### SUMMARY
A tagging issue caused the wrong branch to be published to galaxy,  Release an updated 2.6.x.

##### ISSUE TYPE

- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
galaxy.yml