### PR TITLE
[stable-3] Fixup short description for aws_acm

### DIFF
--- a/plugins/modules/aws_acm.py
+++ b/plugins/modules/aws_acm.py
@@ -28,8 +28,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: aws_acm
-short_description: >
-  Upload and delete certificates in the AWS Certificate Manager service
+short_description: Upload and delete certificates in the AWS Certificate Manager service
 version_added: 1.0.0
 description:
   - >


### PR DESCRIPTION
##### SUMMARY

Fixup short description for aws_acm
partial backport from #1185

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/aws_acm.py

##### ADDITIONAL INFORMATION

`>` (as opposed to `>-`) results in a weird extra new line in the generated docs