### PR TITLE
[5.0.0] iam_server_cerificate - complete deprecation cycles

### DIFF
--- a/changelogs/fragments/1265-iam_server_cerificate_deprecations.yml
+++ b/changelogs/fragments/1265-iam_server_cerificate_deprecations.yml
@@ -1,0 +1,9 @@
+breaking_changes:
+- iam_server_certificate - Passing file names to the ``cert``, ``chain_cert``
+  and ``key`` parameters has been removed. We recommend using a lookup plugin
+  to read the files instead, see the documentation for an example
+  (https://github.com/ansible-collections/community.aws/pull/1265).
+- iam_server_certificate - the default value for the ``dup_ok`` parameter has
+  been changed to ``true``. To preserve the original behaviour explicitly set
+  the ``dup_ok`` parameter to ``false``
+  (https://github.com/ansible-collections/community.aws/pull/1265).

--- a/tests/integration/targets/iam_server_certificate/tasks/main.yml
+++ b/tests/integration/targets/iam_server_certificate/tasks/main.yml
@@ -336,12 +336,13 @@
 
   ################################################
 
-  - name: Create Certificate with identical cert - check_mode
+  - name: Create Certificate with identical cert dup_ok=False - check_mode
     iam_server_certificate:
       name: '{{ cert_name }}-duplicate'
       state: present
       cert: '{{ cert_a_data }}'
       key: '{{ lookup("file", path_cert_key) }}'
+      dup_ok: false
     register: create_duplicate
     ignore_errors: true
 
@@ -350,12 +351,13 @@
       that:
       - create_duplicate is failed
 
-  - name: Create Certificate with identical cert
+  - name: Create Certificate with identical cert dup_ok=False
     iam_server_certificate:
       name: '{{ cert_name }}-duplicate'
       state: present
       cert: '{{ cert_a_data }}'
       key: '{{ lookup("file", path_cert_key) }}'
+      dup_ok: false
     register: create_duplicate
     ignore_errors: true
 
@@ -372,7 +374,6 @@
       state: present
       cert: '{{ cert_a_data }}'
       key: '{{ lookup("file", path_cert_key) }}'
-      dup_ok: true
     register: create_duplicate
     check_mode: true
 
@@ -388,7 +389,6 @@
       state: present
       cert: '{{ cert_a_data }}'
       key: '{{ lookup("file", path_cert_key) }}'
-      dup_ok: true
     register: create_duplicate
 
   - name: check result - Create Certificate with forced identical cert
@@ -414,7 +414,6 @@
       state: present
       cert: '{{ cert_a_data }}'
       key: '{{ lookup("file", path_cert_key) }}'
-      dup_ok: true
     register: create_duplicate
     check_mode: true
 
@@ -430,7 +429,6 @@
       state: present
       cert: '{{ cert_a_data }}'
       key: '{{ lookup("file", path_cert_key) }}'
-      dup_ok: true
     register: create_duplicate
 
   - name: check result - Create Certificate with forced identical cert - idempotency


### PR DESCRIPTION
##### SUMMARY

fixes: #1257 

In #735 we deprecated passing filenames and prepared to switch the default value of dup_ok to True.

This PR completes the deprecation cycle (1 release late)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_server_certificate

##### ADDITIONAL INFORMATION