### PR TITLE
Disable galaxy-importer docs tests

### DIFF
--- a/tests/galaxy-importer.cfg
+++ b/tests/galaxy-importer.cfg
@@ -1,0 +1,2 @@
+[galaxy-importer]
+run_ansible_doc=False


### PR DESCRIPTION
##### SUMMARY

Because galaxy-importer tests the collections in a sterile environment it can't read the shared amazon.aws fragments.

We're separately testing the docs more thoroughly using a github action, so we can disable the broken docs fragment testing via galaxy-importer

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/galaxy-importer.cfg

##### ADDITIONAL INFORMATION
