### PR TITLE
Rename batch modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ Name | Description
 [community.aws.aws_api_gateway](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_api_gateway_module.rst)|Manage AWS API Gateway APIs
 [community.aws.aws_api_gateway_domain](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_api_gateway_domain_module.rst)|Manage AWS API Gateway custom domains
 [community.aws.aws_application_scaling_policy](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_application_scaling_policy_module.rst)|Manage Application Auto Scaling Scaling Policies
-[community.aws.aws_batch_compute_environment](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_batch_compute_environment_module.rst)|Manage AWS Batch Compute Environments
-[community.aws.aws_batch_job_definition](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_batch_job_definition_module.rst)|Manage AWS Batch Job Definitions
-[community.aws.aws_batch_job_queue](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_batch_job_queue_module.rst)|Manage AWS Batch Job Queues
 [community.aws.aws_codebuild](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_codebuild_module.rst)|Create or delete an AWS CodeBuild project
 [community.aws.aws_codecommit](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_codecommit_module.rst)|Manage repositories in AWS CodeCommit
 [community.aws.aws_codepipeline](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_codepipeline_module.rst)|Create or delete AWS CodePipelines
@@ -73,6 +70,9 @@ Name | Description
 [community.aws.aws_waf_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_waf_info_module.rst)|Retrieve information for WAF ACLs, Rule , Conditions and Filters.
 [community.aws.aws_waf_rule](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_waf_rule_module.rst)|Create and delete WAF Rules
 [community.aws.aws_waf_web_acl](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_waf_web_acl_module.rst)|Create and delete WAF Web ACLs
+[community.aws.batch_compute_environment](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.batch_compute_environment_module.rst)|Manage AWS Batch Compute Environments
+[community.aws.batch_job_definition](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.batch_job_definition_module.rst)|Manage AWS Batch Job Definitions
+[community.aws.batch_job_queue](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.batch_job_queue_module.rst)|Manage AWS Batch Job Queues
 [community.aws.cloudformation_exports_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.cloudformation_exports_info_module.rst)|Read a value from CloudFormation Exports
 [community.aws.cloudformation_stack_set](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.cloudformation_stack_set_module.rst)|Manage groups of CloudFormation stacks
 [community.aws.cloudfront_distribution](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.cloudfront_distribution_module.rst)|Create, update and delete AWS CloudFront distributions

--- a/changelogs/fragments/1272-rename-batch.yml
+++ b/changelogs/fragments/1272-rename-batch.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- aws_batch_compute_environment - the ``aws_batch_compute_environment`` module has been renamed to ``batch_compute_environment``, ``aws_batch_compute_environment`` remains as an alias (https://github.com/ansible-collections/community.aws/pull/1272).
+- aws_batch_job_definition - the ``aws_batch_job_definition`` module has been renamed to ``batch_job_definition``, ``aws_batch_job_definition`` remains as an alias (https://github.com/ansible-collections/community.aws/pull/1272).
+- aws_batch_job_queue - the ``aws_batch_job_queue`` module has been renamed to ``batch_job_queue``, ``aws_batch_job_queue`` remains as an alias (https://github.com/ansible-collections/community.aws/pull/1272).

--- a/docs/community.aws.batch_compute_environment_module.rst
+++ b/docs/community.aws.batch_compute_environment_module.rst
@@ -1,11 +1,11 @@
-.. _community.aws.aws_batch_job_queue_module:
+.. _community.aws.batch_compute_environment_module:
 
 
-*********************************
-community.aws.aws_batch_job_queue
-*********************************
+***************************************
+community.aws.batch_compute_environment
+***************************************
 
-**Manage AWS Batch Job Queues**
+**Manage AWS Batch Compute Environments**
 
 
 Version added: 1.0.0
@@ -17,9 +17,10 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- This module allows the management of AWS Batch Job Queues.
+- This module allows the management of AWS Batch Compute Environments.
 - It is idempotent and supports "Check" mode.
-- Use module :ref:`community.aws.aws_batch_compute_environment <community.aws.aws_batch_compute_environment_module>` to manage the compute environment, :ref:`community.aws.aws_batch_job_queue <community.aws.aws_batch_job_queue_module>` to manage job queues, :ref:`community.aws.aws_batch_job_definition <community.aws.aws_batch_job_definition_module>` to manage job definitions.
+- Use module :ref:`community.aws.batch_compute_environment <community.aws.batch_compute_environment_module>` to manage the compute environment, :ref:`community.aws.batch_job_queue <community.aws.batch_job_queue_module>` to manage job queues, :ref:`community.aws.batch_job_definition <community.aws.batch_job_definition_module>` to manage job definitions.
+- Prior to release 5.0.0 this module was called ``community.aws.aws_batch_compute_environment``. The usage did not change.
 
 
 
@@ -39,12 +40,12 @@ Parameters
 
     <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="2">Parameter</th>
+            <th colspan="1">Parameter</th>
             <th>Choices/<font color="blue">Defaults</font></th>
             <th width="100%">Comments</th>
         </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_access_key</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -61,7 +62,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_ca_bundle</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -77,7 +78,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_config</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -93,7 +94,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_secret_key</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -110,43 +111,9 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>compute_environment_order</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">list</span>
-                         / <span style="color: purple">elements=dictionary</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment should execute a given job. Compute environments must be in the VALID state before you can associate them with a job queue. You can associate up to 3 compute environments with a job queue.</div>
-                </td>
-            </tr>
-                                <tr>
-                    <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>compute_environment</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The name of the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                    <td class="elbow-placeholder"></td>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>order</b>
+                    <b>bid_percentage</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
@@ -155,12 +122,69 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The relative priority of the environment.</div>
+                        <div>The minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched.</div>
+                        <div>For example, if your bid percentage is 20%, then the Spot price must be below 20% of the current On-Demand price for that EC2 instance.</div>
                 </td>
             </tr>
-
             <tr>
-                <td colspan="2">
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>compute_environment_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name for your compute environment.</div>
+                        <div>Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>compute_environment_state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>ENABLED</b>&nbsp;&larr;</div></li>
+                                    <li>DISABLED</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The state of the compute environment.</div>
+                        <div>If the state is <code>ENABLED</code>, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>compute_resource_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>EC2</li>
+                                    <li>SPOT</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The type of compute resource.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>debug_botocore_endpoint_logs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -179,7 +203,37 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>desiredv_cpus</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The desired number of EC2 vCPUS in the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ec2_key_pair</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The EC2 key pair that is used for instances launched in the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ec2_url</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -195,9 +249,24 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>job_queue_name</b>
+                    <b>image_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>instance_role</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -207,32 +276,30 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The name for the job queue</div>
+                        <div>The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.</div>
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>job_queue_state</b>
+                    <b>instance_types</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li><div style="color: blue"><b>ENABLED</b>&nbsp;&larr;</div></li>
-                                    <li>DISABLED</li>
-                        </ul>
                 </td>
                 <td>
-                        <div>The state of the job queue. If the job queue state is ENABLED, it is able to accept jobs.</div>
+                        <div>The instance types that may be launched.</div>
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>priority</b>
+                    <b>maxv_cpus</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
@@ -242,11 +309,27 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The priority of the job queue. Job queues with a higher priority (or a lower integer value for the priority parameter) are evaluated first when associated with same compute environment. Priority is determined in ascending order, for example, a job queue with a priority value of 1 is given scheduling preference over a job queue with a priority value of 10.</div>
+                        <div>The maximum number of EC2 vCPUs that an environment can reach.</div>
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>minv_cpus</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The minimum number of EC2 vCPUs that an environment should maintain.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>profile</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -262,7 +345,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>region</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -278,7 +361,24 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>security_group_ids</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The EC2 security groups that are associated with instances launched in the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>security_token</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -296,7 +396,38 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>service_role</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>spot_iam_fleet_role</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -315,7 +446,59 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>subnets</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The VPC subnets into which the compute resources are launched.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>tags</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Key-value pair tags to be applied to resources that are launched in the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>MANAGED</li>
+                                    <li>UNMANAGED</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The type of the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>validate_certs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -352,23 +535,35 @@ Examples
 
 .. code-block:: yaml
 
-    - name: My Batch Job Queue
-      community.aws.aws_batch_job_queue:
-        job_queue_name: jobQueueName
+    - name: My Batch Compute Environment
+      community.aws.batch_compute_environment:
+        compute_environment_name: computeEnvironmentName
         state: present
         region: us-east-1
-        job_queue_state: ENABLED
-        priority: 1
-        compute_environment_order:
-        - order: 1
-          compute_environment: my_compute_env1
-        - order: 2
-          compute_environment: my_compute_env2
-      register: batch_job_queue_action
+        compute_environment_state: ENABLED
+        type: MANAGED
+        compute_resource_type: EC2
+        minv_cpus: 0
+        maxv_cpus: 2
+        desiredv_cpus: 1
+        instance_types:
+          - optimal
+        subnets:
+          - my-subnet1
+          - my-subnet2
+        security_group_ids:
+          - my-sg1
+          - my-sg2
+        instance_role: arn:aws:iam::<account>:instance-profile/<role>
+        tags:
+          tag1: value1
+          tag2: value2
+        service_role: arn:aws:iam::<account>:role/service-role/<role>
+      register: aws_batch_compute_environment_action
 
     - name: show results
       ansible.builtin.debug:
-        var: batch_job_queue_action
+        var: aws_batch_compute_environment_action
 
 
 
@@ -398,7 +593,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>returns what action was taken, whether something was changed, invocation and response</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;batch_job_queue_action&#x27;: &#x27;updated&#x27;, &#x27;changed&#x27;: False, &#x27;response&#x27;: {&#x27;job_queue_arn&#x27;: &#x27;arn:aws:batch:....&#x27;, &#x27;job_queue_name&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;priority&#x27;: 1, &#x27;state&#x27;: &#x27;DISABLED&#x27;, &#x27;status&#x27;: &#x27;UPDATING&#x27;, &#x27;status_reason&#x27;: &#x27;JobQueue Healthy&#x27;}}</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;batch_compute_environment_action&#x27;: &#x27;none&#x27;, &#x27;changed&#x27;: False, &#x27;invocation&#x27;: {&#x27;module_args&#x27;: {&#x27;aws_access_key&#x27;: None, &#x27;aws_secret_key&#x27;: None, &#x27;bid_percentage&#x27;: None, &#x27;compute_environment_name&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;compute_environment_state&#x27;: &#x27;ENABLED&#x27;, &#x27;compute_resource_type&#x27;: &#x27;EC2&#x27;, &#x27;desiredv_cpus&#x27;: 0, &#x27;ec2_key_pair&#x27;: None, &#x27;ec2_url&#x27;: None, &#x27;image_id&#x27;: None, &#x27;instance_role&#x27;: &#x27;arn:aws:iam::...&#x27;, &#x27;instance_types&#x27;: [&#x27;optimal&#x27;], &#x27;maxv_cpus&#x27;: 8, &#x27;minv_cpus&#x27;: 0, &#x27;profile&#x27;: None, &#x27;region&#x27;: &#x27;us-east-1&#x27;, &#x27;security_group_ids&#x27;: [&#x27;*******&#x27;], &#x27;security_token&#x27;: None, &#x27;service_role&#x27;: &#x27;arn:aws:iam::....&#x27;, &#x27;spot_iam_fleet_role&#x27;: None, &#x27;state&#x27;: &#x27;present&#x27;, &#x27;subnets&#x27;: [&#x27;******&#x27;], &#x27;tags&#x27;: {&#x27;Environment&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;Name&#x27;: &#x27;&lt;name&gt;&#x27;}, &#x27;type&#x27;: &#x27;MANAGED&#x27;, &#x27;validate_certs&#x27;: True}}, &#x27;response&#x27;: {&#x27;computeEnvironmentArn&#x27;: &#x27;arn:aws:batch:....&#x27;, &#x27;computeEnvironmentName&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;computeResources&#x27;: {&#x27;desiredvCpus&#x27;: 0, &#x27;instanceRole&#x27;: &#x27;arn:aws:iam::...&#x27;, &#x27;instanceTypes&#x27;: [&#x27;optimal&#x27;], &#x27;maxvCpus&#x27;: 8, &#x27;minvCpus&#x27;: 0, &#x27;securityGroupIds&#x27;: [&#x27;******&#x27;], &#x27;subnets&#x27;: [&#x27;*******&#x27;], &#x27;tags&#x27;: {&#x27;Environment&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;Name&#x27;: &#x27;&lt;name&gt;&#x27;}, &#x27;type&#x27;: &#x27;EC2&#x27;}, &#x27;ecsClusterArn&#x27;: &#x27;arn:aws:ecs:.....&#x27;, &#x27;serviceRole&#x27;: &#x27;arn:aws:iam::...&#x27;, &#x27;state&#x27;: &#x27;ENABLED&#x27;, &#x27;status&#x27;: &#x27;VALID&#x27;, &#x27;statusReason&#x27;: &#x27;ComputeEnvironment Healthy&#x27;, &#x27;type&#x27;: &#x27;MANAGED&#x27;}}</div>
                 </td>
             </tr>
     </table>

--- a/docs/community.aws.batch_job_definition_module.rst
+++ b/docs/community.aws.batch_job_definition_module.rst
@@ -1,9 +1,9 @@
-.. _community.aws.aws_batch_job_definition_module:
+.. _community.aws.batch_job_definition_module:
 
 
-**************************************
-community.aws.aws_batch_job_definition
-**************************************
+**********************************
+community.aws.batch_job_definition
+**********************************
 
 **Manage AWS Batch Job Definitions**
 
@@ -19,7 +19,8 @@ Synopsis
 --------
 - This module allows the management of AWS Batch Job Definitions.
 - It is idempotent and supports "Check" mode.
-- Use module :ref:`community.aws.aws_batch_compute_environment <community.aws.aws_batch_compute_environment_module>` to manage the compute environment, :ref:`community.aws.aws_batch_job_queue <community.aws.aws_batch_job_queue_module>` to manage job queues, :ref:`community.aws.aws_batch_job_definition <community.aws.aws_batch_job_definition_module>` to manage job definitions.
+- Use module :ref:`community.aws.batch_compute_environment <community.aws.batch_compute_environment_module>` to manage the compute environment, :ref:`community.aws.batch_job_queue <community.aws.batch_job_queue_module>` to manage job queues, :ref:`community.aws.batch_job_definition <community.aws.batch_job_definition_module>` to manage job definitions.
+- Prior to release 5.0.0 this module was called ``community.aws.aws_batch_job_definition``. The usage did not change.
 
 
 
@@ -681,13 +682,8 @@ Examples
 .. code-block:: yaml
 
     ---
-    - hosts: localhost
-      gather_facts: no
-      vars:
-        state: present
-      tasks:
     - name: My Batch Job Definition
-      community.aws.aws_batch_job_definition:
+      community.aws.batch_job_definition:
         job_definition_name: My Batch Job Definition
         state: present
         type: container

--- a/docs/community.aws.batch_job_queue_module.rst
+++ b/docs/community.aws.batch_job_queue_module.rst
@@ -1,11 +1,11 @@
-.. _community.aws.aws_batch_compute_environment_module:
+.. _community.aws.batch_job_queue_module:
 
 
-*******************************************
-community.aws.aws_batch_compute_environment
-*******************************************
+*****************************
+community.aws.batch_job_queue
+*****************************
 
-**Manage AWS Batch Compute Environments**
+**Manage AWS Batch Job Queues**
 
 
 Version added: 1.0.0
@@ -17,9 +17,10 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- This module allows the management of AWS Batch Compute Environments.
+- This module allows the management of AWS Batch Job Queues.
 - It is idempotent and supports "Check" mode.
-- Use module :ref:`community.aws.aws_batch_compute_environment <community.aws.aws_batch_compute_environment_module>` to manage the compute environment, :ref:`community.aws.aws_batch_job_queue <community.aws.aws_batch_job_queue_module>` to manage job queues, :ref:`community.aws.aws_batch_job_definition <community.aws.aws_batch_job_definition_module>` to manage job definitions.
+- Use module :ref:`community.aws.batch_compute_environment <community.aws.batch_compute_environment_module>` to manage the compute environment, :ref:`community.aws.batch_job_queue <community.aws.batch_job_queue_module>` to manage job queues, :ref:`community.aws.batch_job_definition <community.aws.batch_job_definition_module>` to manage job definitions.
+- Prior to release 5.0.0 this module was called ``community.aws.aws_batch_job_queue``. The usage did not change.
 
 
 
@@ -39,12 +40,12 @@ Parameters
 
     <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="1">Parameter</th>
+            <th colspan="2">Parameter</th>
             <th>Choices/<font color="blue">Defaults</font></th>
             <th width="100%">Comments</th>
         </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_access_key</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -61,7 +62,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_ca_bundle</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -77,7 +78,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_config</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -93,7 +94,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_secret_key</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -110,9 +111,43 @@ Parameters
                 </td>
             </tr>
             <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>compute_environment_order</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment should execute a given job. Compute environments must be in the VALID state before you can associate them with a job queue. You can associate up to 3 compute environments with a job queue.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>bid_percentage</b>
+                    <b>compute_environment</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name of the compute environment.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>order</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
@@ -121,69 +156,12 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched.</div>
-                        <div>For example, if your bid percentage is 20%, then the Spot price must be below 20% of the current On-Demand price for that EC2 instance.</div>
+                        <div>The relative priority of the environment.</div>
                 </td>
             </tr>
+
             <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>compute_environment_name</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The name for your compute environment.</div>
-                        <div>Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>compute_environment_state</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li><div style="color: blue"><b>ENABLED</b>&nbsp;&larr;</div></li>
-                                    <li>DISABLED</li>
-                        </ul>
-                </td>
-                <td>
-                        <div>The state of the compute environment.</div>
-                        <div>If the state is <code>ENABLED</code>, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>compute_resource_type</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li>EC2</li>
-                                    <li>SPOT</li>
-                        </ul>
-                </td>
-                <td>
-                        <div>The type of compute resource.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>debug_botocore_endpoint_logs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -202,37 +180,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>desiredv_cpus</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">integer</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The desired number of EC2 vCPUS in the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>ec2_key_pair</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The EC2 key pair that is used for instances launched in the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ec2_url</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -248,24 +196,9 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>image_id</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>instance_role</b>
+                    <b>job_queue_name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -275,46 +208,32 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.</div>
+                        <div>The name for the job queue.</div>
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>instance_types</b>
+                    <b>job_queue_state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">list</span>
-                         / <span style="color: purple">elements=string</span>
-                         / <span style="color: red">required</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>ENABLED</b>&nbsp;&larr;</div></li>
+                                    <li>DISABLED</li>
+                        </ul>
                 </td>
                 <td>
-                        <div>The instance types that may be launched.</div>
+                        <div>The state of the job queue. If the job queue state is ENABLED, it is able to accept jobs.</div>
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>maxv_cpus</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">integer</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The maximum number of EC2 vCPUs that an environment can reach.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>minv_cpus</b>
+                    <b>priority</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
@@ -324,11 +243,11 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The minimum number of EC2 vCPUs that an environment should maintain.</div>
+                        <div>The priority of the job queue. Job queues with a higher priority (or a lower integer value for the priority parameter) are evaluated first when associated with same compute environment. Priority is determined in ascending order, for example, a job queue with a priority value of 1 is given scheduling preference over a job queue with a priority value of 10.</div>
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>profile</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -344,7 +263,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>region</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -360,24 +279,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>security_group_ids</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">list</span>
-                         / <span style="color: purple">elements=string</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The EC2 security groups that are associated with instances launched in the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>security_token</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -395,38 +297,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>service_role</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>spot_iam_fleet_role</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -445,59 +316,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>subnets</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">list</span>
-                         / <span style="color: purple">elements=string</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>The VPC subnets into which the compute resources are launched.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>tags</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">dictionary</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>Key-value pair tags to be applied to resources that are launched in the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>type</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
-                    </div>
-                </td>
-                <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li>MANAGED</li>
-                                    <li>UNMANAGED</li>
-                        </ul>
-                </td>
-                <td>
-                        <div>The type of the compute environment.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>validate_certs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -534,35 +353,23 @@ Examples
 
 .. code-block:: yaml
 
-    - name: My Batch Compute Environment
-      community.aws.aws_batch_compute_environment:
-        compute_environment_name: computeEnvironmentName
+    - name: My Batch Job Queue
+      community.aws.batch_job_queue:
+        job_queue_name: jobQueueName
         state: present
         region: us-east-1
-        compute_environment_state: ENABLED
-        type: MANAGED
-        compute_resource_type: EC2
-        minv_cpus: 0
-        maxv_cpus: 2
-        desiredv_cpus: 1
-        instance_types:
-          - optimal
-        subnets:
-          - my-subnet1
-          - my-subnet2
-        security_group_ids:
-          - my-sg1
-          - my-sg2
-        instance_role: arn:aws:iam::<account>:instance-profile/<role>
-        tags:
-          tag1: value1
-          tag2: value2
-        service_role: arn:aws:iam::<account>:role/service-role/<role>
-      register: aws_batch_compute_environment_action
+        job_queue_state: ENABLED
+        priority: 1
+        compute_environment_order:
+        - order: 1
+          compute_environment: my_compute_env1
+        - order: 2
+          compute_environment: my_compute_env2
+      register: batch_job_queue_action
 
     - name: show results
       ansible.builtin.debug:
-        var: aws_batch_compute_environment_action
+        var: batch_job_queue_action
 
 
 
@@ -592,7 +399,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>returns what action was taken, whether something was changed, invocation and response</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;batch_compute_environment_action&#x27;: &#x27;none&#x27;, &#x27;changed&#x27;: False, &#x27;invocation&#x27;: {&#x27;module_args&#x27;: {&#x27;aws_access_key&#x27;: None, &#x27;aws_secret_key&#x27;: None, &#x27;bid_percentage&#x27;: None, &#x27;compute_environment_name&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;compute_environment_state&#x27;: &#x27;ENABLED&#x27;, &#x27;compute_resource_type&#x27;: &#x27;EC2&#x27;, &#x27;desiredv_cpus&#x27;: 0, &#x27;ec2_key_pair&#x27;: None, &#x27;ec2_url&#x27;: None, &#x27;image_id&#x27;: None, &#x27;instance_role&#x27;: &#x27;arn:aws:iam::...&#x27;, &#x27;instance_types&#x27;: [&#x27;optimal&#x27;], &#x27;maxv_cpus&#x27;: 8, &#x27;minv_cpus&#x27;: 0, &#x27;profile&#x27;: None, &#x27;region&#x27;: &#x27;us-east-1&#x27;, &#x27;security_group_ids&#x27;: [&#x27;*******&#x27;], &#x27;security_token&#x27;: None, &#x27;service_role&#x27;: &#x27;arn:aws:iam::....&#x27;, &#x27;spot_iam_fleet_role&#x27;: None, &#x27;state&#x27;: &#x27;present&#x27;, &#x27;subnets&#x27;: [&#x27;******&#x27;], &#x27;tags&#x27;: {&#x27;Environment&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;Name&#x27;: &#x27;&lt;name&gt;&#x27;}, &#x27;type&#x27;: &#x27;MANAGED&#x27;, &#x27;validate_certs&#x27;: True}}, &#x27;response&#x27;: {&#x27;computeEnvironmentArn&#x27;: &#x27;arn:aws:batch:....&#x27;, &#x27;computeEnvironmentName&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;computeResources&#x27;: {&#x27;desiredvCpus&#x27;: 0, &#x27;instanceRole&#x27;: &#x27;arn:aws:iam::...&#x27;, &#x27;instanceTypes&#x27;: [&#x27;optimal&#x27;], &#x27;maxvCpus&#x27;: 8, &#x27;minvCpus&#x27;: 0, &#x27;securityGroupIds&#x27;: [&#x27;******&#x27;], &#x27;subnets&#x27;: [&#x27;*******&#x27;], &#x27;tags&#x27;: {&#x27;Environment&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;Name&#x27;: &#x27;&lt;name&gt;&#x27;}, &#x27;type&#x27;: &#x27;EC2&#x27;}, &#x27;ecsClusterArn&#x27;: &#x27;arn:aws:ecs:.....&#x27;, &#x27;serviceRole&#x27;: &#x27;arn:aws:iam::...&#x27;, &#x27;state&#x27;: &#x27;ENABLED&#x27;, &#x27;status&#x27;: &#x27;VALID&#x27;, &#x27;statusReason&#x27;: &#x27;ComputeEnvironment Healthy&#x27;, &#x27;type&#x27;: &#x27;MANAGED&#x27;}}</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;batch_job_queue_action&#x27;: &#x27;updated&#x27;, &#x27;changed&#x27;: False, &#x27;response&#x27;: {&#x27;job_queue_arn&#x27;: &#x27;arn:aws:batch:....&#x27;, &#x27;job_queue_name&#x27;: &#x27;&lt;name&gt;&#x27;, &#x27;priority&#x27;: 1, &#x27;state&#x27;: &#x27;DISABLED&#x27;, &#x27;status&#x27;: &#x27;UPDATING&#x27;, &#x27;status_reason&#x27;: &#x27;JobQueue Healthy&#x27;}}</div>
                 </td>
             </tr>
     </table>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -47,6 +47,9 @@ action_groups:
   - aws_waf_info
   - aws_waf_rule
   - aws_waf_web_acl
+  - batch_compute_environment
+  - batch_job_definition
+  - batch_job_queue
   - cloudformation_exports_info
   - cloudformation_stack_set
   - cloudfront_distribution
@@ -212,6 +215,15 @@ plugin_routing:
     aws_acm_info:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.acm_certificate_info
+    aws_batch_compute_environment:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.batch_compute_environment
+    aws_batch_job_definition:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.batch_job_definition
+    aws_batch_job_queue:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.batch_job_queue
     aws_ses_identity:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.ses_identity

--- a/plugins/modules/batch_compute_environment.py
+++ b/plugins/modules/batch_compute_environment.py
@@ -8,17 +8,18 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: aws_batch_compute_environment
+module: batch_compute_environment
 version_added: 1.0.0
 short_description: Manage AWS Batch Compute Environments
 description:
-    - This module allows the management of AWS Batch Compute Environments.
-    - It is idempotent and supports "Check" mode.
-    - Use module M(community.aws.aws_batch_compute_environment) to manage the compute
-      environment, M(community.aws.aws_batch_job_queue) to manage job queues, M(community.aws.aws_batch_job_definition) to manage job definitions.
-
-
-author: Jon Meran (@jonmer85)
+  - This module allows the management of AWS Batch Compute Environments.
+  - It is idempotent and supports "Check" mode.
+  - Use module M(community.aws.batch_compute_environment) to manage the compute
+    environment, M(community.aws.batch_job_queue) to manage job queues, M(community.aws.batch_job_definition) to manage job definitions.
+  - Prior to release 5.0.0 this module was called C(community.aws.aws_batch_compute_environment).
+    The usage did not change.
+author:
+  - Jon Meran (@jonmer85)
 options:
   compute_environment_name:
     description:
@@ -119,14 +120,13 @@ options:
       - The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment.
     type: str
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = r'''
 - name: My Batch Compute Environment
-  community.aws.aws_batch_compute_environment:
+  community.aws.batch_compute_environment:
     compute_environment_name: computeEnvironmentName
     state: present
     region: us-east-1

--- a/plugins/modules/batch_job_definition.py
+++ b/plugins/modules/batch_job_definition.py
@@ -8,15 +8,18 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: aws_batch_job_definition
+module: batch_job_definition
 version_added: 1.0.0
 short_description: Manage AWS Batch Job Definitions
 description:
-    - This module allows the management of AWS Batch Job Definitions.
-    - It is idempotent and supports "Check" mode.
-    - Use module M(community.aws.aws_batch_compute_environment) to manage the compute
-      environment, M(community.aws.aws_batch_job_queue) to manage job queues, M(community.aws.aws_batch_job_definition) to manage job definitions.
-author: Jon Meran (@jonmer85)
+  - This module allows the management of AWS Batch Job Definitions.
+  - It is idempotent and supports "Check" mode.
+  - Use module M(community.aws.batch_compute_environment) to manage the compute
+    environment, M(community.aws.batch_job_queue) to manage job queues, M(community.aws.batch_job_definition) to manage job definitions.
+  - Prior to release 5.0.0 this module was called C(community.aws.aws_batch_job_definition).
+    The usage did not change.
+author:
+  - Jon Meran (@jonmer85)
 options:
   job_definition_arn:
     description:
@@ -171,20 +174,14 @@ options:
         many times.
     type: int
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = r'''
 ---
-- hosts: localhost
-  gather_facts: no
-  vars:
-    state: present
-  tasks:
 - name: My Batch Job Definition
-  community.aws.aws_batch_job_definition:
+  community.aws.batch_job_definition:
     job_definition_name: My Batch Job Definition
     state: present
     type: container

--- a/plugins/modules/batch_job_queue.py
+++ b/plugins/modules/batch_job_queue.py
@@ -8,19 +8,22 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: aws_batch_job_queue
+module: batch_job_queue
 version_added: 1.0.0
 short_description: Manage AWS Batch Job Queues
 description:
-    - This module allows the management of AWS Batch Job Queues.
-    - It is idempotent and supports "Check" mode.
-    - Use module M(community.aws.aws_batch_compute_environment) to manage the compute
-      environment, M(community.aws.aws_batch_job_queue) to manage job queues, M(community.aws.aws_batch_job_definition) to manage job definitions.
-author: Jon Meran (@jonmer85)
+  - This module allows the management of AWS Batch Job Queues.
+  - It is idempotent and supports "Check" mode.
+  - Use module M(community.aws.batch_compute_environment) to manage the compute
+    environment, M(community.aws.batch_job_queue) to manage job queues, M(community.aws.batch_job_definition) to manage job definitions.
+  - Prior to release 5.0.0 this module was called C(community.aws.aws_batch_job_queue).
+    The usage did not change.
+author:
+  - Jon Meran (@jonmer85)
 options:
   job_queue_name:
     description:
-      - The name for the job queue
+      - The name for the job queue.
     required: true
     type: str
   state:
@@ -53,21 +56,20 @@ options:
     type: list
     elements: dict
     suboptions:
-        order:
-            type: int
-            description: The relative priority of the environment.
-        compute_environment:
-            type: str
-            description: The name of the compute environment.
+      order:
+        type: int
+        description: The relative priority of the environment.
+      compute_environment:
+        type: str
+        description: The name of the compute environment.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''
 - name: My Batch Job Queue
-  community.aws.aws_batch_job_queue:
+  community.aws.batch_job_queue:
     job_queue_name: jobQueueName
     state: present
     region: us-east-1


### PR DESCRIPTION
##### SUMMARY

In line with the naming guidelines, removes the `aws_` prefix from `aws_batch_compute_environment`, `aws_batch_job_definition` and `aws_batch_job_queue`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_batch_compute_environment.py
plugins/modules/aws_batch_job_definition.py
plugins/modules/aws_batch_job_queue.py
plugins/modules/batch_compute_environment.py
plugins/modules/batch_job_definition.py
plugins/modules/batch_job_queue.py

##### ADDITIONAL INFORMATION