### PR TITLE
rename execute_lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Name | Description
 [community.aws.elb_target_group](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.elb_target_group_module.rst)|Manage a target group for an Application or Network load balancer
 [community.aws.elb_target_group_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.elb_target_group_info_module.rst)|Gather information about ELB target groups in AWS
 [community.aws.elb_target_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.elb_target_info_module.rst)|Gathers which target groups a target is associated with.
-[community.aws.execute_lambda](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.execute_lambda_module.rst)|Execute an AWS Lambda function
 [community.aws.iam_access_key](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.iam_access_key_module.rst)|Manage AWS IAM User access keys
 [community.aws.iam_access_key_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.iam_access_key_info_module.rst)|fetch information about AWS IAM User access keys
 [community.aws.iam_group](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.iam_group_module.rst)|Manage AWS IAM groups
@@ -170,6 +169,7 @@ Name | Description
 [community.aws.lambda](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lambda_module.rst)|Manage AWS Lambda functions
 [community.aws.lambda_alias](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lambda_alias_module.rst)|Creates, updates or deletes AWS Lambda function aliases
 [community.aws.lambda_event](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lambda_event_module.rst)|Creates, updates or deletes AWS Lambda function event mappings
+[community.aws.lambda_execute](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lambda_execute_module.rst)|Execute an AWS Lambda function
 [community.aws.lambda_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lambda_info_module.rst)|Gathers AWS Lambda function details
 [community.aws.lambda_policy](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lambda_policy_module.rst)|Creates, updates or deletes AWS Lambda policy statements.
 [community.aws.lightsail](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.lightsail_module.rst)|Manage instances in AWS Lightsail

--- a/changelogs/fragments/1273-rename-lambda.yml
+++ b/changelogs/fragments/1273-rename-lambda.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- execute_lambda - the ``execute_lambda`` module has been renamed to ``lambda_execute``, ``execute_lambda`` remains as an alias (https://github.com/ansible-collections/community.aws/pull/1273).

--- a/docs/community.aws.lambda_execute_module.rst
+++ b/docs/community.aws.lambda_execute_module.rst
@@ -1,8 +1,8 @@
-.. _community.aws.execute_lambda_module:
+.. _community.aws.lambda_execute_module:
 
 
 ****************************
-community.aws.execute_lambda
+community.aws.lambda_execute
 ****************************
 
 **Execute an AWS Lambda function**
@@ -18,6 +18,7 @@ Version added: 1.0.0
 Synopsis
 --------
 - This module executes AWS Lambda functions, allowing synchronous and asynchronous invocation.
+- Prior to release 5.0.0 this module was called ``community.aws.execute_lambda``. The usage did not change.
 
 
 
@@ -350,7 +351,7 @@ Examples
 
 .. code-block:: yaml
 
-    - community.aws.execute_lambda:
+    - community.aws.lambda_execute:
         name: test-function
         # the payload is automatically serialized and sent to the function
         payload:
@@ -360,11 +361,11 @@ Examples
 
     # Test that you have sufficient permissions to execute a Lambda function in
     # another account
-    - community.aws.execute_lambda:
+    - community.aws.lambda_execute:
         function_arn: arn:aws:lambda:us-east-1:123456789012:function/some-function
         dry_run: true
 
-    - community.aws.execute_lambda:
+    - community.aws.lambda_execute:
         name: test-function
         payload:
           foo: bar
@@ -375,12 +376,12 @@ Examples
       # the response will have a `logs` key that will contain a log (up to 4KB) of the function execution in Lambda
 
     # Pass the Lambda event payload as a json file.
-    - community.aws.execute_lambda:
+    - community.aws.lambda_execute:
         name: test-function
         payload: "{{ lookup('file','lambda_event.json') }}"
       register: response
 
-    - community.aws.execute_lambda:
+    - community.aws.lambda_execute:
         name: test-function
         version_qualifier: PRODUCTION
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -227,9 +227,6 @@ plugin_routing:
     aws_batch_job_queue:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.batch_job_queue
-    aws_ses_identity:
-      # Deprecation for this alias should not *start* prior to 2024-09-01
-      redirect: community.aws.ses_identity
     aws_eks_cluster:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.eks_cluster
@@ -239,6 +236,9 @@ plugin_routing:
     aws_s3_cors:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.s3_cors
+    aws_ses_identity:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.ses_identity
     aws_ses_rule_set:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.ses_rule_set

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -153,6 +153,7 @@ action_groups:
   - lambda
   - lambda_alias
   - lambda_event
+  - lambda_execute
   - lambda_info
   - lambda_policy
   - lightsail
@@ -267,6 +268,9 @@ plugin_routing:
        redirect: amazon.aws.ec2_vpc_route_table_info
     elb_classic_lb:
       redirect: amazon.aws.ec2_elb_lb
+    execute_lambda:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.lambda_execute
     iam_cert:
       redirect: community.aws.iam_server_certificate
       deprecation:

--- a/plugins/modules/lambda_execute.py
+++ b/plugins/modules/lambda_execute.py
@@ -8,17 +8,19 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: execute_lambda
+module: lambda_execute
 version_added: 1.0.0
 short_description: Execute an AWS Lambda function
 description:
   - This module executes AWS Lambda functions, allowing synchronous and asynchronous
     invocation.
+  - Prior to release 5.0.0 this module was called C(community.aws.execute_lambda).
+    The usage did not change.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
-author: "Ryan Scott Brown (@ryansb) <ryansb@redhat.com>"
+  - amazon.aws.aws
+  - amazon.aws.ec2
+author:
+  - "Ryan Scott Brown (@ryansb) <ryansb@redhat.com>"
 notes:
   - Async invocation will always return an empty C(output) key.
   - Synchronous invocation may result in a function timeout, resulting in an
@@ -72,7 +74,7 @@ options:
 '''
 
 EXAMPLES = '''
-- community.aws.execute_lambda:
+- community.aws.lambda_execute:
     name: test-function
     # the payload is automatically serialized and sent to the function
     payload:
@@ -82,11 +84,11 @@ EXAMPLES = '''
 
 # Test that you have sufficient permissions to execute a Lambda function in
 # another account
-- community.aws.execute_lambda:
+- community.aws.lambda_execute:
     function_arn: arn:aws:lambda:us-east-1:123456789012:function/some-function
     dry_run: true
 
-- community.aws.execute_lambda:
+- community.aws.lambda_execute:
     name: test-function
     payload:
       foo: bar
@@ -97,12 +99,12 @@ EXAMPLES = '''
   # the response will have a `logs` key that will contain a log (up to 4KB) of the function execution in Lambda
 
 # Pass the Lambda event payload as a json file.
-- community.aws.execute_lambda:
+- community.aws.lambda_execute:
     name: test-function
     payload: "{{ lookup('file','lambda_event.json') }}"
   register: response
 
-- community.aws.execute_lambda:
+- community.aws.lambda_execute:
     name: test-function
     version_qualifier: PRODUCTION
 '''

--- a/tests/integration/targets/lambda/aliases
+++ b/tests/integration/targets/lambda/aliases
@@ -1,4 +1,4 @@
 cloud/aws
 
-execute_lambda
+lambda_execute
 lambda_info


### PR DESCRIPTION
##### SUMMARY

In line with the naming guidelines, rename execute_lambda to lambda_execute

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/execute_lambda.py
plugins/modules/lambda_execute.py

##### ADDITIONAL INFORMATION
