### PR TITLE
Complete iam_cert and rds_snapshot deprecations

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -271,17 +271,3 @@ plugin_routing:
     execute_lambda:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.lambda_execute
-    iam_cert:
-      redirect: community.aws.iam_server_certificate
-      deprecation:
-        removal_version: 5.0.0
-        warning_text: >-
-          iam_cert has been renamed to iam_server_certificate for consistency.
-          Please update your tasks.
-    rds_snapshot:
-       redirect: community.aws.rds_instance_snapshot
-       deprecation:
-         removal_version: 5.0.0
-         warning_text: >-
-           rds_snapshot has been renamed to rds_instance_snapshot.
-           Please update your tasks.

--- a/plugins/modules/iam_server_certificate.py
+++ b/plugins/modules/iam_server_certificate.py
@@ -22,9 +22,9 @@ DOCUMENTATION = '''
 ---
 module: iam_server_certificate
 version_added: 1.0.0
-short_description: Manage server certificates for use on ELBs and CloudFront
+short_description: Manage IAM server certificates for use on ELBs and CloudFront
 description:
-     - Allows for the management of server certificates.
+  - Allows for the management of IAM server certificates.
 options:
   name:
     description:
@@ -73,10 +73,11 @@ options:
     default: true
     type: bool
 
-author: Jonathan I. Davila (@defionscode)
+author:
+  - Jonathan I. Davila (@defionscode)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''
@@ -103,7 +104,6 @@ EXAMPLES = '''
     new_name: new_very_ssl
     state: present
 '''
-import os
 
 try:
     import botocore

--- a/tests/integration/targets/elb_network_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_network_lb/tasks/main.yml
@@ -11,7 +11,7 @@
   block:
 
   - name: create certificate
-    iam_cert:
+    iam_server_certificate:
       name: test_cert
       state: present
       cert: "{{ lookup('file', 'cert.pem') }}"
@@ -242,7 +242,7 @@
       ignore_errors: yes
 
     - name: destroy certificate
-      iam_cert:
+      iam_server_certificate:
         name: test_cert
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/iam_server_certificate/tasks/main.yml
+++ b/tests/integration/targets/iam_server_certificate/tasks/main.yml
@@ -18,12 +18,6 @@
   block:
   ################################################
 
-  # Check that the alias works
-  - name: Test deprecated alias
-    iam_cert: {}
-    ignore_errors: true
-    register: iam_cert_alias
-
   - name: Test with no args
     iam_server_certificate: {}
     ignore_errors: true
@@ -31,9 +25,7 @@
 
   - assert:
       that:
-      - iam_cert_alias is failed
       - no_args is failed
-      - no_args.msg == iam_cert_alias.msg
       - no_args.msg.startswith('missing required arguments')
 
   ################################################
@@ -195,7 +187,7 @@
   ################################################
 
   - name: Delete certificate - check_mode
-    iam_cert:
+    iam_server_certificate:
       name: '{{ cert_name }}'
       state: absent
     register: delete_cert
@@ -208,7 +200,7 @@
       - delete_cert is changed
 
   - name: Delete certificate
-    iam_cert:
+    iam_server_certificate:
       name: '{{ cert_name }}'
       state: absent
     register: delete_cert
@@ -220,7 +212,7 @@
       - delete_cert is changed
 
   - name: Delete certificate - idempotency - check_mode
-    iam_cert:
+    iam_server_certificate:
       name: '{{ cert_name }}'
       state: absent
     register: delete_cert
@@ -233,7 +225,7 @@
       - delete_cert is not changed
 
   - name: Delete certificate - idempotency
-    iam_cert:
+    iam_server_certificate:
       name: '{{ cert_name }}'
       state: absent
     register: delete_cert
@@ -604,7 +596,7 @@
     ################################################
 
   - name: Delete certificate
-    iam_cert:
+    iam_server_certificate:
       name: '{{ item }}'
       state: absent
     ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Delayed from 4.0.0 to 5.0.0 remove the deprecated aliases

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_server_certificate
rds_instance_snapshot

##### ADDITIONAL INFORMATION
