### PR TITLE
Rename aws_sgw_info module

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Name | Description
 [community.aws.aws_msk_config](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_msk_config_module.rst)|Manage Amazon MSK cluster configurations.
 [community.aws.aws_region_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_region_info_module.rst)|Gather information about AWS regions.
 [community.aws.aws_secret](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_secret_module.rst)|Manage secrets stored in AWS Secrets Manager
-[community.aws.aws_sgw_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_sgw_info_module.rst)|Fetch AWS Storage Gateway information
 [community.aws.aws_ssm_parameter_store](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_ssm_parameter_store_module.rst)|Manage key-value pairs in AWS SSM parameter store
 [community.aws.aws_step_functions_state_machine](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_step_functions_state_machine_module.rst)|Manage AWS Step Functions state machines
 [community.aws.aws_step_functions_state_machine_execution](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_step_functions_state_machine_execution_module.rst)|Start or stop execution of an AWS Step Functions state machine.
@@ -215,6 +214,7 @@ Name | Description
 [community.aws.sns_topic](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.sns_topic_module.rst)|Manages AWS SNS topics and subscriptions
 [community.aws.sns_topic_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.sns_topic_info_module.rst)|sns_topic_info module
 [community.aws.sqs_queue](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.sqs_queue_module.rst)|Creates or deletes AWS SQS queues
+[community.aws.storagegateway_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.storagegateway_info_module.rst)|Fetch AWS Storage Gateway information
 [community.aws.sts_assume_role](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.sts_assume_role_module.rst)|Assume a role using AWS Security Token Service and obtain temporary credentials
 [community.aws.sts_session_token](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.sts_session_token_module.rst)|Obtain a session token from the AWS Security Token Service
 [community.aws.wafv2_ip_set](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.wafv2_ip_set_module.rst)|wafv2_ip_set

--- a/changelogs/fragments/1301-rename-sgw.yml
+++ b/changelogs/fragments/1301-rename-sgw.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_sgw_info - the ``aws_sgw_info`` module has been renamed to ``storagegateway_info``, ``aws_sgw_info`` remains as an alias (https://github.com/ansible-collections/community.aws/pull/1301).

--- a/docs/community.aws.storagegateway_info_module.rst
+++ b/docs/community.aws.storagegateway_info_module.rst
@@ -1,9 +1,9 @@
-.. _community.aws.aws_sgw_info_module:
+.. _community.aws.storagegateway_info_module:
 
 
-**************************
-community.aws.aws_sgw_info
-**************************
+*********************************
+community.aws.storagegateway_info
+*********************************
 
 **Fetch AWS Storage Gateway information**
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -211,6 +211,7 @@ action_groups:
   - sqs_queue
   - sts_assume_role
   - sts_session_token
+  - storagegateway_info
   - wafv2_ip_set
   - wafv2_ip_set_info
   - wafv2_resources
@@ -281,6 +282,9 @@ plugin_routing:
     aws_ses_rule_set:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.ses_rule_set
+    aws_sgw_info:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.storagegateway_info
     ec2_elb:
       redirect: community.aws.elb_instance
     ec2_instance:

--- a/plugins/modules/storagegateway_info.py
+++ b/plugins/modules/storagegateway_info.py
@@ -10,12 +10,13 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: aws_sgw_info
+module: storagegateway_info
 version_added: 1.0.0
 short_description: Fetch AWS Storage Gateway information
 description:
-    - Fetch AWS Storage Gateway information
-author: Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
+  - Fetch AWS Storage Gateway information
+author:
+  - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 options:
   gather_local_disks:
     description:
@@ -42,9 +43,8 @@ options:
     required: false
     default: true
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 RETURN = '''

--- a/tests/integration/targets/legacy_missing_tests/aliases
+++ b/tests/integration/targets/legacy_missing_tests/aliases
@@ -5,7 +5,6 @@ aws_application_scaling_policy
 aws_batch_compute_environment
 aws_batch_job_definition
 aws_batch_job_queue
-aws_sgw_info
 cloudfront_info
 cloudfront_invalidation
 cloudfront_origin_access_identity
@@ -33,3 +32,4 @@ rds_snapshot_info
 redshift_cross_region_snapshots
 s3_cors
 s3_website
+storagegateway_info


### PR DESCRIPTION
##### SUMMARY

In line with the new naming guidelines rename aws_sgw_info to storagegateway_info

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_sgw_info
storagegateway_info

##### ADDITIONAL INFORMATION
