### PR TITLE
Rename aws_application_scaling_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Name | Description
 [community.aws.acm_certificate_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.acm_certificate_info_module.rst)|Retrieve certificate information from AWS Certificate Manager service
 [community.aws.api_gateway](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.api_gateway_module.rst)|Manage AWS API Gateway APIs
 [community.aws.api_gateway_domain](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.api_gateway_domain_module.rst)|Manage AWS API Gateway custom domains
+[community.aws.application_autoscaling_policy](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.application_autoscaling_policy_module.rst)|Manage Application Auto Scaling Scaling Policies
 [community.aws.autoscaling_group](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.autoscaling_group_module.rst)|Create or delete AWS AutoScaling Groups (ASGs)
 [community.aws.autoscaling_group_info](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.autoscaling_group_info_module.rst)|Gather information about EC2 Auto Scaling Groups (ASGs) in AWS
 [community.aws.autoscaling_instance_refresh](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.autoscaling_instance_refresh_module.rst)|Start or cancel an EC2 Auto Scaling Group (ASG) instance refresh in AWS
@@ -46,7 +47,6 @@ Name | Description
 [community.aws.autoscaling_lifecycle_hook](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.autoscaling_lifecycle_hook_module.rst)|Create, delete or update AWS ASG Lifecycle Hooks
 [community.aws.autoscaling_policy](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.autoscaling_policy_module.rst)|Create or delete AWS scaling policies for Autoscaling groups
 [community.aws.autoscaling_scheduled_action](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.autoscaling_scheduled_action_module.rst)|Create, modify and delete ASG scheduled scaling actions
-[community.aws.aws_application_scaling_policy](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_application_scaling_policy_module.rst)|Manage Application Auto Scaling Scaling Policies
 [community.aws.aws_inspector_target](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_inspector_target_module.rst)|Create, Update and Delete Amazon Inspector Assessment Targets
 [community.aws.aws_msk_cluster](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_msk_cluster_module.rst)|Manage Amazon MSK clusters
 [community.aws.aws_msk_config](https://github.com/ansible-collections/community.aws/blob/main/docs/community.aws.aws_msk_config_module.rst)|Manage Amazon MSK cluster configurations.

--- a/changelogs/fragments/1314-rename-app_autoscale.yml
+++ b/changelogs/fragments/1314-rename-app_autoscale.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_application_scaling_policy - the ``aws_application_scaling_policy`` module has been renamed to ``application_autoscaling_policy``, ``aws_application_scaling_policy`` remains as an alias (https://github.com/ansible-collections/community.aws/pull/1314).

--- a/docs/community.aws.application_autoscaling_policy_module.rst
+++ b/docs/community.aws.application_autoscaling_policy_module.rst
@@ -1,8 +1,8 @@
-.. _community.aws.aws_application_scaling_policy_module:
+.. _community.aws.application_autoscaling_policy_module:
 
 
 ********************************************
-community.aws.aws_application_scaling_policy
+community.aws.application_autoscaling_policy
 ********************************************
 
 **Manage Application Auto Scaling Scaling Policies**
@@ -18,6 +18,7 @@ Version added: 1.0.0
 Synopsis
 --------
 - Creates, updates or removes a Scaling Policy.
+- Prior to release 5.0.0 this module was called ``community.aws.aws_application_scaling_policy``. The usage did not change.
 
 
 
@@ -523,7 +524,7 @@ Notes
 -----
 
 .. note::
-   - for details of the parameters and returns see http://boto3.readthedocs.io/en/latest/reference/services/application-autoscaling.html#ApplicationAutoScaling.Client.put_scaling_policy
+   - For more details of the parameters and returns see http://boto3.readthedocs.io/en/latest/reference/services/application-autoscaling.html#ApplicationAutoScaling.Client.put_scaling_policy
    - If parameters are not set within the module, the following environment variables can be used in decreasing order of precedence ``AWS_URL`` or ``EC2_URL``, ``AWS_PROFILE`` or ``AWS_DEFAULT_PROFILE``, ``AWS_ACCESS_KEY_ID`` or ``AWS_ACCESS_KEY`` or ``EC2_ACCESS_KEY``, ``AWS_SECRET_ACCESS_KEY`` or ``AWS_SECRET_KEY`` or ``EC2_SECRET_KEY``, ``AWS_SECURITY_TOKEN`` or ``EC2_SECURITY_TOKEN``, ``AWS_REGION`` or ``EC2_REGION``, ``AWS_CA_BUNDLE``
    - When no credentials are explicitly provided the AWS SDK (boto3) that Ansible uses will fall back to its configuration files (typically ``~/.aws/credentials``). See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html for more information.
    - ``AWS_REGION`` or ``EC2_REGION`` can be typically be used to specify the AWS region, when required, but this can also be defined in the configuration files.

--- a/docs/community.aws.autoscaling_policy_module.rst
+++ b/docs/community.aws.autoscaling_policy_module.rst
@@ -39,12 +39,12 @@ Parameters
 
     <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="2">Parameter</th>
+            <th colspan="3">Parameter</th>
             <th>Choices/<font color="blue">Defaults</font></th>
             <th width="100%">Comments</th>
         </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>adjustment_type</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -65,7 +65,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>asg_name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -81,7 +81,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_access_key</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -98,7 +98,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_ca_bundle</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -114,7 +114,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_config</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -130,7 +130,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>aws_secret_key</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -147,7 +147,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>cooldown</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -163,7 +163,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>debug_botocore_endpoint_logs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -182,7 +182,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ec2_url</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -198,7 +198,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>estimated_instance_warmup</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -213,7 +213,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>metric_aggregation</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -234,7 +234,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>min_adjustment_step</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -250,7 +250,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -266,7 +266,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>policy_type</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -278,6 +278,7 @@ Parameters
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>StepScaling</li>
                                     <li><div style="color: blue"><b>SimpleScaling</b>&nbsp;&larr;</div></li>
+                                    <li>TargetTrackingScaling</li>
                         </ul>
                 </td>
                 <td>
@@ -285,7 +286,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>profile</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -301,7 +302,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>region</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -317,7 +318,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>scaling_adjustment</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -335,7 +336,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>security_token</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -353,7 +354,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -372,7 +373,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="2">
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>step_adjustments</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -393,7 +394,7 @@ Parameters
             </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>lower_bound</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -409,7 +410,7 @@ Parameters
             </tr>
             <tr>
                     <td class="elbow-placeholder"></td>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>scaling_adjustment</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -426,7 +427,7 @@ Parameters
             </tr>
             <tr>
                     <td class="elbow-placeholder"></td>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>upper_bound</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -442,7 +443,236 @@ Parameters
             </tr>
 
             <tr>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>target_tracking_config</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 4.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Allows you to specify a <em>target_tracking_config</em> for autoscaling policies in AWS.</div>
+                        <div><em>target_tracking_config</em> can accept nested dicts for <em>customized_metric_spec</em> or <em>predefined_metric_spec</em>. Each specification aligns with their boto3 equivalent.</div>
+                        <div>Required when <em>TargetTrackingScaling</em> policy is specified.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
                 <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>customized_metric_spec</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify a dict will be passed in as a call for <code>TargetTrackingConfiguration</code>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dimensions</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The dimensions of the metric. The element of the list should be a dict.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>metric_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name of the metric.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>namespace</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The namespace of the metric.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>statistic</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>Average</li>
+                                    <li>Minimum</li>
+                                    <li>Maximum</li>
+                                    <li>SampleCount</li>
+                                    <li>Sum</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The statistic of the metric.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>unit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The unit of the metric. Reference AmazonCloudWatch API for valid Units.</div>
+                </td>
+            </tr>
+
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>disable_scalein</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Indicate whether scaling in by the target tracking scaling policy is disabled.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>predefined_metric_spec</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify a dict will be passed in as a call for <em>TargetTrackingConfiguration</em>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>predefined_metric_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>ASGAverageCPUUtilization</li>
+                                    <li>ASGAverageNetworkIn</li>
+                                    <li>ASGAverageNetworkOut</li>
+                                    <li>ALBRequestCountPerTarget</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Required if <code>predefined_metric_spec</code> is used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>resource_label</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Uniquely identifies a specific ALB target group from which to determine the average request count served by your Auto Scaling group.</div>
+                        <div>You can&#x27;t specify a resource label unless the target group is attached to the Auto Scaling group.</div>
+                </td>
+            </tr>
+
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>target_value</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">float</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify a float number for target utilization.</div>
+                        <div>Required when <em>target_tracking_config</em> is specified.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>validate_certs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -507,6 +737,45 @@ Examples
             scaling_adjustment: 100
         adjustment_type: "PercentChangeInCapacity"
         asg_name: "application-asg"
+
+    - name: create TargetTracking predefined policy
+      ec2_scaling_policy:
+        name: "predefined-policy-1"
+        policy_type: TargetTrackingScaling
+        target_tracking_config:
+          predefined_metric_spec:
+            predefined_metric_type: ASGAverageCPUUtilization
+          target_value: 98.0
+        asg_name: "asg-test-1"
+      register: result
+
+    - name: create TargetTracking predefined policy with resource_label
+      ec2_scaling_policy:
+        name: "predefined-policy-1"
+        policy_type: TargetTrackingScaling
+        target_tracking_config:
+          predefined_metric_spec:
+            predefined_metric_type: ALBRequestCountPerTarget
+            resource_label: app/my-alb/778d41231d141a0f/targetgroup/my-alb-target-group/942f017f100becff
+          target_value: 98.0
+        asg_name: "asg-test-1"
+      register: result
+
+    - name: create TargetTrackingScaling custom policy
+      ec2_scaling_policy:
+        name: "custom-policy-1"
+        policy_type: TargetTrackingScaling
+        target_tracking_config:
+          customized_metric_spec:
+            metric_name: metric_1
+            namespace: namespace_1
+            statistic: Minimum
+            unit: Gigabits
+            dimensions: [{'Name': 'dimension1', 'Value': 'value1'}]
+          disable_scalein: true
+          target_value: 98.0
+        asg_name: asg-test-1
+      register: result
 
 
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -5,6 +5,7 @@ action_groups:
   - acm_certificate_info
   - api_gateway
   - api_gateway_domain
+  - application_autoscaling_policy
   - autoscaling_group_info
   - autoscaling_group
   - autoscaling_instance_refresh_info
@@ -264,6 +265,9 @@ plugin_routing:
     aws_api_gateway_domain:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.api_gateway_domain
+    aws_application_scaling_policy:
+      # Deprecation for this alias should not *start* prior to 2024-09-01
+      redirect: community.aws.application_autoscaling_policy
     aws_batch_compute_environment:
       # Deprecation for this alias should not *start* prior to 2024-09-01
       redirect: community.aws.batch_compute_environment

--- a/plugins/modules/application_autoscaling_policy.py
+++ b/plugins/modules/application_autoscaling_policy.py
@@ -8,14 +8,16 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: aws_application_scaling_policy
+module: application_autoscaling_policy
 version_added: 1.0.0
 short_description: Manage Application Auto Scaling Scaling Policies
 notes:
-    - for details of the parameters and returns see
+    - For more details of the parameters and returns see
       U(http://boto3.readthedocs.io/en/latest/reference/services/application-autoscaling.html#ApplicationAutoScaling.Client.put_scaling_policy)
 description:
     - Creates, updates or removes a Scaling Policy.
+    - Prior to release 5.0.0 this module was called C(community.aws.aws_application_scaling_policy).
+      The usage did not change.
 author:
     - Gustavo Maia (@gurumaia)
     - Chen Leibovich (@chenl87)
@@ -97,13 +99,13 @@ options:
         type: int
     override_task_capacity:
         description:
-        - Whether or not to override values of minimum and/or maximum tasks if it's already set.
-        - Defaults to C(false).
+            - Whether or not to override values of minimum and/or maximum tasks if it's already set.
+            - Defaults to C(false).
         required: no
         type: bool
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+    - amazon.aws.aws
+    - amazon.aws.ec2
 '''
 
 EXAMPLES = '''
@@ -111,7 +113,7 @@ EXAMPLES = '''
 
 # Create step scaling policy for ECS Service
 - name: scaling_policy
-  community.aws.aws_application_scaling_policy:
+  community.aws.application_autoscaling_policy:
     state: present
     policy_name: test_policy
     service_namespace: ecs
@@ -132,7 +134,7 @@ EXAMPLES = '''
 
 # Create target tracking scaling policy for ECS Service
 - name: scaling_policy
-  community.aws.aws_application_scaling_policy:
+  community.aws.application_autoscaling_policy:
     state: present
     policy_name: test_policy
     service_namespace: ecs
@@ -150,7 +152,7 @@ EXAMPLES = '''
 
 # Remove scalable target for ECS Service
 - name: scaling_policy
-  community.aws.aws_application_scaling_policy:
+  community.aws.application_autoscaling_policy:
     state: absent
     policy_name: test_policy
     policy_type: StepScaling


### PR DESCRIPTION
##### SUMMARY

In line with the naming guidelines drop the `aws_` from aws_application_scaling_policy

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/aws_application_scaling_policy.py
plugins/modules/application_autoscaling_policy.py

##### ADDITIONAL INFORMATION
