### PR TITLE
Add force_absent parameter to ecs_ecr module

### DIFF
--- a/changelogs/fragments/1315-ecs_ecr-force_absent.yaml
+++ b/changelogs/fragments/1315-ecs_ecr-force_absent.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_ecr - add `force_absent` parameter for removing repositories that contain images (https://github.com/ansible-collections/community.aws/pull/1316).


### PR DESCRIPTION
##### SUMMARY
Adds a `force_absent` parameter to the `ecs_ecr` module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ecs_ecr` module
##### ADDITIONAL INFORMATION
It would be useful for the `ecs_ecr` module to have capability for removing repositories which still contain images.
This PR adds that ability by adding an additional parameter `force_absent` which has a default value of `false` and essentially just gets passed to the boto3 call for repo deletion.

The following was run against a repository with an image in it.

```yaml
- name: Add ecr repos and sync with external sources.
  hosts: localhost
  connection: local
  gather_facts: false

  tasks:
  - name: test the changes
    register: state
    ecs_ecr:
      state: absent
      force_absent: true
      region: us-east-1
      name: myimage/test

  - debug:
      var: state
```

This was run with `force_absent: true`, `force_absent: false` and `force_absent` not defined.

The expected behavior was seen in all three scenarios.

I haven't added any new cases to the integration tests because there doesn't seem to be a great way to sync images into the repo that is created as part of the tests.