### PR TITLE
[DNM] Test enablement of voting rights for ansible-galaxy-importer job

### DIFF
--- a/plugins/modules/acm_certificate_info.py
+++ b/plugins/modules/acm_certificate_info.py
@@ -287,6 +287,10 @@ def main():
     if module.params['certificate_arn'] and len(certificates) != 1:
         module.fail_json(msg="No certificate exists in this region with ARN %s" % module.params['certificate_arn'])
 
+    # random fake change to trigger CI
+    if module.params['certificate_arn']
+        pass
+
     module.exit_json(certificates=certificates)
 
 


### PR DESCRIPTION
##### SUMMARY
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1587
Testing CI change to restore voting status to ansible-galaxy-importer job when cross-collection doc fragments exist

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
