### PR TITLE
Update s3_sync doc

### DIFF
--- a/plugins/modules/s3_sync.py
+++ b/plugins/modules/s3_sync.py
@@ -225,7 +225,7 @@ filelist_actionable:
                 "whysize": "151 / 151",
                 "whytime": "1477931256 / 1477929260"
            }]
-uploaded:
+uploads:
   description: file listing (dicts) of files that were actually uploaded
   returned: always
   type: list

--- a/tests/integration/targets/s3_sync/tasks/main.yml
+++ b/tests/integration/targets/s3_sync/tasks/main.yml
@@ -143,6 +143,12 @@
     - assert:
         that:
           - output is changed
+          - '"uploads" in output'
+          - '"filelist_initial" in output'
+          - '"filelist_local_etag" in output'
+          - '"filelist_s3" in output'
+          - '"filelist_typed" in output'
+          - '"filelist_actionable" in output'
 
   always:
 


### PR DESCRIPTION
##### SUMMARY

fixes: #1229 

The key returned by the module is `uploads` not `uploaded`.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

s3_sync

##### ADDITIONAL INFORMATION

Docs don't match the actual returned value.