### PR TITLE
kms_key_info - improve AccessDeniedException handing

### DIFF
--- a/changelogs/fragments/206-kms_key_info.yml
+++ b/changelogs/fragments/206-kms_key_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- kms_key_info - handle access denied errors more liberally (https://github.com/ansible-collections/community.aws/issues/206).

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_grants.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_grants.yml
@@ -82,6 +82,10 @@
         that:
           - key.changed
 
+    # Roles can take a little while to get ready, pause briefly to give it chance
+    - wait_for:
+        timeout: 20
+
     - name: Add grant
       aws_kms:
         alias: '{{ kms_key_alias }}'


### PR DESCRIPTION
##### SUMMARY

fixes: #206 

Because KMS doesn't support server-side filtering of keys we have to pull full metadata for all KMS keys unless querying a specific key.  This can result in additional permission denied errors, even though we may have permissions to read many of the keys.  Try to handle `AccessDeniedException` more liberally.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

kms_key_info

##### ADDITIONAL INFORMATION