### PR TITLE
secretsmanager_secret - Support adding JSON

### DIFF
--- a/changelogs/fragments/656-secrets-json.yml
+++ b/changelogs/fragments/656-secrets-json.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- secretsmanager_secret - add support for storing JSON in secrets (https://github.com/ansible-collections/community.aws/issues/656).

--- a/plugins/modules/secretsmanager_secret.py
+++ b/plugins/modules/secretsmanager_secret.py
@@ -447,14 +447,10 @@ def main():
     state = module.params.get('state')
     secrets_mgr = SecretsManagerInterface(module)
     recovery_window = module.params.get('recovery_window')
-    if module.params.get('json_secret') is not None:
-        secret_value = module.params.get('json_secret')
-    else:
-        secret_value = module.params.get('secret')
     secret = Secret(
         module.params.get('name'),
         module.params.get('secret_type'),
-        secret_value,
+        module.params.get('secret') or module.params.get('json_secret'),
         description=module.params.get('description'),
         kms_key_id=module.params.get('kms_key_id'),
         resource_policy=module.params.get('resource_policy'),

--- a/tests/integration/targets/secretsmanager_secret/tasks/basic.yml
+++ b/tests/integration/targets/secretsmanager_secret/tasks/basic.yml
@@ -19,6 +19,15 @@
 #     - object *NOT* updated
 #     - Tests idemoptency
 
+- set_fact:
+    # As a lookup plugin we won't have access to module_defaults
+    connection_args:
+      region: "{{ aws_region }}"
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      aws_security_token: "{{ security_token | default(omit) }}"
+  no_log: True
+
 - vars:
     first_tags:
       'Key with Spaces': Value with spaces
@@ -611,6 +620,73 @@
     assert:
       that:
         - not result.changed
+
+  # ============================================================
+  # Update secret using JSON string
+  # ============================================================
+
+  - name: Update secret with JSON (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      json_secret:
+        my_key: '{{ super_secret_string }}'
+    register: result
+    check_mode: True
+
+  - name: assert key would be changed
+    assert:
+      that:
+        - result.changed
+
+  - name: Update secret with JSON
+    aws_secret:
+      name: "{{ secret_name }}"
+      state: present
+      description: 'this is a change to this secret'
+      secret_type: 'string'
+      json_secret:
+        my_key: '{{ super_secret_string }}'
+    register: result
+
+  - name: assert key is changed
+    assert:
+      that:
+        - result.changed
+
+  - name: Update secret with JSON - idempotency (CHECK_MODE)
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      json_secret:
+        my_key: '{{ super_secret_string }}'
+    register: result
+    check_mode: True
+
+  - name: assert key is not changed
+    assert:
+      that:
+        - result is not changed
+
+  - name: Update secret with JSON - idempotency
+    aws_secret:
+      name: "{{ secret_name }}"
+      description: 'this is a change to this secret'
+      state: present
+      secret_type: 'string'
+      json_secret:
+        my_key: '{{ super_secret_string }}'
+    register: result
+    check_mode: True
+
+  - name: assert key is not changed
+    assert:
+      that:
+        - result is not changed
 
   # ============================================================
   # Removal testing


### PR DESCRIPTION
##### SUMMARY

fixes: #656 

Amazon supports passing JSON in as the secret as a mechanism for storing and retreiving more complex structures.

While in theory it's possible to pass JSON in as a string to secretsmanager_secret.  However, because Ansible often does funky things with when templated strings are passed to a parameter (#656) it's non-trivial to pass JSON into secretsmanager_secret.

  
##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

secretsmanager_secret

##### ADDITIONAL INFORMATION

Backstory:

If Ansible sees `{{ }}` within a string it'll trigger the `safe_eval` handlers, automatically converting the JSON into a complex structure of lists/dicts, which is then converted to the python string representation of the complex structures - the python string representation is *not* valid JSON and breaks the AWS integration.