### PR TITLE
Update default value of purge_tags to True

### DIFF
--- a/changelogs/fragments/1343-purge_tags.yml
+++ b/changelogs/fragments/1343-purge_tags.yml
@@ -1,0 +1,9 @@
+breaking_changes:
+- acm_certificate - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- cloudfront_distribution - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- ec2_vpc_vpn - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- kms_key - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- rds_param_group - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- route53_health_check - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- route53_zone - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).
+- sqs_queue - the previously deprecated default value of ``purge_tags=False`` has been updated to ``purge_tags=True`` (https://github.com/ansible-collections/community.aws/pull/1343).

--- a/plugins/modules/acm_certificate.py
+++ b/plugins/modules/acm_certificate.py
@@ -177,7 +177,7 @@ author:
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 '''
 
 EXAMPLES = '''
@@ -495,7 +495,7 @@ def main():
         name_tag=dict(aliases=['name']),
         private_key=dict(no_log=True),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
         state=dict(default='present', choices=['present', 'absent']),
     )
     module = AnsibleAWSModule(
@@ -503,14 +503,6 @@ def main():
         supports_check_mode=True,
     )
     acm = ACMServiceManager(module)
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     # Check argument requirements
     if module.params['state'] == 'present':

--- a/plugins/modules/acm_certificate.py
+++ b/plugins/modules/acm_certificate.py
@@ -524,6 +524,9 @@ def main():
     desired_tags = None
     if module.params.get('tags') is not None:
         desired_tags = module.params['tags']
+    else:
+        # Because we're setting the Name tag, we need to explicitly not purge when tags isn't passed
+        module.params['purge_tags'] = False
     if module.params.get('name_tag') is not None:
         # The module was originally implemented to filter certificates based on the 'Name' tag.
         # Other tags are not used to filter certificates.

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -24,7 +24,7 @@ author:
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 
 options:
 
@@ -2109,7 +2109,7 @@ def main():
         distribution_id=dict(),
         e_tag=dict(),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
         alias=dict(),
         aliases=dict(type='list', default=[], elements='str'),
         purge_aliases=dict(type='bool', default=False),
@@ -2147,14 +2147,6 @@ def main():
             ['default_origin_domain_name', 'alias'],
         ]
     )
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     client = module.client('cloudfront', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -17,7 +17,7 @@ description:
 extends_documentation_fragment:
   - amazon.aws.ec2
   - amazon.aws.aws
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 author:
   - "Sloane Hertel (@s-hertel)"
 options:
@@ -767,7 +767,7 @@ def main():
         static_only=dict(default=False, type='bool'),
         customer_gateway_id=dict(type='str'),
         vpn_connection_id=dict(type='str'),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
         routes=dict(type='list', default=[], elements='str'),
         purge_routes=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=600),
@@ -776,14 +776,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)
     connection = module.client('ec2', retry_decorator=VPNRetry.jittered_backoff(retries=10))
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     state = module.params.get('state')
     parameters = dict(module.params)

--- a/plugins/modules/kms_key.py
+++ b/plugins/modules/kms_key.py
@@ -195,7 +195,7 @@ author:
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 
 notes:
   - There are known inconsistencies in the amount of time required for updates of KMS keys to be fully reflected on AWS.
@@ -809,9 +809,6 @@ def update_tags(connection, module, key, desired_tags, purge_tags):
     if desired_tags is None:
         return False
 
-    # purge_tags needs to be explicitly set, so an empty tags list means remove
-    # all tags
-
     to_add, to_remove = compare_aws_tags(key['tags'], desired_tags, purge_tags)
     if not (bool(to_add) or bool(to_remove)):
         return False
@@ -1154,7 +1151,7 @@ def main():
         description=dict(),
         enabled=dict(type='bool', default=True),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
         grants=dict(type='list', default=[], elements='dict'),
         policy=dict(type='json'),
         purge_grants=dict(type='bool', default=False),
@@ -1174,14 +1171,6 @@ def main():
     mode = module.params['policy_mode']
 
     kms = module.client('kms')
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     module.deprecate("The 'policies' return key is deprecated and will be replaced by 'key_policies'. Both values are returned for now.",
                      date='2024-05-01', collection_name='community.aws')

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -54,7 +54,7 @@ author:
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 
 '''
 
@@ -315,21 +315,13 @@ def main():
         params=dict(aliases=['parameters'], type='dict'),
         immediate=dict(type='bool', aliases=['apply_immediately']),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         required_if=[['state', 'present', ['description', 'engine']]],
         supports_check_mode=True
     )
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     try:
         conn = module.client('rds', retry_decorator=AWSRetry.jittered_backoff())

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -115,7 +115,7 @@ notes:
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 '''
 
 EXAMPLES = '''
@@ -503,7 +503,7 @@ def main():
         request_interval=dict(type='int', choices=[10, 30], default=30),
         failure_threshold=dict(type='int', choices=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
         health_check_id=dict(type='str', aliases=['id'], required=False),
         health_check_name=dict(type='str', aliases=['name'], required=False),
         use_unique_names=dict(type='bool', required=False),
@@ -536,14 +536,6 @@ def main():
         mutually_exclusive=args_mutually_exclusive,
         supports_check_mode=True,
     )
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     if not module.params.get('health_check_id') and not module.params.get('type'):
         module.fail_json(msg="parameter 'type' is required if not updating or deleting health check by ID.")

--- a/plugins/modules/route53_zone.py
+++ b/plugins/modules/route53_zone.py
@@ -49,7 +49,7 @@ options:
 extends_documentation_fragment:
     - amazon.aws.aws
     - amazon.aws.ec2
-    - amazon.aws.tags.deprecated_purge
+    - amazon.aws.tags
 notes:
     - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
 author:
@@ -437,7 +437,7 @@ def main():
         hosted_zone_id=dict(),
         delegation_set_id=dict(),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
     )
 
     mutually_exclusive = [
@@ -450,14 +450,6 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     zone_in = module.params.get('zone').lower()
     state = module.params.get('state').lower()

--- a/plugins/modules/sqs_queue.py
+++ b/plugins/modules/sqs_queue.py
@@ -90,7 +90,7 @@ options:
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2
-  - amazon.aws.tags.deprecated_purge
+  - amazon.aws.tags
 '''
 
 RETURN = r'''
@@ -474,17 +474,9 @@ def main():
         kms_data_key_reuse_period_seconds=dict(type='int', aliases=['kms_data_key_reuse_period'], no_log=False),
         content_based_deduplication=dict(type='bool'),
         tags=dict(type='dict', aliases=['resource_tags']),
-        purge_tags=dict(type='bool'),
+        purge_tags=dict(type='bool', default=True),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if module.params.get('purge_tags') is None:
-        module.deprecate(
-            'The purge_tags parameter currently defaults to False.'
-            ' For consistency across the collection, this default value'
-            ' will change to True in release 5.0.0.',
-            version='5.0.0', collection_name='community.aws')
-        module.params['purge_tags'] = False
 
     state = module.params.get('state')
     retry_decorator = AWSRetry.jittered_backoff(catch_extra_error_codes=['AWS.SimpleQueueService.NonExistentQueue'])

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_tagging.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_tagging.yml
@@ -56,6 +56,7 @@
         tags:
           tag_one: tag_one
           tag_two: tag_two
+        purge_tags: no
       register: key
 
     - name: Assert tags added

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,9 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/acm_certificate.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/cloudfront_distribution.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/ec2_vpc_vpn.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/kms_key.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/rds_param_group.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_zone.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/sqs_queue.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,10 +1,2 @@
 plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/acm_certificate.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/cloudfront_distribution.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/ec2_vpc_vpn.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/kms_key.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/rds_param_group.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_zone.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/sqs_queue.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,10 +1,2 @@
 plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/acm_certificate.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/cloudfront_distribution.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/ec2_vpc_vpn.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/kms_key.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/rds_param_group.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_zone.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/sqs_queue.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,10 +1,2 @@
 plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/acm_certificate.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/cloudfront_distribution.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/ec2_vpc_vpn.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/kms_key.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/rds_param_group.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_zone.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/sqs_queue.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,10 +1,2 @@
 plugins/modules/cloudfront_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/acm_certificate.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/cloudfront_distribution.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/ec2_vpc_vpn.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/kms_key.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/rds_param_group.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_zone.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/sqs_queue.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -3,11 +3,3 @@ plugins/modules/aws_kms_info.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_policy.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_role.py pylint:ansible-deprecated-no-version
 plugins/modules/iam_user.py pylint:ansible-deprecated-no-version
-plugins/modules/acm_certificate.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/cloudfront_distribution.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/ec2_vpc_vpn.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/kms_key.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/rds_param_group.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/route53_zone.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/sqs_queue.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0


### PR DESCRIPTION
##### SUMMARY

Complete the deprecation cycle and update `purge_tags` default value to `True`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/acm_certificate.py
plugins/modules/cloudfront_distribution.py
plugins/modules/ec2_vpc_vpn.py
plugins/modules/kms_key.py
plugins/modules/rds_param_group.py
plugins/modules/route53_health_check.py
plugins/modules/route53_zone.py
plugins/modules/sqs_queue.py

##### ADDITIONAL INFORMATION