### PR TITLE
kms_key - Finish deprecation of policy_grant_types and related keys

### DIFF
--- a/changelogs/fragments/1344-kms_key-policy_grant_types.yml
+++ b/changelogs/fragments/1344-kms_key-policy_grant_types.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- kms_key - managing the KMS IAM Policy via ``policy_mode`` and ``policy_grant_types`` was previously deprecated and has been removed in favor of the ``policy`` option (https://github.com/ansible-collections/community.aws/pull/1344).

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_modify.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_modify.yml
@@ -258,37 +258,6 @@
 
     # ------------------------------------------------------------------------------------------
 
-    - name: grant user-style access to production secrets
-      aws_kms:
-        mode: grant
-        alias: "alias/{{ kms_key_alias }}"
-        role_name: '{{ kms_key_alias }}'
-        grant_types: "role,role grant"
-      register: new_key
-
-    - assert:
-        that:
-          - new_key.changed
-          - "'changes_needed' in new_key"
-
-    - name: remove access to production secrets from role
-      aws_kms:
-        mode: deny
-        alias: "alias/{{ kms_key_alias }}"
-        role_arn: "{{ iam_role_result.iam_role.arn }}"
-      register: new_key
-
-    - assert:
-        that:
-          - new_key.changed
-          - "'changes_needed' in new_key"
-
-    - name: Sleep to wait for updates to propagate
-      wait_for:
-        timeout: 45
-
-    # ------------------------------------------------------------------------------------------
-
     - name: update policy to remove access to key rotation status
       aws_kms:
         alias: 'alias/{{ kms_key_alias }}'


### PR DESCRIPTION
##### SUMMARY

Managing the KMS IAM Policy via ``policy_mode`` and ``policy_grant_types`` was fragile and previously deprecated.

Complete the deprecation and remove the options in in favour of the ``policy`` option.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/kms_key.py

##### ADDITIONAL INFORMATION

Original deprecation: https://github.com/ansible/ansible/pull/60561