### PR TITLE
ec2_vpc_peer - Fix idempotency when accepter/requester is reversed

### DIFF
--- a/changelogs/fragments/580-vpc_peer-idempotency.yml
+++ b/changelogs/fragments/580-vpc_peer-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_vpc_peer - fix idempotency when requester/accepter is reversed (https://github.com/ansible-collections/community.aws/issues/580).

--- a/plugins/modules/ec2_vpc_peer.py
+++ b/plugins/modules/ec2_vpc_peer.py
@@ -394,6 +394,11 @@ def describe_peering_connections(params, client):
         Filters=ansible_dict_to_boto3_filter_list(peer_filter),
     )
     if result['VpcPeeringConnections'] == []:
+        # Try again with the VPC/Peer relationship reversed
+        peer_filter = {
+            'requester-vpc-info.vpc-id': params['PeerVpcId'],
+            'accepter-vpc-info.vpc-id': params['VpcId'],
+        }
         result = client.describe_vpc_peering_connections(
             aws_retry=True,
             Filters=ansible_dict_to_boto3_filter_list(peer_filter),

--- a/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
@@ -103,6 +103,22 @@
         - vpc_peer is successful
         - vpc_peer.peering_id == peer_id_1
 
+  - name: (re-) Create local account VPC peering Connection request with accepter/requester reversed (idempotency)
+    ec2_vpc_peer:
+      vpc_id: '{{ vpc_2 }}'
+      peer_vpc_id: '{{ vpc_1 }}'
+      state: present
+      tags:
+        Name: '{{ connection_name }}'
+    register: vpc_peer
+
+  - name: Assert success
+    assert:
+      that:
+        - vpc_peer is not changed
+        - vpc_peer is successful
+        - vpc_peer.peering_id == peer_id_1
+
   - name: Get details on specific VPC peer
     ec2_vpc_peering_info:
       peer_connection_ids:
@@ -458,21 +474,30 @@
         - delete_peer is successful
 
   always:
+
+  - name: Find all VPC Peering connections for our VPCs
+    ec2_vpc_peering_info:
+      filters:
+        accepter-vpc-info.vpc-id: '{{ item }}'
+    register: peering_info
+    loop:
+    - '{{ vpc_1 }}'
+    - '{{ vpc_2 }}'
+
+  - set_fact:
+      vpc_peering_connection_ids: '{{ _vpc_peering_connections | map(attribute="vpc_peering_connection_id") | list }}'
+    vars:
+      _vpc_peering_connections: '{{ peering_info.results | map(attribute="vpc_peering_connections") | flatten }}'
+    ignore_errors: True
+
     # ============================================================
 
-  - name: delete a local VPC peering Connection
+  - name: Delete remaining Peering connections
     ec2_vpc_peer:
-      peering_id: "{{ vpc_peer.peering_id }}"
+      peering_id: "{{ item }}"
       state: absent
-    register: delete_peer
     ignore_errors: True
-
-  - name: delete a local VPC peering Connection
-    ec2_vpc_peer:
-      peering_id: "{{ vpc_peer2.peering_id }}"
-      state: absent
-    register: delete_peer
-    ignore_errors: True
+    loop: '{{ vpc_peering_connection_ids }}'
 
   - name: tidy up VPC 2
     ec2_vpc_net:


### PR DESCRIPTION
##### SUMMARY

fixes: #580 

Fixes a bug where a new peering request would be created when the accepter/requester is reversed

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/ec2_vpc_peer.py

##### ADDITIONAL INFORMATION
