### PR TITLE
Mark cloudformation_exports_info tests stable again

### DIFF
--- a/tests/integration/targets/cloudformation_exports_info/aliases
+++ b/tests/integration/targets/cloudformation_exports_info/aliases
@@ -1,4 +1,1 @@
-# https://github.com/ansible-collections/community.aws/issues/157
-unstable
-
 cloud/aws


### PR DESCRIPTION
##### SUMMARY

fixes: #157

re-enable the cloudformation_exports_info tests.  The CI account isn't as busy these days because we don't run "full" integration tests anywhere near as often any more.  This should mean that the (likely) capacity related issues we were seeing should be gone.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

cloudformation_exports_info

##### ADDITIONAL INFORMATION