### PR TITLE
elb_target_group make health_check_protocol required if health_check_path or successful_response_codes is set

### DIFF
--- a/changelogs/29-elb_target_group-health_check_protocol.yml
+++ b/changelogs/29-elb_target_group-health_check_protocol.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- elb_target_group - instead of completely ignoring ``health_check_path`` and ``successful_response_codes`` if ``health_check_protocol`` is not supplied, now raises an error (https://github.com/ansible-collections/community.aws/issues/29).

--- a/plugins/modules/elb_target_group.py
+++ b/plugins/modules/elb_target_group.py
@@ -931,14 +931,17 @@ def main():
         wait_timeout=dict(type='int', default=200),
         wait=dict(type='bool', default=False)
     )
+    required_by = dict(
+        health_check_path=['health_check_protocol'],
+        successful_response_codes=['health_check_protocol'],
+    )
+    required_if = [
+        ['target_type', 'instance', ['protocol', 'port', 'vpc_id']],
+        ['target_type', 'ip', ['protocol', 'port', 'vpc_id']],
+        ['target_type', 'alb', ['protocol', 'port', 'vpc_id']],
+    ]
 
-    module = AnsibleAWSModule(argument_spec=argument_spec,
-                              required_if=[
-                                  ['target_type', 'instance', ['protocol', 'port', 'vpc_id']],
-                                  ['target_type', 'ip', ['protocol', 'port', 'vpc_id']],
-                                  ['target_type', 'alb', ['protocol', 'port', 'vpc_id']],
-                              ]
-                              )
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_by=required_by, required_if=required_if)
 
     if module.params.get('target_type') is None:
         module.params['target_type'] = 'instance'


### PR DESCRIPTION
fixes: https://github.com/ansible-collections/community.aws/issues/29

##### SUMMARY

`health_check_path` and `successful_response_codes` were previously silently dropped on the floor if health_check_protocol wasn't set.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

elb_target_group

##### ADDITIONAL INFORMATION
