### PR TITLE
cloudwatchevent_rule - Add argspec validation for targets

### DIFF
--- a/changelogs/fragments/623-cloudwatchevents_rule-support_input_transformer.yml
+++ b/changelogs/fragments/623-cloudwatchevents_rule-support_input_transformer.yml
@@ -1,2 +1,4 @@
 minor_changes:
-  - cloudwatchevent_rule - Added ``input_paths_map`` and ``input_template`` parameters to support ``input_transformer`` on CloudWatch event rule (https://github.com/ansible-collections/community.aws/pull/623).
+  - cloudwatchevent_rule - Added ``targets.input_transformer.input_paths_map`` and ``targets.input_transformer.input_template`` parameters to
+    support configuring on CloudWatch event rule input transformation (https://github.com/ansible-collections/community.aws/pull/623).
+  - cloudwatchevent_rule - Applied validation of ``targets`` arguments (https://github.com/ansible-collections/community.aws/issues/201).

--- a/tests/integration/targets/cloudwatchevent_rule/defaults/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-name_pattern: "cloudwatch_event_rule"
-unique_id: "{{ tiny_prefix  }}"
+name_pattern: "cloudwatch_event_rule-{{ tiny_prefix }}"
 
 test_event_names:
-  - "{{ name_pattern }}-{{ unique_id }}-1"
-  - "{{ name_pattern }}-{{ unique_id }}-2"
+  - "{{ name_pattern }}-1"
+  - "{{ name_pattern }}-2"
 
-input_transformer_event_name: "{{ name_pattern }}-{{ unique_id }}-3"
+input_transformer_event_name: "{{ name_pattern }}-3"
+input_event_name: "{{ name_pattern }}-4"

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -25,6 +25,12 @@
       register: event_rules_classic_output
       loop: "{{ test_event_names }}"
 
+    - name: Assert that classic event rules were created
+      assert:
+        that:
+          - event_rules_classic_output.changed
+          - event_rules_classic_output.msg == "All items completed"
+
     - name: Create cloudwatch event rule with input transformer
       cloudwatchevent_rule:
         name: "{{ input_transformer_event_name }}"
@@ -34,17 +40,34 @@
         targets:
           - id: "{{ sns_topic_output.sns_topic.name }}"
             arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
-            input_paths_map:
-              instance: "$.detail.instance-id"
-              state: "$.detail.state"
-            input_template: "<instance> is in state <state>"
+            input_transformer:
+              input_paths_map:
+                instance: "$.detail.instance-id"
+                state: "$.detail.state"
+              input_template: "<instance> is in state <state>"
       register: event_rule_input_transformer_output
 
-    - name: Assert that classic event rules were created
+    - name: Assert that input transformer event rule was created
       assert:
         that:
-          - event_rules_classic_output.changed
-          - event_rules_classic_output.msg == "All items completed"
+          - event_rule_input_transformer_output.changed
+
+    - name: Create cloudwatch event rule with inputs
+      cloudwatchevent_rule:
+        name: "{{ input_event_name }}"
+        description: "Event rule with input configuration"
+        state: present
+        event_pattern: '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["pending"]}}'
+        targets:
+          - id: "{{ sns_topic_output.sns_topic.name }}"
+            arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
+            input: 'Hello World'
+          - id: "{{ sns_topic_output.sns_topic.name }}2"
+            arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
+            input:
+              start: 'Hello World'
+              end: 'Goodbye oh cruel World'
+      register: event_rule_input_transformer_output
 
     - name: Assert that input transformer event rule was created
       assert:
@@ -61,8 +84,11 @@
 
     - name: Delete input transformer CloudWatch event rules
       cloudwatchevent_rule:
-        name: "{{ input_transformer_event_name }}"
+        name: "{{ item }}"
         state: absent
+      loop:
+        - "{{ input_transformer_event_name }}"
+        - "{{ input_event_name }}"
 
     - name: Delete SNS topic
       sns_topic:


### PR DESCRIPTION
##### SUMMARY

fixes: #201

Targets currently has minimal validation applied.
Because of the way Ansible converts JSON strings to dicts/lists, then back to the Python format string representing the dicts/lists, unless we explicitly define a parameter is a JSON string they get corrupted.

This also moves the new input_paths_map/input_template parameters under input_transformer.  Because we've not released 4.1.0 yet this doesn't cause any breakage.  This will make adding other target parameters simpler further down the road.  (There's a *lot* that we don't support today)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

cloudwatchevent_rule

##### ADDITIONAL INFORMATION