### PR TITLE
Add deprecation note about Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ PEP440 is the schema used to describe the versions of Ansible.
 
 ## Python version compatibility
 
-As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/), this collection requires Python 3.6 or greater.
+This collection depends on the AWS SDK for Python (Boto3 and Botocore).  Due to the
+[AWS SDK Python Support Policy](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+this collection requires Python 3.6 or greater.
+
+Amazon have also announced the end of support for
+[Python less than 3.7](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).
+As such support for Python less than 3.7 by this collection has been deprecated and will be removed in a release
+after 2023-05-31.
 
 ## AWS SDK version compatibility
 

--- a/changelogs/fragments/python.yml
+++ b/changelogs/fragments/python.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+- community.aws collection - due to the AWS SDKs announcing the end of support for Python less than 3.7
+  (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+  support for Python less than 3.7 by this collection has been deprecated and will be removed in a
+  release after 2023-05-31
+  (https://github.com/ansible-collections/community.aws/pull/1361).


### PR DESCRIPTION
##### SUMMARY

The AWS SDK for Python has now [dropped support for Python 3.6](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/) and announced that in future they're dropping support 6 months after PSF End Of Support for a version.

Keeping with our 1-year-old Botocore/Boto3 requirements, this will result in us needing to drop support for Python 3.6 in about a year, when we would be scheduled to bump to `botocore >= 1.27.0`, as 1.27.0 requires Python 3.7.  This means we're generally going to drop support for a version of Python around 18 months after PSF End Of Support.  For the sake of transparency to our users, add a deprecation notice.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

README.md

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible-collections/amazon.aws/pull/935