### PR TITLE
elb_application_lb/elb_network_lb - Add documentation for TargetGroupName

### DIFF
--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -122,8 +122,14 @@ options:
                     description: The type of action.
                     type: str
                 TargetGroupArn:
-                    description: The Amazon Resource Name (ARN) of the target group.
+                    description:
+                      - The Amazon Resource Name (ARN) of the target group.
+                      - Mutually exclusive with I(TargetGroupName).
                     type: str
+                TargetGroupName:
+                    description:
+                      - The name of the target group.
+                      - Mutually exclusive with I(TargetGroupArn).
         Rules:
             type: list
             elements: dict

--- a/plugins/modules/elb_network_lb.py
+++ b/plugins/modules/elb_network_lb.py
@@ -64,8 +64,14 @@ options:
                     description: The type of action.
                     type: str
                 TargetGroupArn:
-                    description: The Amazon Resource Name (ARN) of the target group.
+                    description:
+                      - The Amazon Resource Name (ARN) of the target group.
+                      - Mutually exclusive with I(TargetGroupName).
                     type: str
+                TargetGroupName:
+                    description:
+                      - The name of the target group.
+                      - Mutually exclusive with I(TargetGroupArn).
   name:
     description:
       - The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric


### PR DESCRIPTION
##### SUMMARY

fixes: #915

elb_application_lb and elb_network_lb have a poorly documented feature, that you can use TargetGroupName instead of TargetGroupArn.  While this is shown in the examples, it's in the options documentation.

While undocumented the feature's been there since at release 1.0.0

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/elb_application_lb.py
plugins/modules/elb_network_lb.py

##### ADDITIONAL INFORMATION
