### PR TITLE
New module - accessanalyzer_validate_policy_info

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,6 +1,7 @@
 requires_ansible: '>=2.9.10'
 action_groups:
   aws:
+  - accessanalyzer_validate_policy_info
   - acm_certificate
   - acm_certificate_info
   - api_gateway

--- a/plugins/modules/accessanalyzer_validate_policy_info.py
+++ b/plugins/modules/accessanalyzer_validate_policy_info.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: accessanalyzer_validate_policy_info
+version_added: 5.0.0
+short_description: Performs validation of IAM policies
+description:
+  - Requests the validation of a policy and returns a list of findings.
+options:
+  policy:
+    description:
+      - A properly json formatted policy.
+    type: json
+    aliases: ['policy_document']
+    required: true
+  locale:
+    description:
+      - The locale to use for localizing the findings.
+      - Supported locales include C(DE), C(EN), C(ES), C(FR), C(IT), C(JA), C(KO), C(PT_BR),
+        C(ZH_CN) and C(ZH_TW).
+      - For more information about supported locales see the AWS Documentation
+        C(https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_ValidatePolicy.html)
+    type: str
+    required: false
+    default: 'EN'
+  policy_type:
+    description:
+      - The type of policy to validate.
+      - C(identity) policies grant permissions to IAM principals, including both managed and inline
+        policies for IAM roles, users, and groups.
+      - C(resource) policies policies grant permissions on AWS resources, including trust policies
+        for IAM roles and bucket policies for S3 buckets.
+    type: str
+    choices: ['identity', 'resource', 'service_control']
+    default: 'identity'
+    required: false
+  resource_type:
+    description:
+      - The type of resource to attach to your resource policy.
+      - Ignored unless I(policy_type=resource).
+      - Supported resource types include C(AWS::S3::Bucket), C(AWS::S3::AccessPoint),
+        C(AWS::S3::MultiRegionAccessPoint) and C(AWS::S3ObjectLambda::AccessPoint)
+      - For resource types not supported as valid values, IAM Access Analyzer runs policy checks
+        that apply to all resource policies.
+      - For more information about supported locales see the AWS Documentation
+        C(https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_ValidatePolicy.html)
+    type: str
+    required: false
+  results_filter:
+    description:
+      - Filter the findings and limit them to specific finding types.
+    type: list
+    elements: str
+    choices: ['error', 'security', 'suggestion', 'warning']
+    required: false
+author:
+  - Mark Chappell (@tremble)
+extends_documentation_fragment:
+  - amazon.aws.aws
+  - amazon.aws.ec2
+'''
+
+EXAMPLES = r'''
+# Validate a policy
+- name: Validate a simple IAM policy
+  community.aws.accessanalyzer_validate_policy_info:
+    policy: "{{ lookup('template', 'managed_policy.json.j2') }}"
+'''
+
+RETURN = r'''
+findings:
+  description: The list of findings in a policy returned by IAM Access Analyzer based on its suite of policy checks.
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    finding_details:
+      description:
+        - A localized message describing the finding.
+      type: str
+      returned: success
+      sample: 'Resource ARN does not match the expected ARN format. Update the resource portion of the ARN.'
+    finding_type:
+      description:
+        - The severity of the finding.
+      type: str
+      returned: success
+      sample: 'ERROR'
+    issue_code:
+      description:
+        - An identifier for the type of issue found.
+      type: str
+      returned: success
+      sample: 'INVALID_ARN_RESOURCE'
+    learn_more_link:
+      description:
+        - A link to additional information about the finding type.
+      type: str
+      returned: success
+      sample: 'https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html'
+    locations:
+      description:
+        - The location of the item resulting in the recommendations.
+      type: list
+      returned: success
+      elements: dict
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+
+
+def main():
+    # Botocore only supports specific values for locale and resource_type, however the supported
+    # values are likely to be expanded, let's avoid hard coding limits which might not hold true in
+    # the long term...
+    argument_spec = dict(
+        policy=dict(required=True, type='json', aliases=['policy_document']),
+        locale=dict(required=False, type='str', default='EN'),
+        policy_type=dict(required=False, type='str', default='identity',
+                         choices=['identity', 'resource', 'service_control']),
+        resource_type=dict(required=False, type='str'),
+        results_filter=dict(required=False, type='list', elements='str',
+                            choices=['error', 'security', 'suggestion', 'warning']),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    policy_type_map = dict(identity='IDENTITY_POLICY', resource='RESOURCE_POLICY',
+                           service_control='SERVICE_CONTROL_POLICY')
+
+    policy = module.params.get('policy')
+    policy_type = policy_type_map[module.params.get('policy_type')]
+    locale = module.params.get('locale').upper()
+    resource_type = module.params.get('resource_type')
+
+    try:
+        client = module.client('accessanalyzer', retry_decorator=AWSRetry.jittered_backoff())
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Failed to connect to AWS')
+
+    params = dict(locale=locale, policyDocument=policy, policyType=policy_type)
+    if policy_type == 'RESOURCE_POLICY' and resource_type:
+        params['policyType'] = resource_type
+
+    results = client.validate_policy(aws_retry=True, **params)
+    results = camel_dict_to_snake_dict(results)
+
+    module.exit_json(changed=False, **results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/accessanalyzer_validate_policy_info.py
+++ b/plugins/modules/accessanalyzer_validate_policy_info.py
@@ -111,6 +111,54 @@ findings:
       type: list
       returned: success
       elements: dict
+      contains:
+        path:
+          description: A path in a policy, represented as a sequence of path elements.
+          type: list
+          elements: dict
+          returned: success
+          sample: [{"value": "Statement"}, {"index": 0}, {"value": "Resource"}, {"index": 0}]
+        span:
+          description:
+            - Where in the policy the finding refers to.
+            - Note - when using lookups or passing dictionaries to I(policy) the policy string may be
+              converted to a single line of JSON, changing th column, line and offset values.
+          type: dict
+          contains:
+            start:
+              description: The start position of the span.
+              type: dict
+              returned: success
+              contains:
+                column:
+                  description: The column of the position, starting from C(0).
+                  type: int
+                  returned: success
+                line:
+                  description: The line of the position, starting from C(1).
+                  type: int
+                  returned: success
+                offset:
+                  description: The offset within the policy that corresponds to the position, starting from C(0).
+                  type: int
+                  returned: success
+            end:
+              description: The end position of the span.
+              type: dict
+              returned: success
+              contains:
+                column:
+                  description: The column of the position, starting from C(0).
+                  type: int
+                  returned: success
+                line:
+                  description: The line of the position, starting from C(1).
+                  type: int
+                  returned: success
+                offset:
+                  description: The offset within the policy that corresponds to the position, starting from C(0).
+                  type: int
+                  returned: success
 '''
 
 try:

--- a/tests/integration/targets/accessanalyzer_validate_policy_info/aliases
+++ b/tests/integration/targets/accessanalyzer_validate_policy_info/aliases
@@ -1,0 +1,1 @@
+cloud/aws

--- a/tests/integration/targets/accessanalyzer_validate_policy_info/meta/main.yml
+++ b/tests/integration/targets/accessanalyzer_validate_policy_info/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/accessanalyzer_validate_policy_info/tasks/main.yml
+++ b/tests/integration/targets/accessanalyzer_validate_policy_info/tasks/main.yml
@@ -15,7 +15,17 @@
       set_fact:
         aws_account_id: '{{ aws_caller_info.account }}'
 
-    - accessanalyzer_validate_policy_info:
+    # Notes:
+    # - Because the policy validation includes both linting, security hints and error detection, we
+    #   can't assume that we'll only get the entry we expect.
+    # - Because Ansible's done its thing and converted from YAML to dict to JSON string, line
+    #   numbers aren't useful, as such we can test that the fields we expect are there, but we
+    #   can't test things like locations
+    # - Some fields are arbitrary strings with recommendations, we shouldn't assume these will stay
+    #   constant
+
+    - name: Test with invalid role ('ERROR')
+      accessanalyzer_validate_policy_info:
         policy:
           Version: '2012-10-17'
           Statement:
@@ -24,14 +34,251 @@
               Action:
                 - iam:AttachRolePolicy
               Resource:
-                - 'arn:aws:iam::{{ aws_account_id }}:invalid-role/dms-vpc-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:invalid-role/example-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:role/example-role'
               Condition:
                 ArnLike:
                   iam:PolicyArn:
-                    - 'arn:aws:iam::aws:policy/*'
+                    - 'arn:aws:iam::aws:policy/MyExamplePolicy'
       register: results
 
     - assert:
         that:
           - "'findings' in results"
-          - results.findings | length > 1
+          - results.findings | length >= 1
+          - "'INVALID_ARN_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+          - "'finding_details' in expected_finding"
+          # We should be relatively relaxed with this message, there's a risk AWS will change the
+          # wording, but make a vague check that we're getting English as expected
+          - "'does not match the expected' in expected_finding.finding_details"
+          - "'finding_type' in expected_finding"
+          - expected_finding.finding_type == 'ERROR'
+          - "'issue_code' in expected_finding"
+          - expected_finding.issue_code == 'INVALID_ARN_RESOURCE'
+          - "'learn_more_link' in expected_finding"
+          - "'locations' in expected_finding"
+          - "'path' in first_location"
+          - "'span' in first_location"
+      vars:
+        expected_finding: "{{ results.findings | selectattr('issue_code', 'equalto', 'INVALID_ARN_RESOURCE') | flatten | first }}"
+        first_location: "{{ expected_finding.locations | first }}"
+
+    - name: Test with duplicate role ('SUGGESTION')
+      accessanalyzer_validate_policy_info:
+        policy: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [{
+                "Sid": "AttachPolicyToDuplicateWildcardRole",
+                "Effect": "Allow",
+                "Action": ["iam:AttachRolePolicy"],
+                "Resource": [
+                    "arn:aws:iam::123456789012:role/example-role",
+                    "arn:aws:iam::123456789012:role/example*"
+                ],
+                "Condition": {
+                  "ArnLike": {
+                    "iam:PolicyArn": [
+                      "arn:aws:iam::aws:policy/MyExamplePolicy"
+                    ]
+                  }
+                }
+              }]
+            }
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length >= 1
+          - "'REDUNDANT_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+          - "'finding_details' in expected_finding"
+          - "'finding_type' in expected_finding"
+          - expected_finding.finding_type == 'SUGGESTION'
+          - "'issue_code' in expected_finding"
+          - expected_finding.issue_code == 'REDUNDANT_RESOURCE'
+          - "'learn_more_link' in expected_finding"
+          - "'locations' in expected_finding"
+          - "'path' in first_location"
+          - "'span' in first_location"
+      vars:
+        expected_finding: "{{ results.findings | selectattr('issue_code', 'equalto', 'REDUNDANT_RESOURCE') | flatten | first }}"
+        first_location: "{{ expected_finding.locations | first }}"
+
+    - name: Test with duplicate SID ('WARNING')
+      accessanalyzer_validate_policy_info:
+        policy_type: resource
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: DuplicateSID
+              Effect: Allow
+              Action:
+                - sts:AssumeRole
+              Principal:
+                Service: 'ssm-incidents.amazonaws.com'
+            - Sid: DuplicateSID
+              Effect: Allow
+              Action:
+                - sts:AssumeRole
+              Principal:
+                Service: 'ec2.amazonaws.com'
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length >= 1
+          - "'UNIQUE_SIDS_RECOMMENDED' in (results.findings | map(attribute='issue_code'))"
+          - "'finding_details' in expected_finding"
+          - "'finding_type' in expected_finding"
+          - expected_finding.finding_type == 'WARNING'
+          - "'issue_code' in expected_finding"
+          - expected_finding.issue_code == 'UNIQUE_SIDS_RECOMMENDED'
+          - "'learn_more_link' in expected_finding"
+          - "'locations' in expected_finding"
+          - "'path' in first_location"
+          - "'span' in first_location"
+      vars:
+        expected_finding: "{{ results.findings | selectattr('issue_code', 'equalto', 'UNIQUE_SIDS_RECOMMENDED') | flatten | first }}"
+        first_location: "{{ expected_finding.locations | first }}"
+
+    - name: Test with wildcard to PassRole ('SECURITY_WARNING')
+      accessanalyzer_validate_policy_info:
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: PassRoleWithWildcard
+              Effect: Allow
+              Action:
+                - iam:PassRole
+              Resource:
+                - '*'
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length >= 1
+          - "'PASS_ROLE_WITH_STAR_IN_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+          - "'finding_details' in expected_finding"
+          - "'finding_type' in expected_finding"
+          - expected_finding.finding_type == 'SECURITY_WARNING'
+          - "'issue_code' in expected_finding"
+          - expected_finding.issue_code == 'PASS_ROLE_WITH_STAR_IN_RESOURCE'
+          - "'learn_more_link' in expected_finding"
+          - "'locations' in expected_finding"
+          - "'path' in first_location"
+          - "'span' in first_location"
+      vars:
+        expected_finding: "{{ results.findings | selectattr('issue_code', 'equalto', 'PASS_ROLE_WITH_STAR_IN_RESOURCE') | flatten | first }}"
+        first_location: "{{ expected_finding.locations | first }}"
+
+    - name: Test with single filter value
+      accessanalyzer_validate_policy_info:
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: AttachPolicyToInvalidRole
+              Effect: Allow
+              Action:
+                - iam:AttachRolePolicy
+              Resource:
+                - 'arn:aws:iam::{{ aws_account_id }}:invalid-role/example-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:role/example-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:role/example-*'
+              Condition:
+                ArnLike:
+                  iam:PolicyArn:
+                    - 'arn:aws:iam::aws:policy/MyExamplePolicy'
+            - Sid: PassRoleWithWildcard
+              Effect: Allow
+              Action:
+                - iam:PassRole
+              Resource:
+                - '*'
+        results_filter: 'error'
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length >= 1
+          - results.findings | map(attribute='finding_type') | unique | list == ['ERROR']
+          - "'INVALID_ARN_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+
+    - name: Test with multiple filter value
+      accessanalyzer_validate_policy_info:
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: AttachPolicyToInvalidRole
+              Effect: Allow
+              Action:
+                - iam:AttachRolePolicy
+              Resource:
+                - 'arn:aws:iam::{{ aws_account_id }}:invalid-role/example-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:role/example-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:role/example-*'
+              Condition:
+                ArnLike:
+                  iam:PolicyArn:
+                    - 'arn:aws:iam::aws:policy/MyExamplePolicy'
+            - Sid: PassRoleWithWildcard
+              Effect: Allow
+              Action:
+                - iam:PassRole
+              Resource:
+                - '*'
+        results_filter:
+          - 'error'
+          - 'security'
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length >= 1
+          - results.findings | map(attribute='finding_type') | unique | list | sort == ['ERROR', 'SECURITY_WARNING']
+          - "'INVALID_ARN_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+          - "'PASS_ROLE_WITH_STAR_IN_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+
+    - name: Test with Locale
+      accessanalyzer_validate_policy_info:
+        locale: 'DE'
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: AttachPolicyToInvalidRole
+              Effect: Allow
+              Action:
+                - iam:AttachRolePolicy
+              Resource:
+                - 'arn:aws:iam::{{ aws_account_id }}:invalid-role/example-role'
+                - 'arn:aws:iam::{{ aws_account_id }}:role/example-role'
+              Condition:
+                ArnLike:
+                  iam:PolicyArn:
+                    - 'arn:aws:iam::aws:policy/MyExamplePolicy'
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length >= 1
+          - "'INVALID_ARN_RESOURCE' in (results.findings | map(attribute='issue_code'))"
+          - "'finding_details' in expected_finding"
+          # We should be relatively relaxed with this message, there's a risk AWS will change the
+          # wording, but make a vague check that we're getting German as expected
+          - "'stimmt nicht mit dem erwarteten' in expected_finding.finding_details"
+          - "'finding_type' in expected_finding"
+          - expected_finding.finding_type == 'ERROR'
+          - "'issue_code' in expected_finding"
+          - expected_finding.issue_code == 'INVALID_ARN_RESOURCE'
+          - "'learn_more_link' in expected_finding"
+          - "'locations' in expected_finding"
+          - "'path' in first_location"
+          - "'span' in first_location"
+      vars:
+        expected_finding: "{{ results.findings | selectattr('issue_code', 'equalto', 'INVALID_ARN_RESOURCE') | flatten | first }}"
+        first_location: "{{ expected_finding.locations | first }}"

--- a/tests/integration/targets/accessanalyzer_validate_policy_info/tasks/main.yml
+++ b/tests/integration/targets/accessanalyzer_validate_policy_info/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- module_defaults:
+    group/aws:
+      aws_access_key: '{{ aws_access_key | default(omit) }}'
+      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      security_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region | default(omit) }}'
+
+  block:
+    - name: get ARN of calling user
+      aws_caller_info:
+      register: aws_caller_info
+
+    - name: Store Account ID for later use
+      set_fact:
+        aws_account_id: '{{ aws_caller_info.account }}'
+
+    - accessanalyzer_validate_policy_info:
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: AttachPolicyToInvalidRole
+              Effect: Allow
+              Action:
+                - iam:AttachRolePolicy
+              Resource:
+                - 'arn:aws:iam::{{ aws_account_id }}:invalid-role/dms-vpc-role'
+              Condition:
+                ArnLike:
+                  iam:PolicyArn:
+                    - 'arn:aws:iam::aws:policy/*'
+      register: results
+
+    - assert:
+        that:
+          - "'findings' in results"
+          - results.findings | length > 1


### PR DESCRIPTION
##### SUMMARY

fixes: #626

Adds a module which supports validating and linting IAM policies

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

plugins/modules/accessanalyzer_validate_policy_info.py

##### ADDITIONAL INFORMATION
