### PR TITLE
iam_policy - add support for diff mode

### DIFF
--- a/changelogs/fragments/560-iam_policy-diff.yml
+++ b/changelogs/fragments/560-iam_policy-diff.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- iam_policy - added support for ``--diff`` mode (https://github.com/ansible-collections/community.aws/issues/560).
+- iam_policy - attempts to continue when read requests are denied by IAM policy (https://github.com/ansible-collections/community.aws/pull/1375).
+deprecated_features:
+- iam_policy - the ``policies`` return value has been renamed ``policy_names`` and will be removed in a release after 2024-08-01, both values are currently returned (https://github.com/ansible-collections/community.aws/pull/1375).


### PR DESCRIPTION
##### SUMMARY

fixes: #560 

- Adds support for diff mode
- renames `policies` to `policy_names` so that in future we can return the policies (outside of the diff) too.
- Attempts to handle AccessDenied more cleanly

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_policy

##### ADDITIONAL INFORMATION
