### PR TITLE
lambda - Add support for setting supported architectures

### DIFF
--- a/changelogs/fragments/744-lambda-architectures.yml
+++ b/changelogs/fragments/744-lambda-architectures.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- lambda - Adds support for setting Architechtures (https://github.com/ansible-collections/community.aws/issues/744).
+- lambda - Adds support for setting Architectures (https://github.com/ansible-collections/community.aws/issues/744).

--- a/changelogs/fragments/744-lambda-architectures.yml
+++ b/changelogs/fragments/744-lambda-architectures.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- lambda - Adds support for setting Architechtures (https://github.com/ansible-collections/community.aws/issues/744).

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -15,8 +15,6 @@ description:
   - Gathers various details related to Lambda functions, including aliases, versions and event source mappings.
   - Use module M(community.aws.lambda) to manage the lambda function itself, M(community.aws.lambda_alias) to manage function aliases,
     M(community.aws.lambda_event) to manage lambda event source mappings, and M(community.aws.lambda_policy) to manage policy statements.
-
-
 options:
   query:
     description:
@@ -34,11 +32,11 @@ options:
     description:
       - When I(query=mappings), this is the Amazon Resource Name (ARN) of the Amazon Kinesis or DynamoDB stream.
     type: str
-author: Pierre Jodouin (@pjodouin)
+author:
+  - Pierre Jodouin (@pjodouin)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''
@@ -94,6 +92,12 @@ functions:
             returned: when C(query) is I(aliases) or I(all)
             type: list
             elements: str
+        architectures:
+            description: The architectures supported by the function.
+            returned: successful run where botocore >= 1.21.51
+            type: list
+            elements: str
+            sample: ['arm64']
         code_sha256:
             description: The SHA256 hash of the function's deployment package.
             returned: success

--- a/tests/integration/targets/lambda/meta/main.yml
+++ b/tests/integration/targets/lambda/meta/main.yml
@@ -1,1 +1,4 @@
-dependencies: []
+dependencies:
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: "1.21.51"

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -110,6 +110,9 @@
       handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
+      architecture: arm64
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     register: result
     check_mode: yes
   - name: assert lambda upload succeeded
@@ -124,12 +127,16 @@
       handler: '{{ lambda_python_handler }}'
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
+      architecture: arm64
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     register: result
   - name: assert lambda upload succeeded
     assert:
       that:
       - result.changed
       - result.configuration.tracing_config.mode == "PassThrough"
+      - result.configuration.architectures == ['arm64']
 
   - include_tasks: 'tagging.yml'
 
@@ -260,6 +267,8 @@
       query: all
     register: lambda_infos_all
     check_mode: yes
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   - name: lambda_info | Assert successfull retrieval of all information
     assert:
       that:
@@ -275,6 +284,7 @@
       - lambda_infos_all.functions[0].policy is defined
       - lambda_infos_all.functions[0].mappings is defined
       - lambda_infos_all.functions[0].tags is defined
+      - lambda_infos_all.functions[0].architectures == ['arm64']
 
   - name: lambda_info | Ensure default query value is 'config' when function name omitted
     lambda_info:


### PR DESCRIPTION
##### SUMMARY

fixes: #744 

Adds support for setting supported architectures - needs botocore 1.21.51

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/lambda.py
plugins/modules/lambda_info.py

##### ADDITIONAL INFORMATION

Return docs changes have no version_added because they only depend the botocore version rather than the module version. (1.0.0 would return the values if botocore was new enough)