### PR TITLE
route53: Restore support for zero weighted DNS records

### DIFF
--- a/changelogs/fragments/1379-zero_weight_dns_fix.yml
+++ b/changelogs/fragments/1379-zero_weight_dns_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - route53 - fixes bug preventing creating a DNS record with a weight of zero (https://github.com/ansible-collections/community.aws/issues/1378)

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -628,7 +628,7 @@ def main():
     if command_in == 'create' or command_in == 'delete':
         if alias_in and len(value_in) != 1:
             module.fail_json(msg="parameter 'value' must contain a single dns name for alias records")
-        if not any([weight_in, region_in, failover_in, geo_location]) and identifier_in is not None:
+        if (weight_in is None and region_in is None and failover_in is None and geo_location is None) and identifier_in is not None:
             module.fail_json(msg="You have specified identifier which makes sense only if you specify one of: weight, region, geo_location or failover.")
 
     retry_decorator = AWSRetry.jittered_backoff(

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -635,6 +635,42 @@
         - weighted_record is not failed
         - weighted_record is not changed
 
+  - name: 'Create a zero weighted record'
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'zero_weighted.{{ zone_one }}'
+      type: CNAME
+      value: 'zid_test.{{ zone_one }}'
+      overwrite: True
+      identifier: "host1@www"
+      weight: 0
+      region: '{{ omit }}'
+    register: weighted_record
+  - name: 'This should be changed'
+    assert:
+      that:
+        - weighted_record is not failed
+        - weighted_record is changed
+
+  - name: 'Re-Create a zero weighted record'
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'zero_weighted.{{ zone_one }}'
+      type: CNAME
+      value: 'zid_test.{{ zone_one }}'
+      overwrite: True
+      identifier: "host1@www"
+      weight: 0
+      region: '{{ omit }}'
+    register: weighted_record
+  - name: 'This should not be changed'
+    assert:
+      that:
+        - weighted_record is not failed
+        - weighted_record is not changed
+
 #Test Geo Location - Continent Code
   - name: Create a record with geo_location - continent_code (check_mode)
     route53:


### PR DESCRIPTION
##### SUMMARY
In https://github.com/ansible-collections/community.aws/pull/1117#discussion_r867822728 and https://github.com/ansible-collections/community.aws/pull/1117/files#r869391659 this line was recommended to be simplified, but `not any` will also return `true` if `weight_in` has a value of 0, not only when it is `None`

Fixes #1378 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
route53

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Previously it was possible to create weighted records with a weight of 0. Currently the playbook below returns the error:
```
You have specified identifier which makes sense only if you specify one of: weight, region, geo_location or failover.
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Bug demo
  hosts: localhost
  tasks:
    - name: Set 0 weight for old env
      route53:
        wait: yes
        ttl: '5'
        type: 'CNAME'
        identifier: old
        overwrite: yes
        record: 'record.example.com.'
        zone: 'example.com.'
        value: 'record-old.example.com.'
        weight: '0'
        state: present
```
