### PR TITLE
Remove deprecated AWSRetry.backoff usage

### DIFF
--- a/changelogs/fragments/946-retries.yml
+++ b/changelogs/fragments/946-retries.yml
@@ -1,0 +1,8 @@
+minor_changes:
+- acm_certificate_info - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+- acm_certificate - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+- api_gateway_domain - Move to jittered backoff (https://github.com/ansible-collections/community.aws/pull/1386).
+- waf_condition - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+- waf_info - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+- waf_rule - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+- waf_web_acl - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).

--- a/plugins/modules/acm_certificate_info.py
+++ b/plugins/modules/acm_certificate_info.py
@@ -20,9 +20,9 @@ options:
     description:
       - If provided, the results will be filtered to show only the certificate with this ARN.
       - If no certificate with this ARN exists, this task will fail.
-      - If a certificate with this ARN exists in a different region, this task will fail
+      - If a certificate with this ARN exists in a different region, this task will fail.
     aliases:
-     - arn
+      - arn
     type: str
   domain_name:
     description:
@@ -43,8 +43,8 @@ options:
 author:
   - Will Thames (@willthames)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/api_gateway_domain.py
+++ b/plugins/modules/api_gateway_domain.py
@@ -229,20 +229,20 @@ def delete_domain(module, client):
     return camel_dict_to_snake_dict(result)
 
 
-retry_params = {"tries": 10, "delay": 5, "backoff": 1.2}
+retry_params = {"delay": 5, "backoff": 1.2}
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def get_domain_name(client, domain_name):
     return client.get_domain_name(domainName=domain_name)
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def get_domain_mappings(client, domain_name):
     return client.get_base_path_mappings(domainName=domain_name, limit=200).get('items', [])
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def create_domain_name(module, client, domain_name, certificate_arn, endpoint_type, security_policy):
     endpoint_configuration = {'types': [endpoint_type]}
 
@@ -263,12 +263,12 @@ def create_domain_name(module, client, domain_name, certificate_arn, endpoint_ty
         )
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def add_domain_mapping(client, domain_name, base_path, rest_api_id, stage):
     return client.create_base_path_mapping(domainName=domain_name, basePath=base_path, restApiId=rest_api_id, stage=stage)
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def update_domain_name(client, domain_name, **kwargs):
     patch_operations = []
 
@@ -281,12 +281,12 @@ def update_domain_name(client, domain_name, **kwargs):
     return client.update_domain_name(domainName=domain_name, patchOperations=patch_operations)
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def delete_domain_name(client, domain_name):
     return client.delete_domain_name(domainName=domain_name)
 
 
-@AWSRetry.backoff(**retry_params)
+@AWSRetry.jittered_backoff(**retry_params)
 def delete_domain_mapping(client, domain_name, base_path):
     return client.delete_base_path_mapping(domainName=domain_name, basePath=base_path)
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/946

##### SUMMARY

AWSRetry.backoff was deprecated (and originally slated for removal in 4.0.0) remove usage.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

acm_certificate_info
acm_certificate
api_gateway_domain
waf_condition
waf_info
waf_rule
waf_web_acl

##### ADDITIONAL INFORMATION

WAF and ACM changes are coming from amazon.aws (linked PR), this just drops in a changelog fragment