### PR TITLE
Flag rds_instance_snapshot tests as slow

### DIFF
--- a/tests/integration/targets/acm_certificate/aliases
+++ b/tests/integration/targets/acm_certificate/aliases
@@ -1,6 +1,3 @@
-# https://github.com/ansible/ansible/issues/67788
-# unstable
-
 cloud/aws
 
 acm_certificate_info

--- a/tests/integration/targets/rds_instance_snapshot/aliases
+++ b/tests/integration/targets/rds_instance_snapshot/aliases
@@ -1,3 +1,5 @@
+slow
+
 cloud/aws
 
 rds_snapshot_info


### PR DESCRIPTION
##### SUMMARY

rds_instance_snapshot tests are slow, which causes problems when module_util changes in amazon.aws trigger lots of tests to run.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

rds_instance_snapshot

##### ADDITIONAL INFORMATION