### PR TITLE
s3-lifecycle: fix remove rule with empty prefix

### DIFF
--- a/changelogs/fragments/1398-s3_lifecycle-no-prefix.yml
+++ b/changelogs/fragments/1398-s3_lifecycle-no-prefix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_lifecycle - fix bug when deleting rules with an empty prefix (https://github.com/ansible-collections/community.aws/pull/1398).

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -345,9 +345,9 @@ def compare_and_update_configuration(client, module, current_lifecycle_rules, ru
     if current_lifecycle_rules:
         # If rule ID exists, use that for comparison otherwise compare based on prefix
         for existing_rule in current_lifecycle_rules:
-            if rule.get('ID') == existing_rule.get('ID') and rule['Filter']['Prefix'] != existing_rule.get('Filter', {}).get('Prefix', ''):
+            if rule.get('ID') == existing_rule.get('ID') and rule['Filter'].get('Prefix', '') != existing_rule.get('Filter', {}).get('Prefix', ''):
                 existing_rule.pop('ID')
-            elif rule_id is None and rule['Filter']['Prefix'] == existing_rule.get('Filter', {}).get('Prefix', ''):
+            elif rule_id is None and rule['Filter'].get('Prefix', '') == existing_rule.get('Filter', {}).get('Prefix', ''):
                 existing_rule.pop('ID')
             if rule.get('ID') == existing_rule.get('ID'):
                 changed_, appended_ = update_or_append_rule(rule, existing_rule, purge_transitions, lifecycle_configuration)
@@ -407,7 +407,7 @@ def compare_and_remove_rule(current_lifecycle_rules, rule_id=None, prefix=None):
                 lifecycle_configuration['Rules'].append(existing_rule)
     else:
         for existing_rule in current_lifecycle_rules:
-            if prefix == existing_rule['Filter']['Prefix']:
+            if prefix == existing_rule['Filter'].get('Prefix', ''):
                 # We're not keeping the rule (i.e. deleting) so mark as changed
                 changed = True
             else:

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -622,6 +622,31 @@
         that:
           - output is not changed
 
+    # Check create and delete lifecycle policy with an empty prefix
+    - name: example 8
+      s3_lifecycle:
+        name: "{{ bucket_name }}"
+        rule_id: empty-prefix
+        state: present
+        status: enabled
+        expiration_days: 30
+      register: output
+    - assert:
+        that:
+          - output is changed
+
+    - name: example 8 (idempotency)
+      s3_lifecycle:
+        name: "{{ bucket_name }}"
+        rule_id: empty-prefix
+        state: absent
+        status: enabled
+        expiration_days: 30
+      register: output
+    - assert:
+        that:
+          - output is changed
+
  # ============================================================
   always:
     - name: Ensure all buckets are deleted

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -623,7 +623,7 @@
           - output is not changed
 
     # Check create and delete lifecycle policy with an empty prefix
-    - name: example 8
+    - name: Create rule with no prefix
       s3_lifecycle:
         name: "{{ bucket_name }}"
         rule_id: empty-prefix
@@ -635,7 +635,7 @@
         that:
           - output is changed
 
-    - name: example 8 (idempotency)
+    - name: Delete rule with no prefix
       s3_lifecycle:
         name: "{{ bucket_name }}"
         rule_id: empty-prefix


### PR DESCRIPTION
##### SUMMARY
In case of removing a lifecycle policy without a prefix, there will be no prefix key in the existing_rule filter

Signed-off-by: Seena Fallah <seenafallah@gmail.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`s3_lifecycle`