### PR TITLE
Fix KeyError when Cluster Parameter Group is specified in rds_cluster.py

### DIFF
--- a/changelogs/fragments/1417-cluster-param-group-keyerror.yml
+++ b/changelogs/fragments/1417-cluster-param-group-keyerror.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- rds_cluster - fixes bug where specifiying an rds cluster parameter group raises a `KeyError` (https://github.com/ansible-collections/community.aws/pull/1417).

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -833,6 +833,11 @@ def changing_cluster_options(modify_params, current_cluster):
         if desired_vpc_sgs:
             changing_params['VpcSecurityGroupIds'] = desired_vpc_sgs
 
+    desired_db_cluster_parameter_group = modify_params.pop("DBClusterParameterGroupName", None)
+    if desired_db_cluster_parameter_group:
+        if desired_db_cluster_parameter_group != current_cluster["DBClusterParameterGroup"]:
+            changing_params["DBClusterParameterGroupName"] = desired_db_cluster_parameter_group
+
     for param in modify_params:
         if modify_params[param] != current_cluster[param]:
             changing_params[param] = modify_params[param]

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/defaults/main.yml
@@ -15,6 +15,7 @@ tags_create:
 new_cluster_id: 'ansible-test-cluster-{{ tiny_prefix }}-new'
 new_port: 1155
 new_password: 'test-rds_password-new'
+new_db_parameter_group_name: 'test-db-parameter-group-{{ tiny_prefix }}-new'
 
 # Tag cluster
 tags_patch:

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/defaults/main.yml
@@ -15,7 +15,7 @@ tags_create:
 new_cluster_id: 'ansible-test-cluster-{{ tiny_prefix }}-new'
 new_port: 1155
 new_password: 'test-rds_password-new'
-new_db_parameter_group_name: 'test-db-parameter-group-{{ tiny_prefix }}-new'
+new_db_parameter_group_name: 'ansible-test-db-parameter-group-{{ tiny_prefix }}-new'
 
 # Tag cluster
 tags_patch:

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
@@ -14,7 +14,7 @@
       that:
         - not _result_delete_db_cluster.changed
     ignore_errors: yes
-        
+    
   - name: Create a DB cluster
     rds_cluster:
       id: "{{ cluster_id }}"
@@ -154,6 +154,61 @@
       - "'tags' in _result_modify_id"
       - "'vpc_security_groups' in _result_modify_id"
 
+  - name: Check if DB cluster parameter group exists
+    command: 'aws rds describe-db-cluster-parameter-groups --db-cluster-parameter-group-name {{ new_db_parameter_group_name }}'
+    environment:
+      AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+      AWS_DEFAULT_REGION: "{{ aws_region }}"
+    register: _result_check_db_parameter_group
+    ignore_errors: True
+    changed_when: "_result_check_db_parameter_group.rc == 0"
+
+  - name: Create DB cluster parameter group if not exists
+    command: 'aws rds create-db-cluster-parameter-group --db-cluster-parameter-group-name {{ new_db_parameter_group_name }} --db-parameter-group-family aurora5.6 --description "Test DB cluster parameter group"'
+    environment:
+      AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+      AWS_DEFAULT_REGION: "{{ aws_region }}"
+    register: _result_create_db_parameter_group
+    when: "_result_check_db_parameter_group.rc == 0"
+
+
+  - name: Modify DB cluster parameter group
+    rds_cluster:
+      id: "{{ cluster_id }}"
+      state: present
+      db_cluster_parameter_group_name: "{{ new_db_parameter_group_name }}"
+    register: _result_modify_db_parameter_group_name
+
+  - assert:
+      that:
+        - _result_modify_db_parameter_group_name.changed
+        - "'allocated_storage' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.allocated_storage == 1
+        - "'cluster_create_time' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.copy_tags_to_snapshot == false
+        - "'db_cluster_arn' in _result_modify_db_parameter_group_name"
+        - "_result_modify_db_parameter_group_name.db_cluster_identifier == '{{ cluster_id }}'"
+        - "'db_cluster_parameter_group' in _result_modify_db_parameter_group_name"
+        - "'db_cluster_resource_id' in _result_modify_db_parameter_group_name"
+        - "'endpoint' in _result_modify_db_parameter_group_name"
+        - "'engine' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.engine == "{{ engine }}"
+        - "'engine_mode' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.engine_mode == "provisioned"
+        - "'engine_version' in _result_modify_db_parameter_group_name"
+        - "'master_username' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.master_username == "{{ username }}"
+        - "'port' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.db_cluster_parameter_group == "{{ new_db_parameter_group_name }}"
+        - "'status' in _result_modify_db_parameter_group_name"
+        - _result_modify_db_parameter_group_name.status == "available"
+        - "'tags' in _result_modify_db_parameter_group_name"
+        - "'vpc_security_groups' in _result_modify_db_parameter_group_name"
+
   - name: Delete DB cluster without creating a final snapshot (CHECK MODE)
     rds_cluster:
       state: absent
@@ -194,4 +249,13 @@
       state: absent
       cluster_id: "{{ cluster_id }}"
       skip_final_snapshot: True
+    ignore_errors: true
+
+  - name: Delete cluster parameter group
+    command: 'aws rds delete-db-cluster-parameter-group --db-cluster-parameter-group-name {{ new_db_parameter_group_name }}'
+    environment:
+      AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+      AWS_DEFAULT_REGION: "{{ aws_region }}"
     ignore_errors: true

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
@@ -19,7 +19,7 @@
     rds_cluster:
       id: "{{ cluster_id }}"
       state: present
-      engine: "{{ engine}}"
+      engine: "{{ engine }}"
       username: "{{ username }}"
       password: "{{ password }}"
     register: _result_create_source_db_cluster
@@ -163,7 +163,7 @@
       AWS_DEFAULT_REGION: "{{ aws_region }}"
     register: _result_check_db_parameter_group
     ignore_errors: True
-    changed_when: "_result_check_db_parameter_group.rc == 0"
+    changed_when: _result_check_db_parameter_group.rc == 0
 
   - name: Create DB cluster parameter group if not exists
     command: 'aws rds create-db-cluster-parameter-group --db-cluster-parameter-group-name {{ new_db_parameter_group_name }} --db-parameter-group-family aurora5.6 --description "Test DB cluster parameter group"'
@@ -173,13 +173,13 @@
       AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
       AWS_DEFAULT_REGION: "{{ aws_region }}"
     register: _result_create_db_parameter_group
-    when: "_result_check_db_parameter_group.rc == 0"
-
+    when: _result_check_db_parameter_group.rc != 0
 
   - name: Modify DB cluster parameter group
     rds_cluster:
       id: "{{ cluster_id }}"
       state: present
+      engine: "{{ engine }}"
       db_cluster_parameter_group_name: "{{ new_db_parameter_group_name }}"
     register: _result_modify_db_parameter_group_name
 

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
@@ -191,7 +191,7 @@
         - "'cluster_create_time' in _result_modify_db_parameter_group_name"
         - _result_modify_db_parameter_group_name.copy_tags_to_snapshot == false
         - "'db_cluster_arn' in _result_modify_db_parameter_group_name"
-        - "_result_modify_db_parameter_group_name.db_cluster_identifier == '{{ cluster_id }}'"
+        - "_result_modify_db_parameter_group_name.db_cluster_identifier == '{{ new_cluster_id }}'"
         - "'db_cluster_parameter_group' in _result_modify_db_parameter_group_name"
         - "'db_cluster_resource_id' in _result_modify_db_parameter_group_name"
         - "'endpoint' in _result_modify_db_parameter_group_name"

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
@@ -177,10 +177,10 @@
 
   - name: Modify DB cluster parameter group
     rds_cluster:
-      id: "{{ cluster_id }}"
+      id: "{{ new_cluster_id }}"
       state: present
-      engine: "{{ engine }}"
       db_cluster_parameter_group_name: "{{ new_db_parameter_group_name }}"
+      apply_immediately: True
     register: _result_modify_db_parameter_group_name
 
   - assert:

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
@@ -179,6 +179,7 @@
     rds_cluster:
       id: "{{ new_cluster_id }}"
       state: present
+      engine: "{{ engine }}"
       db_cluster_parameter_group_name: "{{ new_db_parameter_group_name }}"
       apply_immediately: True
     register: _result_modify_db_parameter_group_name

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_modify.yml
@@ -179,7 +179,6 @@
     rds_cluster:
       id: "{{ new_cluster_id }}"
       state: present
-      engine: "{{ engine }}"
       db_cluster_parameter_group_name: "{{ new_db_parameter_group_name }}"
       apply_immediately: True
     register: _result_modify_db_parameter_group_name


### PR DESCRIPTION
##### SUMMARY

Fix KeyError when comparing state.
Fixes: [#1409 ](https://github.com/ansible-collections/community.aws/issues/1409)

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

rds_cluster.py