### PR TITLE
sns_topic - Fix Permission Issue for Cross Account Subscriptions

### DIFF
--- a/changelogs/fragments/sns_topic-cross-account.yml
+++ b/changelogs/fragments/sns_topic-cross-account.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- sns_topic - avoid fetching attributes from subscribers when not setting them, this can cause permissions issues (https://github.com/ansible-collections/community.aws/pull/1418).

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -523,13 +523,16 @@ class SnsTopicManager(object):
                 # subscription isn't defined in desired, skipping
                 continue
 
+            raw_message = self.desired_subscription_attributes[sub_key].get('RawMessageDelivery')
+            if raw_message is None:
+                continue
+
             try:
                 sub_current_attributes = self.connection.get_subscription_attributes(SubscriptionArn=sub_arn)['Attributes']
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 self.module.fail_json_aws(e, "Couldn't get subscription attributes for subscription %s" % sub_arn)
 
-            raw_message = self.desired_subscription_attributes[sub_key].get('RawMessageDelivery')
-            if raw_message is not None and 'RawMessageDelivery' in sub_current_attributes:
+            if 'RawMessageDelivery' in sub_current_attributes:
                 if sub_current_attributes['RawMessageDelivery'].lower() != raw_message.lower():
                     changed = True
                     if not self.check_mode:

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -519,8 +519,8 @@ class SnsTopicManager(object):
         for sub in list_topic_subscriptions(self.connection, self.module, self.topic_arn):
             sub_key = (sub['Protocol'], sub['Endpoint'])
             sub_arn = sub['SubscriptionArn']
-            if sub_key not in self.desired_subscription_attributes or not self.desired_subscription_attributes[sub_key]:
-                # subscription isn't defined in desired, skipping
+            if not self.desired_subscription_attributes.get(sub_key):
+                # subscription attributes aren't defined in desired, skipping
                 continue
 
             try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`sns_topic` currently fails with the following error if it has any cross account subscriptions:

```
Couldn't get subscription attributes for subscription arn:aws:sns:us-east-1:123412341234:my-sns-topic-name:555950dc-7c5f-416c-8f8e-e8f38eabfa54: An error occurred (AuthorizationError) when calling the GetSubscriptionAttributes operation: Not authorized to access this subscription
```

This happens, for example, when a Lambda function in account A is subscribed to an SNS topic in account B, as described [here](https://docs.aws.amazon.com/lambda/latest/dg/with-sns-example.html#with-sns-example-create-test-function). 

I believe this was caused by #640.

I am not sure how to write a test for this specific situation as it would require multiple AWS accounts.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sns_topic

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- community.aws.sns_topic:
    name: my-sns-topic-in-account-123412341234
    subscriptions:
      - endpoint: "arn:aws:lambda:us-east-1:567856785678:function:my-lambda-function-in-account-567856785678"
        protocol: lambda
    state: present
```