### PR TITLE
Botocore test requirement cleanup

### DIFF
--- a/tests/integration/targets/autoscaling_launch_config/meta/main.yml
+++ b/tests/integration/targets/autoscaling_launch_config/meta/main.yml
@@ -1,5 +1,2 @@
 dependencies:
   - setup_ec2_facts
-  - role: setup_botocore_pip
-    vars:
-      boto3_version: "1.17.86"

--- a/tests/integration/targets/autoscaling_launch_config/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_launch_config/tasks/main.yml
@@ -28,8 +28,6 @@
       register: lc_1_create
 
     - name: Gather information about launch configuration 1
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       community.aws.ec2_lc_info:
         name: '{{ resource_prefix }}-lc1'
       register: lc_1_info_result
@@ -77,8 +75,6 @@
       register: lc_2_create
 
     - name: Gather information about launch configuration 2
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       community.aws.ec2_lc_info:
         name: '{{ resource_prefix }}-lc2'
       register: lc_2_info_result
@@ -113,8 +109,6 @@
           - '"autoscaling:CreateLaunchConfiguration" not in lc_2_create_idem.resource_actions'
 
     - name: Create launch configuration 3 - test throughput parameter
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       community.aws.ec2_lc:
         name: '{{ resource_prefix }}-lc3'
         image_id: '{{ ec2_ami_id }}'
@@ -128,8 +122,6 @@
       register: lc_3_create
 
     - name: Gather information about launch configuration 3
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       community.aws.ec2_lc_info:
         name: '{{ resource_prefix }}-lc3'
       register: lc_3_info_result
@@ -145,8 +137,6 @@
           - '"autoscaling:CreateLaunchConfiguration" in lc_3_create.resource_actions'
 
     - name: Create launch configuration 3 - Idempotency
-      vars:
-          ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       community.aws.ec2_lc:
         name: '{{ resource_prefix }}-lc3'
         image_id: '{{ ec2_ami_id }}'

--- a/tests/integration/targets/ec2_launch_template/meta/main.yml
+++ b/tests/integration/targets/ec2_launch_template/meta/main.yml
@@ -2,4 +2,4 @@ dependencies:
   - setup_ec2_facts
   - role: setup_botocore_pip
     vars:
-      boto3_version: "1.20.30"
+      botocore_version: "1.23.30"

--- a/tests/integration/targets/wafv2/meta/main.yml
+++ b/tests/integration/targets/wafv2/meta/main.yml
@@ -1,5 +1,1 @@
-dependencies:
-  - role: setup_botocore_pip
-    vars:
-      boto3_version: "1.18.0"
-      botocore_version: "1.21.0"
+dependencies: []

--- a/tests/integration/targets/wafv2/tasks/create_webacl.yml
+++ b/tests/integration/targets/wafv2/tasks/create_webacl.yml
@@ -2,10 +2,7 @@
 ## Create web acl
 #######################
 
-- name: Wrap test in virtualenv created above (use other python interpreter)
-  vars:
-    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
-  block:
+- block:
 
     - name: check_mode create web acl
       wafv2_web_acl:

--- a/tests/integration/targets/wafv2/tasks/rule_group.yml
+++ b/tests/integration/targets/wafv2/tasks/rule_group.yml
@@ -11,9 +11,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -49,9 +49,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -98,9 +98,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -135,9 +135,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -172,9 +172,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -209,9 +209,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -227,9 +227,9 @@
                 priority: 0
       - name: zwei
         priority: 2
-        action: 
+        action:
           block: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: ddos
@@ -250,7 +250,7 @@
                     body: {}
                   text_transformations:
                     - type: NONE
-                      priority: 0      
+                      priority: 0
     cloudwatch_metrics: yes
     tags:
       A: B
@@ -272,9 +272,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -290,9 +290,9 @@
                 priority: 0
       - name: zwei
         priority: 2
-        action: 
+        action:
           block: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: ddos
@@ -313,7 +313,7 @@
                     body: {}
                   text_transformations:
                     - type: NONE
-                      priority: 0 
+                      priority: 0
     cloudwatch_metrics: yes
     tags:
       A: B
@@ -335,9 +335,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -353,9 +353,9 @@
                 priority: 0
       - name: zwei
         priority: 3
-        action: 
+        action:
           block: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: ddos
@@ -376,7 +376,7 @@
                     body: {}
                   text_transformations:
                     - type: NONE
-                      priority: 0 
+                      priority: 0
     cloudwatch_metrics: yes
     tags:
       A: B
@@ -398,9 +398,9 @@
     rules:
       - name: eins
         priority: 1
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -416,9 +416,9 @@
                 priority: 0
       - name: zwei
         priority: 3
-        action: 
+        action:
           block: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: ddos
@@ -439,7 +439,7 @@
                     body: {}
                   text_transformations:
                     - type: NONE
-                      priority: 0 
+                      priority: 0
     cloudwatch_metrics: yes
     tags:
       A: B
@@ -461,9 +461,9 @@
     rules:
       - name: zwei
         priority: 1
-        action: 
+        action:
           block: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: ddos
@@ -487,9 +487,9 @@
                       priority: 0
       - name: eins
         priority: 2
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -525,9 +525,9 @@
     rules:
       - name: allow-admin-svg
         priority: 3
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: allow-admin-svg
@@ -574,9 +574,9 @@
     rules:
       - name: allow-admin-svg
         priority: 3
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: allow-admin-svg
@@ -611,9 +611,9 @@
     rules:
       - name: allow-admin-svg
         priority: 3
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: allow-admin-svg
@@ -646,9 +646,9 @@
     rules:
       - name: allow-admin-svg
         priority: 3
-        action: 
+        action:
           allow: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: allow-admin-svg

--- a/tests/integration/targets/wafv2/tasks/test_webacl.yml
+++ b/tests/integration/targets/wafv2/tasks/test_webacl.yml
@@ -25,9 +25,9 @@
     rules:
       - name: zwei
         priority: 2
-        action: 
+        action:
           block: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: ddos
@@ -40,9 +40,9 @@
                 priority: 0
       - name: admin_protect
         priority: 1
-        override_action: 
+        override_action:
           none: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -75,9 +75,9 @@
     rules:
       - name: bla
         priority: 8
-        override_action: 
+        override_action:
           none: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: fsd
@@ -120,9 +120,9 @@
     rules:
       - name: admin_protect
         priority: 1
-        override_action: 
+        override_action:
           none: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: admin_protect
@@ -164,9 +164,9 @@
     rules:
       - name: admin_protect
         priority: 1
-        override_action: 
+        override_action:
           none: {}
-        visibility_config: 
+        visibility_config:
           sampled_requests_enabled: yes
           cloud_watch_metrics_enabled: yes
           metric_name: admin_protect

--- a/tests/integration/targets/wafv2_web_acl/meta/main.yml
+++ b/tests/integration/targets/wafv2_web_acl/meta/main.yml
@@ -1,4 +1,1 @@
-dependencies:
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.20.40"
+dependencies: []

--- a/tests/integration/targets/wafv2_web_acl/tasks/main.yml
+++ b/tests/integration/targets/wafv2_web_acl/tasks/main.yml
@@ -5,8 +5,6 @@
       aws_secret_key: "{{ aws_secret_key }}"
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
-  vars:
-    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   block:
 
     #######################


### PR DESCRIPTION
##### SUMMARY

When updating the minimum botocore/boto3 for the collection, I missed cleaning up some of integration tests which no longer need a newer version than the collection supports

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/autoscaling_launch_config
tests/integration/targets/ec2_launch_template
tests/integration/targets/wafv2
tests/integration/targets/wafv2_web_acl

##### ADDITIONAL INFORMATION
