### PR TITLE
Fix detection of ssm connection bucket region

### DIFF
--- a/changelogs/fragments/1428-aws-ssm-missing-credentials.yml
+++ b/changelogs/fragments/1428-aws-ssm-missing-credentials.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - aws_ssm - fixes S3 bucket region detection by ensuring boto client has correct credentials and exists in correct partition
+  - aws_ssm - fixes S3 bucket region detection by ensuring boto client has correct credentials and exists in correct partition (https://github.com/ansible-collections/community.aws/pull/1428/files).

--- a/changelogs/fragments/1428-aws-ssm-missing-credentials.yml
+++ b/changelogs/fragments/1428-aws-ssm-missing-credentials.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - fixes S3 bucket region detection by ensuring boto client has correct credentials and exists in correct partition

--- a/changelogs/fragments/1428-aws-ssm-missing-credentials.yml
+++ b/changelogs/fragments/1428-aws-ssm-missing-credentials.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - aws_ssm - fixes S3 bucket region detection by ensuring boto client has correct credentials and exists in correct partition (https://github.com/ansible-collections/community.aws/pull/1428/files).
+  - aws_ssm - fixes S3 bucket region detection by ensuring boto client has correct credentials and exists in correct partition (https://github.com/ansible-collections/community.aws/pull/1428).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -534,12 +534,14 @@ class Connection(ConnectionBase):
     def _get_url(self, client_method, bucket_name, out_path, http_method, profile_name, extra_args=None):
         ''' Generate URL for get_object / put_object '''
 
-        bucket_location = boto3.client('s3').get_bucket_location(
+        region_name = self.get_option('region') or 'us-east-1'
+
+        bucket_location = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name).get_bucket_location(
             Bucket=(self.get_option('bucket_name')),
         )
-        region_name = bucket_location['LocationConstraint']
+        bucket_region_name = bucket_location['LocationConstraint']
 
-        client = self._get_boto_client('s3', region_name=region_name, profile_name=profile_name)
+        client = self._get_boto_client('s3', region_name=bucket_region_name, profile_name=profile_name)
         params = {'Bucket': bucket_name, 'Key': out_path}
         if extra_args is not None:
             params.update(extra_args)


### PR DESCRIPTION
Fix detection of ssm connection bucket region by ensuring that the boto client is created normally and able to use supported credential sources

##### SUMMARY
PR #1176 introduced detection of an S3 bucket's region to handle cases where the bucket is in a different region than the SSM connection itself. This change did not use the preferred mechanism for creating client objects, which caused it to not have access to credentials from all supported sources. It also broke the ability to use this plugin in partitions other than `aws`. (e.g. `aws-us-gov`).

This change fixes this by building the bucket location client using `_get_boto_client` and the region for the connection to ensure it is both getting the proper credentials and starting in a region from the same partition as the client itself. From the default global region (or a hard-coded region), it will detect the bucket's region and continue S3 API calls using the bucket's own region.

Fixes bug introduced from #1176 
Fixes #1413

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
aws_ssm connection plugin

