### PR TITLE
Changelog Rename ec2_url to endpoint_url

### DIFF
--- a/changelogs/fragments/992-ec2_url.yml
+++ b/changelogs/fragments/992-ec2_url.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- community.aws modules - the ``ec2_url`` parameter has been renamed to ``endpoint_url`` for consistency, ``ec2_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/992).


### PR DESCRIPTION
##### SUMMARY

In https://github.com/ansible-collections/amazon.aws/pull/992 ec2_url was renamed to endpoint_url, with ec2_url remaining as an alias.  This fragment is to improve visibility for a cross-collection change.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

changelogs/fragments/

##### ADDITIONAL INFORMATION