### PR TITLE
Make sure community.aws docs are built with access to amazon.aws fragments

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
+      extra-collections: 'amazon.aws'
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY

missed in #1436 resulting in failed builds

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

.github/workflows/docs-push.yml

##### ADDITIONAL INFORMATION
