### PR TITLE
[main] docs-build - point to github for collection source

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
-      extra-collections: 'amazon.aws'
+      extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
 
 
   build-docs:
@@ -29,7 +29,7 @@ jobs:
     with:
       init-lenient: true
       init-fail-on-error: false
-      extra-collections: 'amazon.aws'
+      extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
 
   comment:
     permissions:

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
-      extra-collections: 'amazon.aws'
+      extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY

We currently build the github-pages using amazon.aws from galaxy - pull it directly from github so things like python/SDK requirements match the current branch.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

.github/workflows/

##### ADDITIONAL INFORMATION

See 
https://github.com/tremble/community.aws/runs/8270312560?check_suite_focus=true  (main)
https://github.com/tremble/community.aws/runs/8270362640?check_suite_focus=true (stable branch)

For me testing this out