### PR TITLE
Allow to use labels from other amazon.aws docsites

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -31,6 +31,8 @@ jobs:
       init-lenient: true
       init-fail-on-error: false
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
+      provide-link-targets: |
+        ansible_collections.amazon.aws.cloudtrail
 
   comment:
     permissions:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -19,7 +19,8 @@ jobs:
       init-lenient: false
       init-fail-on-error: true
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
-
+      provide-link-targets: |
+        ansible_collections.amazon.aws.cloudtrail
 
   build-docs:
     permissions:

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -22,6 +22,8 @@ jobs:
       init-lenient: false
       init-fail-on-error: true
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
+      provide-link-targets: |
+        ansible_collections.amazon.aws.cloudtrail
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow to use labels from other amazon.aws docsites. See https://github.com/ansible-collections/community.aws/pull/1459

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

