### PR TITLE
Attempt to fix the docs workflows again

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -20,7 +20,7 @@ jobs:
       init-fail-on-error: true
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
       provide-link-targets: |
-        ansible_collections.amazon.aws.cloudtrail
+        ansible_collections.amazon.aws.cloudtrail_module
 
   build-docs:
     permissions:
@@ -32,7 +32,7 @@ jobs:
       init-fail-on-error: false
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
       provide-link-targets: |
-        ansible_collections.amazon.aws.cloudtrail
+        ansible_collections.amazon.aws.cloudtrail_module
 
   comment:
     permissions:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -19,6 +19,7 @@ jobs:
       init-lenient: false
       init-fail-on-error: true
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
+      # Please also update docs-push.yml
       provide-link-targets: |
         ansible_collections.amazon.aws.cloudtrail_module
 
@@ -31,6 +32,7 @@ jobs:
       init-lenient: true
       init-fail-on-error: false
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
+      # Please also update docs-push.yml
       provide-link-targets: |
         ansible_collections.amazon.aws.cloudtrail_module
 

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -19,11 +19,11 @@ jobs:
     name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
     with:
-      init-lenient: false
+      init-lenient: true
       init-fail-on-error: true
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
-      provide-link-targets: |
-        ansible_collections.amazon.aws.cloudtrail
+#      provide-link-targets: |
+#        ansible_collections.amazon.aws.cloudtrail_module
 
   publish-docs-gh-pages:
     # use to prevent running on forks

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -22,8 +22,9 @@ jobs:
       init-lenient: true
       init-fail-on-error: true
       extra-collections: 'git+https://github.com/ansible-collections/amazon.aws.git,main'
-#      provide-link-targets: |
-#        ansible_collections.amazon.aws.cloudtrail_module
+      # Please also update docs-pr.yml
+      provide-link-targets: |
+        ansible_collections.amazon.aws.cloudtrail_module
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY

Docs workflows are currently broken because we're using `<module_name>` instead of `<module_name>_module` in `provide-link-targets`

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

.github/workflow

##### ADDITIONAL INFORMATION
