### PR TITLE
tests/acm_certificate: retries aws_acm_info called when needed

### DIFF
--- a/changelogs/fragments/tests-acm_certificate.yaml
+++ b/changelogs/fragments/tests-acm_certificate.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Improve the reliability of cm_certificate integration tests." 

--- a/tests/integration/targets/acm_certificate/tasks/main.yml
+++ b/tests/integration/targets/acm_certificate/tasks/main.yml
@@ -505,6 +505,8 @@
       tags:
         Name: '{{ chained_cert.name }}'
     register: check_chain
+    until: check_chain.certificates|length > 0
+    retries: 3
   - name: check chain of cert we just uploaded
     assert:
       that:
@@ -545,6 +547,8 @@
       tags:
         Name: '{{ chained_cert.name }}'
     register: check_chain_2
+    until: check_chain_2.certificates|length > 0
+    retries: 3
   - name: check chain of cert we just uploaded
     assert:
       that:


### PR DESCRIPTION
The `aws_acm_info` may return an empty list if a certificate has just been recreated (race condition). We now retry 3 times until we've got a list.
