### PR TITLE
tests/autoscaling_scheduled_action: use default botocore version

### DIFF
--- a/changelogs/fragments/tests-autoscaling_scheduled_action.yaml
+++ b/changelogs/fragments/tests-autoscaling_scheduled_action.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "tests/autoscaling_scheduled_action: Use the regular supported version of botocore during the tests."

--- a/tests/integration/targets/autoscaling_scheduled_action/meta/main.yml
+++ b/tests/integration/targets/autoscaling_scheduled_action/meta/main.yml
@@ -1,5 +1,2 @@
 dependencies:
   - role: setup_ec2_facts
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.20.24"

--- a/tests/integration/targets/autoscaling_scheduled_action/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_scheduled_action/tasks/main.yml
@@ -10,284 +10,279 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - name: Run tests in virtualenv
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
-      block:
-        ## Set up the testing dependencies: VPC, subnet, security group, and launch configuration
-        - name: Create VPC for use in testing
-          ec2_vpc_net:
-            name: "{{ resource_prefix }}-vpc"
-            cidr_block: 10.55.77.0/24
-            tenancy: default
-          register: testing_vpc
+    ## Set up the testing dependencies: VPC, subnet, security group, and launch configuration
+    - name: Create VPC for use in testing
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.55.77.0/24
+        tenancy: default
+      register: testing_vpc
 
-        - name: Create subnet for use in testing
-          ec2_vpc_subnet:
-            state: present
-            vpc_id: "{{ testing_vpc.vpc.id }}"
-            cidr: 10.55.77.0/24
-            az: "{{ aws_region }}a"
-            resource_tags:
-              Name: "{{ resource_prefix }}-subnet"
-          register: testing_subnet
+    - name: Create subnet for use in testing
+      ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.55.77.0/24
+        az: "{{ aws_region }}a"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet"
+      register: testing_subnet
 
-        - name: create a security group with the vpc created in the ec2_setup
-          ec2_group:
-            name: "{{ resource_prefix }}-sg"
-            description: a security group for ansible tests
-            vpc_id: "{{ testing_vpc.vpc.id }}"
-            rules:
-              - proto: tcp
-                from_port: 22
-                to_port: 22
-                cidr_ip: 0.0.0.0/0
-              - proto: tcp
-                from_port: 80
-                to_port: 80
-                cidr_ip: 0.0.0.0/0
-          register: sg
+    - name: create a security group with the vpc created in the ec2_setup
+      ec2_group:
+        name: "{{ resource_prefix }}-sg"
+        description: a security group for ansible tests
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 0.0.0.0/0
+          - proto: tcp
+            from_port: 80
+            to_port: 80
+            cidr_ip: 0.0.0.0/0
+      register: sg
 
-        - name: ensure launch configs exist
-          ec2_lc:
-            name: "{{ resource_prefix }}-lc"
-            assign_public_ip: true
-            image_id: "{{ ec2_ami_id }}"
-            security_groups: "{{ sg.group_id }}"
-            instance_type: t3.micro
+    - name: ensure launch configs exist
+      ec2_lc:
+        name: "{{ resource_prefix }}-lc"
+        assign_public_ip: true
+        image_id: "{{ ec2_ami_id }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: t3.micro
 
-        - name: Create ASG ready
-          ec2_asg:
-            name: "{{ resource_prefix }}-asg"
-            launch_config_name: "{{ resource_prefix }}-lc"
-            desired_capacity: 1
-            min_size: 1
-            max_size: 2
-            vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
-            state: present
-            wait_for_instances: yes
-          register: output
+    - name: Create ASG ready
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 2
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        wait_for_instances: yes
+      register: output
 
-        - assert:
-            that:
-              - "output.viable_instances == 1"
+    - assert:
+        that:
+          - "output.viable_instances == 1"
 
-        ## Create minimal basic scheduled action
-        - name: Create basic scheduled_action - check_mode
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 08:00 UTC
-            recurrence: 40 22 * * 1-5
-            desired_capacity: 2
-            state: present
-          register: scheduled_action
-          check_mode: True
+    ## Create minimal basic scheduled action
+    - name: Create basic scheduled_action - check_mode
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 08:00 UTC
+        recurrence: 40 22 * * 1-5
+        desired_capacity: 2
+        state: present
+      register: scheduled_action
+      check_mode: True
 
-        - name: Check results - Create basic scheduled_action - check_mode
-          assert:
-            that:
-              - scheduled_action is successful
-              - scheduled_action is changed
+    - name: Check results - Create basic scheduled_action - check_mode
+      assert:
+        that:
+          - scheduled_action is successful
+          - scheduled_action is changed
 
-        - name: Create basic scheduled_action
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 08:00 UTC
-            recurrence: 40 22 * * 1-5
-            desired_capacity: 2
-            state: present
-          register: scheduled_action
+    - name: Create basic scheduled_action
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 08:00 UTC
+        recurrence: 40 22 * * 1-5
+        desired_capacity: 2
+        state: present
+      register: scheduled_action
 
-        - name: Check results - Create basic scheduled_action
-          assert:
-            that:
-              - scheduled_action is successful
-              - scheduled_action is changed
-              - scheduled_action.scheduled_action_name == "{{ resource_prefix }}-test"
-              - scheduled_action.desired_capacity == 2
+    - name: Check results - Create basic scheduled_action
+      assert:
+        that:
+          - scheduled_action is successful
+          - scheduled_action is changed
+          - scheduled_action.scheduled_action_name == "{{ resource_prefix }}-test"
+          - scheduled_action.desired_capacity == 2
 
-        - name: Create basic scheduled_action - idempotent
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 08:00 UTC
-            recurrence: 40 22 * * 1-5
-            desired_capacity: 2
-            state: present
-          register: scheduled_action
+    - name: Create basic scheduled_action - idempotent
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 08:00 UTC
+        recurrence: 40 22 * * 1-5
+        desired_capacity: 2
+        state: present
+      register: scheduled_action
 
-        - name: Check results - Create advanced scheduled_action - idempotent
-          assert:
-            that:
-              - scheduled_action is successful
-              - scheduled_action is not changed
+    - name: Check results - Create advanced scheduled_action - idempotent
+      assert:
+        that:
+          - scheduled_action is successful
+          - scheduled_action is not changed
 
-        ## Update minimal basic scheduled action
-        - name: Update basic scheduled_action - check_mode
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 08:00 UTC
-            recurrence: 40 22 * * 1-5
-            desired_capacity: 3
-            min_size: 3
-            state: present
-          register: scheduled_action
-          check_mode: True
+    ## Update minimal basic scheduled action
+    - name: Update basic scheduled_action - check_mode
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 08:00 UTC
+        recurrence: 40 22 * * 1-5
+        desired_capacity: 3
+        min_size: 3
+        state: present
+      register: scheduled_action
+      check_mode: True
 
-        - name: Check results - Update basic scheduled_action - check_mode
-          assert:
-            that:
-              - scheduled_action is successful
-              - scheduled_action is changed
+    - name: Check results - Update basic scheduled_action - check_mode
+      assert:
+        that:
+          - scheduled_action is successful
+          - scheduled_action is changed
 
-        - name: Update basic scheduled_action
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 08:00 UTC
-            recurrence: 40 22 * * 1-5
-            desired_capacity: 3
-            min_size: 3
-            state: present
-          register: scheduled_action
+    - name: Update basic scheduled_action
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 08:00 UTC
+        recurrence: 40 22 * * 1-5
+        desired_capacity: 3
+        min_size: 3
+        state: present
+      register: scheduled_action
 
-        - name: Check results - Update basic scheduled_action
-          assert:
-            that:
-              - scheduled_action is successful
-              - scheduled_action is changed
-              - scheduled_action.scheduled_action_name == "{{ resource_prefix }}-test"
-              - scheduled_action.desired_capacity == 3
-              - scheduled_action.min_size == 3
+    - name: Check results - Update basic scheduled_action
+      assert:
+        that:
+          - scheduled_action is successful
+          - scheduled_action is changed
+          - scheduled_action.scheduled_action_name == "{{ resource_prefix }}-test"
+          - scheduled_action.desired_capacity == 3
+          - scheduled_action.min_size == 3
 
-        - name: Update basic scheduled_action - idempotent
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 08:00 UTC
-            recurrence: 40 22 * * 1-5
-            desired_capacity: 3
-            min_size: 3
-            state: present
-          register: scheduled_action
+    - name: Update basic scheduled_action - idempotent
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 08:00 UTC
+        recurrence: 40 22 * * 1-5
+        desired_capacity: 3
+        min_size: 3
+        state: present
+      register: scheduled_action
 
-        - name: Check results - Update advanced scheduled_action - idempotent
-          assert:
-            that:
-              - scheduled_action is successful
-              - scheduled_action is not changed
+    - name: Check results - Update advanced scheduled_action - idempotent
+      assert:
+        that:
+          - scheduled_action is successful
+          - scheduled_action is not changed
 
-        ## Create advanced scheduled action
-        - name: Create advanced scheduled_action - check_mode
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test"
-            start_time: 2022 October 25 09:00 UTC
-            end_time: 2022 October 25 10:00 UTC
-            time_zone: Europe/London
-            recurrence: 40 22 * * 1-5
-            min_size: 2
-            max_size: 5
-            desired_capacity: 2
-            state: present
-          register: advanced_scheduled_action
-          check_mode: True
+    ## Create advanced scheduled action
+    - name: Create advanced scheduled_action - check_mode
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test"
+        start_time: 2022 October 25 09:00 UTC
+        end_time: 2022 October 25 10:00 UTC
+        time_zone: Europe/London
+        recurrence: 40 22 * * 1-5
+        min_size: 2
+        max_size: 5
+        desired_capacity: 2
+        state: present
+      register: advanced_scheduled_action
+      check_mode: True
 
-        - name: Check results - Create basic scheduled_action - check_mode
-          assert:
-            that:
-              - advanced_scheduled_action is successful
-              - advanced_scheduled_action is changed
+    - name: Check results - Create basic scheduled_action - check_mode
+      assert:
+        that:
+          - advanced_scheduled_action is successful
+          - advanced_scheduled_action is changed
 
-        - name: Create advanced scheduled_action
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test1"
-            start_time: 2022 October 25 09:00 UTC
-            end_time: 2022 October 25 10:00 UTC
-            time_zone: Europe/London
-            recurrence: 40 22 * * 1-5
-            min_size: 2
-            max_size: 5
-            desired_capacity: 2
-            state: present
-          register: advanced_scheduled_action
+    - name: Create advanced scheduled_action
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test1"
+        start_time: 2022 October 25 09:00 UTC
+        end_time: 2022 October 25 10:00 UTC
+        time_zone: Europe/London
+        recurrence: 40 22 * * 1-5
+        min_size: 2
+        max_size: 5
+        desired_capacity: 2
+        state: present
+      register: advanced_scheduled_action
 
-        - name: Check results - Create advanced scheduled_action
-          assert:
-            that:
-              - advanced_scheduled_action is successful
-              - advanced_scheduled_action is changed
-              - advanced_scheduled_action.scheduled_action_name == "{{ resource_prefix }}-test1"
-              - advanced_scheduled_action.desired_capacity == 2
-              - advanced_scheduled_action.min_size == 2
-              - advanced_scheduled_action.max_size == 5
-              - advanced_scheduled_action.time_zone == "Europe/London"
+    - name: Check results - Create advanced scheduled_action
+      assert:
+        that:
+          - advanced_scheduled_action is successful
+          - advanced_scheduled_action is changed
+          - advanced_scheduled_action.scheduled_action_name == "{{ resource_prefix }}-test1"
+          - advanced_scheduled_action.desired_capacity == 2
+          - advanced_scheduled_action.min_size == 2
+          - advanced_scheduled_action.max_size == 5
+          - advanced_scheduled_action.time_zone == "Europe/London"
 
-        - name: Create advanced scheduled_action - idempotent
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test1"
-            start_time: 2022 October 25 09:00 UTC
-            end_time: 2022 October 25 10:00 UTC
-            time_zone: Europe/London
-            recurrence: 40 22 * * 1-5
-            min_size: 2
-            max_size: 5
-            desired_capacity: 2
-            state: present
-          register: advanced_scheduled_action
+    - name: Create advanced scheduled_action - idempotent
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test1"
+        start_time: 2022 October 25 09:00 UTC
+        end_time: 2022 October 25 10:00 UTC
+        time_zone: Europe/London
+        recurrence: 40 22 * * 1-5
+        min_size: 2
+        max_size: 5
+        desired_capacity: 2
+        state: present
+      register: advanced_scheduled_action
 
-        - name: Check results - Create basic scheduled_action - idempotent
-          assert:
-            that:
-              - advanced_scheduled_action is successful
-              - advanced_scheduled_action is not changed
+    - name: Check results - Create basic scheduled_action - idempotent
+      assert:
+        that:
+          - advanced_scheduled_action is successful
+          - advanced_scheduled_action is not changed
 
-        ## Delete scheduled action
-        - name: Delete scheduled_action - check_mode
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test1"
-            state: absent
-          register: scheduled_action_deletion
-          check_mode: True
+    ## Delete scheduled action
+    - name: Delete scheduled_action - check_mode
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test1"
+        state: absent
+      register: scheduled_action_deletion
+      check_mode: True
 
-        - name: Delete scheduled_action - check_mode
-          assert:
-            that:
-              - scheduled_action_deletion is successful
-              - scheduled_action_deletion is changed
+    - name: Delete scheduled_action - check_mode
+      assert:
+        that:
+          - scheduled_action_deletion is successful
+          - scheduled_action_deletion is changed
 
-        - name: Delete scheduled_action
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test1"
-            state: absent
-          register: scheduled_action_deletion
+    - name: Delete scheduled_action
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test1"
+        state: absent
+      register: scheduled_action_deletion
 
-        - name: Delete scheduled_action
-          assert:
-            that:
-              - scheduled_action_deletion is successful
-              - scheduled_action_deletion is changed
+    - name: Delete scheduled_action
+      assert:
+        that:
+          - scheduled_action_deletion is successful
+          - scheduled_action_deletion is changed
 
-        - name: Delete scheduled_action - idempotent
-          ec2_asg_scheduled_action:
-            autoscaling_group_name: "{{ resource_prefix }}-asg"
-            scheduled_action_name: "{{ resource_prefix }}-test1"
-            state: absent
-          register: scheduled_action_deletion
+    - name: Delete scheduled_action - idempotent
+      ec2_asg_scheduled_action:
+        autoscaling_group_name: "{{ resource_prefix }}-asg"
+        scheduled_action_name: "{{ resource_prefix }}-test1"
+        state: absent
+      register: scheduled_action_deletion
 
-        - name: Delete scheduled_action - idempotent
-          assert:
-            that:
-              - scheduled_action_deletion is successful
-              - scheduled_action_deletion is not changed
-
+    - name: Delete scheduled_action - idempotent
+      assert:
+        that:
+          - scheduled_action_deletion is successful
+          - scheduled_action_deletion is not changed
   always:
     - name: Remove ASG
       ec2_asg:


### PR DESCRIPTION
pip was not able anymore to pull botocore 1.20.24 with an uncapped boto3 version.
To address this we just remove the ad-hoc virtualenv.
botocore 1.20.24 is unsupported anyway.
