### PR TITLE
tests/ec2_vpc_egress_igw: avoid a InvalidVpcId.Malformed error

### DIFF
--- a/tests/integration/targets/ec2_vpc_egress_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_egress_igw/tasks/main.yml
@@ -26,7 +26,7 @@
   - name: test failure with non-existent VPC ID
     ec2_vpc_egress_igw:
       state: present
-      vpc_id: vpc-012345678
+      vpc_id: vpc-02394e50abc1807e8
     register: result
     ignore_errors: true
 


### PR DESCRIPTION
Ensures the "test failure with non-existent VPC ID" test uses a properly
formatted VPC ID.
Otherwise, the API now returns the following error:

```
"error": {
    "code": "InvalidVpcId.Malformed",
    "message": "The vpc ID vpc-012345678 is malformed"
},
```
