### PR TITLE
ec2_placement_group: Handle a potential race creation during create

### DIFF
--- a/changelogs/fragments/ec2_placement_group_race_on_create.yaml
+++ b/changelogs/fragments/ec2_placement_group_race_on_create.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "ec2_placement_group - Handle a potential race creation during the creation of a new Placement Group (https://github.com/ansible-collections/community.aws/pull/1477)."


### PR DESCRIPTION
Address a race condition during the creation of a new Placement Group.
The consequence was a `"placement_group": null` in output after a
successful new creation.

e.g: https://af0ac3e5f4e1620a8d63-ed3785e7f94a59162d05eede0959ab4b.ssl.cf5.rackcdn.com/1459/71e1a28c8ab7c12471b7f1cce5a37846ff642439/check/integration-community.aws-12/aa426fe/job-output.txt
