### PR TITLE
tests: dedicate more time to ec2_transit_gateway_vpc_attachment

### DIFF
--- a/changelogs/fragments/ec2_transit_gateway_vpc_attachment_increase_test_duration.yaml
+++ b/changelogs/fragments/ec2_transit_gateway_vpc_attachment_increase_test_duration.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "ec2_transit_gateway_vpc_attachment - Increase the test duration (https://github.com/ansible-collections/community.aws/pull/1494)."

--- a/tests/integration/targets/ec2_transit_gateway_vpc_attachment/aliases
+++ b/tests/integration/targets/ec2_transit_gateway_vpc_attachment/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-time=21m
+time=35m
 # ec2_transit_gateway_vpc_attachment_info


### PR DESCRIPTION
ec2_transit_gateway_vpc_attachment took 0:33:49 during the following
buildset:
https://ansible.softwarefactory-project.io/zuul/buildset/92340ac9ef144d5ca9e59f7cd3769451
