### PR TITLE
[PR #1468/1cd7cebb backport][stable-3] tests/autoscaling_{group,lifecycle_hook}: use setup_ec2_facts

### DIFF
--- a/tests/integration/targets/ec2_asg/main.yml
+++ b/tests/integration/targets/ec2_asg/main.yml
@@ -20,6 +20,8 @@
       setup_run_once: yes
     block:
     - include_role:
+        name: 'setup_ec2_facts'
+    - include_role:
         name: 'ec2_asg'
         tasks_from: env_setup.yml
     rescue:

--- a/tests/integration/targets/ec2_asg/meta/main.yml
+++ b/tests/integration/targets/ec2_asg/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_ec2_facts

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/defaults/main.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-# defaults file for ec2_asg
-# Amazon Linux 2 AMI 2019.06.12 (HVM), GP2 Volume Type
-ec2_ami_name: 'amzn2-ami-hvm-2.0.20190612-x86_64-gp2'
+load_balancer_name: "{{ tiny_prefix }}-lb"

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/create_update_delete.yml
@@ -26,7 +26,7 @@
       ec2_lc:
         name: "{{ item }}"
         assign_public_ip: true
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         user_data: |
           #cloud-config
           package_upgrade: true
@@ -473,7 +473,7 @@
     - name: create launch template for autoscaling group to test its mixed instances policy
       ec2_launch_template:
         template_name: "{{ resource_prefix }}-lt"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         instance_type: t3.micro
         credit_specification:
           cpu_credits: standard

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/env_setup.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/env_setup.yml
@@ -2,17 +2,6 @@
 
   block:
 
-    # ============================================================
-
-    - name: Find AMI to use
-      ec2_ami_info:
-        owners: 'amazon'
-        filters:
-          name: '{{ ec2_ami_name }}'
-      register: ec2_amis
-    - set_fact:
-        ec2_ami_image: '{{ ec2_amis.images[0].image_id }}'
-
     # Set up the testing dependencies: VPC, subnet, security group, and two launch configurations
     - name: Create VPC for use in testing
       ec2_vpc_net:

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/instance_detach.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/instance_detach.yml
@@ -4,7 +4,7 @@
     - name: create a launch configuration
       ec2_lc:
         name: "{{ resource_prefix }}-lc-detach-test"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         region: "{{ aws_region }}"
         instance_type: t2.micro
         assign_public_ip: yes

--- a/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/tag_operations.yml
+++ b/tests/integration/targets/ec2_asg/roles/ec2_asg/tasks/tag_operations.yml
@@ -4,7 +4,7 @@
     - name: create a launch configuration
       ec2_lc:
         name: "{{ resource_prefix }}-lc-tag-test"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         region: "{{ aws_region }}"
         instance_type: t2.micro
         assign_public_ip: yes


### PR DESCRIPTION
amzn2-ami-hvm-2.0.20190612-x86_64-gp2 is not available anymore, we now use setup_ec2_facts to get the right AMI ID.

Reviewed-by: Mark Chappell <None>

##### SUMMARY

Partial backport of #1468 (lifecycle hooks didn't exist in stable-3)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/ec2_asg

##### ADDITIONAL INFORMATION