### PR TITLE
EFS: Added backup option

### DIFF
--- a/tests/integration/targets/efs/tasks/main.yml
+++ b/tests/integration/targets/efs/tasks/main.yml
@@ -304,6 +304,74 @@
           - efs_result is not changed
 
     # ============================================================
+    - name: Efs enable automatic backup 
+      efs:
+        state: present
+        name: "{{ efs_name }}-test-efs"
+        tags:
+            Name: "{{ efs_name }}-test-tag"
+            Purpose: file-storage
+        targets:
+            - subnet_id: "{{testing_subnet_a.subnet.id}}"
+            - subnet_id: "{{testing_subnet_b.subnet.id}}"
+        backup: 'enabled'
+      register: efs_result
+    
+    - assert:
+        that:
+          - efs_result is changed
+
+    - name: Efs enable automatic backup - idempotency
+      efs:
+        state: present
+        name: "{{ efs_name }}-test-efs"
+        tags:
+            Name: "{{ efs_name }}-test-tag"
+            Purpose: file-storage
+        targets:
+            - subnet_id: "{{testing_subnet_a.subnet.id}}"
+            - subnet_id: "{{testing_subnet_b.subnet.id}}"
+        backup: 'enabled'
+      register: efs_result
+    
+    - assert:
+        that:
+          - efs_result is not changed
+
+    - name: Efs disable automatic backup 
+      efs:
+        state: present
+        name: "{{ efs_name }}-test-efs"
+        tags:
+            Name: "{{ efs_name }}-test-tag"
+            Purpose: file-storage
+        targets:
+            - subnet_id: "{{testing_subnet_a.subnet.id}}"
+            - subnet_id: "{{testing_subnet_b.subnet.id}}"
+        backup: 'disabled'
+      register: efs_result
+
+    - assert:
+        that:
+          - efs_result is changed
+
+    - name: Efs disable automatic backup - idempotency
+      efs:
+        state: present
+        name: "{{ efs_name }}-test-efs"
+        tags:
+            Name: "{{ efs_name }}-test-tag"
+            Purpose: file-storage
+        targets:
+            - subnet_id: "{{testing_subnet_a.subnet.id}}"
+            - subnet_id: "{{testing_subnet_b.subnet.id}}"
+        backup: 'disabled'
+      register: efs_result
+
+    - assert:
+        that:
+          - efs_result is not changed
+    # ============================================================
     - name: Query unknown EFS by tag
       efs_info:
         tags:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added backup option to the `efs` module which enables automatic backup of the file system.
Addresses issue #1266 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Impacted component: `efs` module
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To enable automatic backup, you can add the following to the playbook
```
- name: Efs enable automatic backup 
      efs:
        state: present
        name: 'efs-name'
        tags:
            Name: 'tag-name'
        targets:
            - subnet_id: subnet-id
            - subnet_id: subnet-id
        backup: 'enabled'
```
Disabling automatic backup:

```
- name: Efs enable automatic backup 
      efs:
        state: present
        name: 'efs-name'
        tags:
            Name: 'tag-name'
        targets:
            - subnet_id: 'subnet-id'
            - subnet_id: 'subnet-id'
        backup: 'disabled'
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
