### PR TITLE
ec2_eip: apply the tags during the object creation

### DIFF
--- a/changelogs/fragments/eip-apply-tag-early.yaml
+++ b/changelogs/fragments/eip-apply-tag-early.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "ec2_eip - Don't delay the tagging of new Elastic IP (https://github.com/ansible-collections/community.aws/pull/1495)."


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/1495

Apply the tags during the Elastic IP creation using `TagSpecifications`. This to avoid
a potential race condition between the moment the object is created and the moment we apply
the tags.

See: https://github.com/ansible-collections/community.aws/pull/1495#issuecomment-1252103591
