### PR TITLE
Initial sanity ignore file for Ansible 2.15 (branching happened)

### DIFF
--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,2 @@
+plugins/modules/cloudfront_distribution_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this


### PR DESCRIPTION
##### SUMMARY

stable-2.14 was branched yesterday, with devel becoming 2.15.  As such we need to create the initial ignore file based upon the existing 2.14 file.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/sanity/ignore-2.15.txt

##### ADDITIONAL INFORMATION