### PR TITLE
DNM - debugging AWS collection build failures

### DIFF
--- a/tests/integration/targets/aws_region_info/aliases
+++ b/tests/integration/targets/aws_region_info/aliases
@@ -1,1 +1,3 @@
 cloud/aws
+
+# NUDGE

--- a/tests/integration/targets/legacy_missing_tests/aliases
+++ b/tests/integration/targets/legacy_missing_tests/aliases
@@ -31,3 +31,5 @@ redshift_cross_region_snapshots
 s3_cors
 s3_website
 storagegateway_info
+
+# NUDGE


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1637

##### SUMMARY

Having problems running integration tests at the minutes

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration

##### ADDITIONAL INFORMATION

https://97bb81bfe7670c714480-a6648ca8110212c198a9b4b05b98476d.ssl.cf5.rackcdn.com/1066/d92306fc0ae0b10cb692883a5b1378c9268f7e14/check/integration-amazon.aws-6/f91e6f5/job-output.txt

```
2022-09-26 11:00:17.105877 | TASK [ansible-test : Install python requirements]
2022-09-26 11:00:18.060437 | controller | ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/constraints.txt'
2022-09-26 11:00:18.063138 | controller | WARNING: You are using pip version 21.3.1; however, version 22.2.2 is available.
2022-09-26 11:00:18.063159 | controller | You should consider upgrading via the '/home/zuul/venv/bin/python3.9 -m pip install --upgrade pip' command.
```