### PR TITLE
Drop support for Ansible Core < 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@ The Ansible Community AWS collection includes a variety of Ansible content to he
 
 AWS related modules and plugins supported by the Ansible Cloud team are in the [amazon.aws](https://github.com/ansible-collections/amazon.aws) collection.
 
-<!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.9.10**.
+Tested with the Ansible Core 2.12, and 2.13 releases, and the current development version of Ansible. Ansible Core versions before 2.11.0 are not supported. In particular, Ansible Core 2.10 and Ansible 2.9 are not supported.
 
-Plugins and modules within a collection may be tested with only specific Ansible versions.
-A collection may contain metadata that identifies these versions.
-PEP440 is the schema used to describe the versions of Ansible.
-<!--end requires_ansible-->
+Use community.aws 4.x.y if you are using Ansible 2.9 or Ansible Core 2.10.
 
 ## Python version compatibility
 

--- a/changelogs/fragments/1541-old-ansible.yml
+++ b/changelogs/fragments/1541-old-ansible.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- community.aws collection - Support for ansible-core < 2.11 has been dropped (https://github.com/ansible-collections/community.aws/pull/1541).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.11.0'
 action_groups:
   aws:
   - accessanalyzer_validate_policy_info


### PR DESCRIPTION
##### SUMMARY

Following up on https://github.com/ansible-collections/amazon.aws/pull/1087

We only perform integration tests against milestone.  And we only perform sanity tests against 2.12+.  Ansible Core  2.11 goes out of support in [November](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

meta/runtime.yml

##### ADDITIONAL INFORMATION

We already dropped support in amazon.aws

Additionally:

- AAP 1.2 (based on 2.9) is in "Maintenance support 2" bugs and security fixes only (https://access.redhat.com/support/policy/updates/ansible-automation-platform), which we can support by backporting fixes if necessary
- Later versions of AAP support ee-2.9, however ee-2.9 is only supported for "the Ansible Core RPMs" which would mean backports
- Ansible Tower is in "Maintenance support 2" bugs and security fixes only (https://access.redhat.com/support/policy/updates/ansible-tower), with support ending in November which we can support by backporting fixes if necessary.
- Ansible Engine 2.9 support has ended already (https://access.redhat.com/support/policy/updates/ansible-engine)