### PR TITLE
Add missing redirection for module_utils/route53

### DIFF
--- a/changelogs/fragments/1541-route53-module_utills.yml
+++ b/changelogs/fragments/1541-route53-module_utills.yml
@@ -1,0 +1,2 @@
+trivial:
+- meta/runtime.yml - Add missing redirect for route53 module_utils (https://github.com/ansible-collections/community.aws/pull/1542).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -498,3 +498,6 @@ plugin_routing:
       redirect: amazon.aws.route53_info
     route53_zone:
       redirect: amazon.aws.route53_zone
+  module_utils:
+    route53:
+      redirect: amazon.aws.route53


### PR DESCRIPTION
##### SUMMARY

When migrating module_utils/route53 in #1537 we missed adding a redirection over to amazon.aws

Since this is supported, add it for completeness

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

meta/runtime.yml

##### ADDITIONAL INFORMATION
