### PR TITLE
ecs_ecr - Fix `RepositoryNotFoundException` when creating Repositories in check mode

### DIFF
--- a/changelogs/fragments/1550-ecs_ecr-RepositoryNotFound.yml
+++ b/changelogs/fragments/1550-ecs_ecr-RepositoryNotFound.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ecs_ecr - fix a ``RepositoryNotFound`` exception when trying to create repositories in check mode (https://github.com/ansible-collections/community.aws/pull/1550).

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -246,7 +246,7 @@ class EcsEcr:
                 repositoryName=name, **build_kwargs(registry_id))
             text = res.get('policyText')
             return text and json.loads(text)
-        except is_boto3_error_code('RepositoryPolicyNotFoundException'):
+        except is_boto3_error_code(['RepositoryNotFoundException', 'RepositoryPolicyNotFoundException']):
             return None
 
     def create_repository(self, registry_id, name, image_tag_mutability):
@@ -334,7 +334,7 @@ class EcsEcr:
                 repositoryName=name, **build_kwargs(registry_id))
             text = res.get('lifecyclePolicyText')
             return text and json.loads(text)
-        except is_boto3_error_code('LifecyclePolicyNotFoundException'):
+        except is_boto3_error_code(['LifecyclePolicyNotFoundException', 'RepositoryNotFoundException']):
             return None
 
     def put_lifecycle_policy(self, registry_id, name, policy_text):

--- a/tests/integration/targets/ecs_ecr/aliases
+++ b/tests/integration/targets/ecs_ecr/aliases
@@ -1,4 +1,1 @@
-# reason: boto2
-unstable
-
 cloud/aws

--- a/tests/integration/targets/ecs_ecr/tasks/main.yml
+++ b/tests/integration/targets/ecs_ecr/tasks/main.yml
@@ -58,12 +58,12 @@
       ecs_ecr:
         name: '{{ ecr_name }}'
       register: result
-      
+
     - name: it should return the repo but without a policy and not create or change
       assert:
         that:
           - result.repository
-          - not result.policy
+          - '"policy" not in result'
           - not result.created
           - not result.changed
 
@@ -136,11 +136,11 @@
       ecs_ecr:
         name: '{{ ecr_name }}'
       register: result
-      
+
     - name: it should return the policy but not create or change
       assert:
         that:
-          - result.policy
+          - '"policy" in result'
           - not result.created
           - not result.changed
 
@@ -151,30 +151,12 @@
       register: result
       check_mode: yes
 
-    - name: it should skip, change but not create, have deprecations
+    - name: it should skip, change but not create
       assert:
         that:
           - result is skipped
           - result is changed
           - not result.created
-          - result.deprecations
-
-
-    - name: When in check mode, and purging a policy that exists
-      ecs_ecr:
-        name: '{{ ecr_name }}'
-        purge_policy: yes
-      register: result
-      check_mode: yes
-
-    - name: it should skip, change but not create, no deprecations
-      assert:
-        that:
-          - result is skipped
-          - result is changed
-          - not result.created
-          - result.deprecations is not defined
-
 
     - name: When purging a policy that exists
       ecs_ecr:
@@ -290,7 +272,7 @@
         that:
           - result is changed
           - not result.created
-          - result.lifecycle_policy is defined
+          - '"lifecycle_policy" in result'
           - result.lifecycle_policy.rules|length == 1
 
 


### PR DESCRIPTION
##### SUMMARY

When trying to create a repository in check mode the module throws a `RepositoryNotFoundException` trying to access policy objects on the repositories

also fixes and re-enables basic integration tests

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ecs_ecr

##### ADDITIONAL INFORMATION
