### PR TITLE
ecs_ecr - Use compare_policies instead of naive dict sort

### DIFF
--- a/changelogs/fragments/1551-ecs_ecr-sort_json_policy.yml
+++ b/changelogs/fragments/1551-ecs_ecr-sort_json_policy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_ecr - use ``compare_policies`` when comparing lifecycle policies instead of naive ``sort_json_policy_dict`` comparisons (https://github.com/ansible-collections/community.aws/pull/1551).

--- a/plugins/modules/ecs_ecr.py
+++ b/plugins/modules/ecs_ecr.py
@@ -207,7 +207,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSM
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import sort_json_policy_dict
 
 
 def build_kwargs(registry_id):
@@ -457,17 +456,11 @@ def run(ecr, params):
 
             elif lifecycle_policy_text is not None:
                 try:
-                    lifecycle_policy = sort_json_policy_dict(lifecycle_policy)
                     result['lifecycle_policy'] = lifecycle_policy
-
                     original_lifecycle_policy = ecr.get_lifecycle_policy(
                         registry_id, name)
 
-                    if original_lifecycle_policy:
-                        original_lifecycle_policy = sort_json_policy_dict(
-                            original_lifecycle_policy)
-
-                    if original_lifecycle_policy != lifecycle_policy:
+                    if compare_policies(original_lifecycle_policy, lifecycle_policy):
                         ecr.put_lifecycle_policy(registry_id, name,
                                                  lifecycle_policy_text)
                         result['changed'] = True


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/1550

##### SUMMARY

When comparing policies on the repos ecs_ecr currently uses a very naive sort function.  Since we have something more comprehensive, use it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/ecs_ecr.py

##### ADDITIONAL INFORMATION

ecs_ecr is currently the only module using sort_json_policy_dict and it has poor test coverage.