### PR TITLE
tests: increase the default max duration of some tests

### DIFF
--- a/changelogs/fragments/integration_tests_max_duration_increase.yaml
+++ b/changelogs/fragments/integration_tests_max_duration_increase.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+- "s2_lifecycle - Increase the max duration of the integration tests (https://github.com/ansible-collections/community.aws/pull/1578)." 
+- "secretsmanager_secret - Increase the max duration of the integration tests (https://github.com/ansible-collections/community.aws/pull/1578)." 

--- a/tests/integration/targets/s3_lifecycle/aliases
+++ b/tests/integration/targets/s3_lifecycle/aliases
@@ -1,1 +1,2 @@
+time=17m
 cloud/aws

--- a/tests/integration/targets/secretsmanager_secret/aliases
+++ b/tests/integration/targets/secretsmanager_secret/aliases
@@ -1,1 +1,2 @@
+time=37m
 cloud/aws


### PR DESCRIPTION
- s3_lifecycle up to 17 minutes
- secretsmanager_secret up to 32m

See: https://ansible.softwarefactory-project.io/zuul/buildset/478fdb5e4d4f494584686371ff992a3b
