### PR TITLE
Fix broken ec2_vpc_vgw tests

### DIFF
--- a/changelogs/fragments/1579-ec2_vpc_vgw-deleted.yml
+++ b/changelogs/fragments/1579-ec2_vpc_vgw-deleted.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_vpc_vgw - update integration tests to allow for attachments being removed from the list once deleted (https://github.com/ansible-collections/community.aws/pull/1579).

--- a/tests/integration/targets/ec2_vpc_vgw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_vgw/tasks/main.yml
@@ -105,8 +105,11 @@
           - vgw_details.state == 'available'
           - '"Name" in vgw_details.resource_tags'
           - vgw_details.resource_tags.Name == vgw_name
-          - vgw_details.vpc_attachments | length == 2
-          - attach_1_description in vgw_details.vpc_attachments
+          - (
+              attach_1_description in vgw_details.vpc_attachments
+              and
+              vgw_details.vpc_attachments | length == 2
+            ) or ( vgw_details.vpc_attachments | length == 1 )
           - attach_2_description in vgw_details.vpc_attachments
 
     - name: get VPC VGW facts by Tag
@@ -138,8 +141,11 @@
           - vgw_details.state == 'available'
           - '"Name" in vgw_details.resource_tags'
           - vgw_details.resource_tags.Name == vgw_name
-          - vgw_details.vpc_attachments | length == 2
-          - attach_1_description in vgw_details.vpc_attachments
+          - (
+              attach_1_description in vgw_details.vpc_attachments
+              and
+              vgw_details.vpc_attachments | length == 2
+            ) or ( vgw_details.vpc_attachments | length == 1 )
           - attach_2_description in vgw_details.vpc_attachments
 
     # ============================================================
@@ -211,7 +217,7 @@
     - name: delete vpn gateway
       ec2_vpc_vgw:
         state: absent
-        vpn_gateway_id: '{{ vgw.vgw.id }}'
+        vpn_gateway_id: '{{ vgw.vgw.id | default(vgw_id) }}'
       ignore_errors: yes
 
     - name: delete vpc


### PR DESCRIPTION
##### SUMMARY

The APIs are no longer consistently returning deleted attachments.  Accept both the attachment being listed but marked 'deleted', and not being listed.

Amazon's APIs used to be very slow to update this, making waiting for it a bad idea.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_vgw

##### ADDITIONAL INFORMATION
