### PR TITLE
fix: always use regional S3 url

### DIFF
--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -572,11 +572,18 @@ class Connection(ConnectionBase):
         if profile_name:
             session_args['profile_name'] = profile_name
         session = boto3.session.Session(**session_args)
-
-        client = session.client(
-            service,
-            config=Config(signature_version="s3v4")
-        )
+        
+        if service == 's3' and region_name:
+            client = session.client(
+                service,
+                endpoint_url=('https://s3.' + region_name + '.amazonaws.com'),
+                config=Config(signature_version="s3v4")
+            )
+        else:
+            client = session.client(
+                service,
+                config=Config(signature_version="s3v4")
+            )
         return client
 
     @_ssm_retry


### PR DESCRIPTION
##### SUMMARY

At the moment, command used to fetch `AnsiballZ_setup.py` from S3 bucket to remote has the following shape:

```
curl 'https://BUCKET-NAME.s3.amazonaws.com/PATH/IN/BUCKET/AnsiballZ_setup.py?X-Amz-Algorithm=REST_OF_PRESIGNED_URL' -o '/RANDOM/DESTINATION/file.py'
```

Above is not suitable for S3 buckets that are recently created and results in the response along the lines of:

```
<?xml version="1.0" encoding="UTF-8"?>
<Error>
<Code>TemporaryRedirect</Code>
<Message>Please re-send this request to the specified temporary endpoint. Continue to use the original request endpoint for future requests.</Message>
<Endpoint>BUCKET-NAME.s3.REGION.amazonaws.com</Endpoint>
<Bucket>BUCKET-NAME</Bucket>
<RequestId>SOME-ID</RequestId>
<HostId>SOME-ID=</HostId>
</Error>
``` 

Resource related to the above behaviour:

https://stackoverflow.com/questions/56517156/s3-presigned-url-works-90-minutes-after-bucket-creation

This PR is attempting to fix the fact that at the moment, there is no way for this module to work with S3 buckets that are recently created. I am happy to hear any opinion on the topic, as long as this issue is resolved.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

aws ssm connection plugin

<!--- ##### ADDITIONAL INFORMATION -->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!---```paste below -->

<!--- ``` -->
