### PR TITLE
eks_cluster: adding tags to eks cluster

### DIFF
--- a/changelogs/fragments/1591-eks-add-tags-cluster.yml
+++ b/changelogs/fragments/1591-eks-add-tags-cluster.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - eks-add-tags-cluster - adding tags to eks cluster creation (https://github.com/ansible-collections/community.aws/pull/1591).
+  - eks_cluster - adding tags to eks cluster creation (https://github.com/ansible-collections/community.aws/pull/1591).

--- a/changelogs/fragments/1591-eks-add-tags-cluster.yml
+++ b/changelogs/fragments/1591-eks-add-tags-cluster.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - eks-add-tags-cluster - adding tags to eks cluster creation (https://github.com/ansible-collections/community.aws/pull/1591).

--- a/plugins/modules/eks_cluster.py
+++ b/plugins/modules/eks_cluster.py
@@ -49,7 +49,7 @@ options:
     description:
       - A dictionary of tags to add the EKS cluster.
     type: dict
-    version_added: 5.2.0
+    version_added: 5.3.0
   wait:
     description: >-
       Specifies whether the module waits until the cluster is active or deleted

--- a/plugins/modules/eks_cluster.py
+++ b/plugins/modules/eks_cluster.py
@@ -45,6 +45,10 @@ options:
       - present
     default: present
     type: str
+  tags:
+    description:
+      - A dictionary of tags to add the EKS cluster.
+    type: dict    
   wait:
     description: >-
       Specifies whether the module waits until the cluster is active or deleted
@@ -211,6 +215,8 @@ def ensure_present(client, module):
                       )
         if module.params['version']:
             params['version'] = module.params['version']
+        if module.params['tags']:
+            params['tags'] = module.params['tags']
         cluster = client.create_cluster(**params)['cluster']
     except botocore.exceptions.EndpointConnectionError as e:
         module.fail_json(msg="Region %s is not supported by EKS" % client.meta.region_name)
@@ -275,6 +281,7 @@ def main():
         subnets=dict(type='list', elements='str'),
         security_groups=dict(type='list', elements='str'),
         state=dict(choices=['absent', 'present'], default='present'),
+        tags=dict(type='dict', required=False),
         wait=dict(default=False, type='bool'),
         wait_timeout=dict(default=1200, type='int')
     )

--- a/plugins/modules/eks_cluster.py
+++ b/plugins/modules/eks_cluster.py
@@ -48,7 +48,8 @@ options:
   tags:
     description:
       - A dictionary of tags to add the EKS cluster.
-    type: dict    
+    type: dict
+    version_added: 5.1.0
   wait:
     description: >-
       Specifies whether the module waits until the cluster is active or deleted

--- a/plugins/modules/eks_cluster.py
+++ b/plugins/modules/eks_cluster.py
@@ -49,7 +49,7 @@ options:
     description:
       - A dictionary of tags to add the EKS cluster.
     type: dict
-    version_added: 5.1.0
+    version_added: 5.2.0
   wait:
     description: >-
       Specifies whether the module waits until the cluster is active or deleted

--- a/tests/integration/targets/eks_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/eks_cluster/tasks/full_test.yml
@@ -90,6 +90,7 @@
         that:
           - eks_create is changed
           - eks_create.name == eks_cluster_name
+          - eks_create.tags.another == "foobar"
 
     - name: create EKS cluster with same details but wait for it to become active
       aws_eks_cluster:

--- a/tests/integration/targets/eks_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/eks_cluster/tasks/full_test.yml
@@ -80,6 +80,9 @@
         security_groups: "{{ eks_security_groups | map(attribute='name') }}"
         subnets: "{{ setup_subnets.results | map(attribute='subnet.id') }}"
         role_arn: "{{ iam_role.arn }}"
+        tags:
+          Name: "{{ resource_prefix }}"
+          another: foobar
       register: eks_create
 
     - name: check that EKS cluster was created


### PR DESCRIPTION
##### SUMMARY

As described by issue https://github.com/ansible-collections/community.aws/issues/1513
All the other community aws modules that I use support applying tags to the created resources (where such a feature is supported by aws). Using aws_eks_cluster it is not possible to add tags, although this appears to be a supported feature when viewing a cluster in the aws console.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_eks_cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
