### PR TITLE
Fix aws_ssm to work with Ubuntu dash shell

### DIFF
--- a/changelogs/fragments/1597-fix-aws_ssm-to-work-with-Ubuntu-dash-shell.yml
+++ b/changelogs/fragments/1597-fix-aws_ssm-to-work-with-Ubuntu-dash-shell.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - format commands in a way that is executable on Ubuntu dash shell (https://github.com/ansible-collections/community.aws/pull/1597).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -463,7 +463,7 @@ class Connection(ConnectionBase):
         else:
             if sudoable:
                 cmd = "sudo " + cmd
-            cmd = "echo " + mark_start + "\n" + cmd + "\necho $'\\n'$?\n" + "echo " + mark_end + "\n"
+            cmd = " echo " + mark_start + "; " + cmd + "; echo $'\\n'$?; " + " echo " + mark_end + ";\n"
 
         display.vvvv(u"_wrap_command: '{0}'".format(to_text(cmd)), host=self.host)
         return cmd


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The way the command if formatted to run on target host is not compatible with dash the default shell on Ubuntu, with the result that the command is not executed. Writing the command all on a single line works.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #1163 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ssm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Output before this patch

```
<i-0845d1adbe853d3e0> EXEC ( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" && echo ansible-tmp-1668533193.4742794-568-272265113538326="` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" )
<i-0845d1adbe853d3e0> _wrap_command: 'echo WNTtQCvJaoWiMmMmFHSErdqylF
( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" && echo ansible-tmp-1668533193.4742794-568-272265113538326="` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" )
echo $'\n'$?
echo pVOVOmpZRdYQFBYfpXViDjtNqR
'
<i-0845d1adbe853d3e0> EXEC stdout line:
<i-0845d1adbe853d3e0> EXEC stdout line: Starting session with SessionId: <redacted>
<i-0845d1adbe853d3e0> EXEC remaining: 60
<i-0845d1adbe853d3e0> EXEC remaining: 59
<i-0845d1adbe853d3e0> EXEC remaining: 58
<i-0845d1adbe853d3e0> EXEC stdout line: This session is encrypted using AWS KMS.
<i-0845d1adbe853d3e0> EXEC remaining: 56
<i-0845d1adbe853d3e0> EXEC stdout line: $ stty -echo
<i-0845d1adbe853d3e0> EXEC stdout line: PS1=''
<i-0845d1adbe853d3e0> EXEC stdout line: echo WNTtQCvJaoWiMmMmFHSErdqylF
<i-0845d1adbe853d3e0> EXEC stdout line: ( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" && echo ansible-tmp-1668533193.4742794-568-272265113538326="` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" )
<i-0845d1adbe853d3e0> EXEC stdout line: echo $'\n'$?
<i-0845d1adbe853d3e0> EXEC stdout line: echo pVOVOmpZRdYQFBYfpXViDjtNqR
<i-0845d1adbe853d3e0> POST_PROCESS: ( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" && echo ansible-tmp-1668533193.4742794-568-272265113538326="` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" )
echo $'\n'$?
echo $'\n'$?
<i-0845d1adbe853d3e0> ssm_retry: attempt: 0, caught exception(invalid literal for int() with base 10: "echo $'\\n'$?") from cmd (( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" && echo ansible-tmp-1668533193.4742794-568-272265113538326="` echo /tmp/.ansible-ssm/ansible-tmp-1668533193.4742794-568-272265113538326 `" )...), pausing for 0 seconds
```

Output after this patch

```
<i-0f23419597c809a60> EXEC ( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153 `" && echo ansible-tmp-1668593900.396902-90-55430003099153="` echo /tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153 `" )
<i-0f23419597c809a60> _wrap_command: ' echo MTOdARDmFuDpeRKtikhLktnMyP; ( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153 `" && echo ansible-tmp-1668593900.396902-90-55430003099153="` echo /tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153 `" ); echo $'\n'$?;  echo iMfEzpqcrufFFIFDmExbSyTqnr;
'
<i-0f23419597c809a60> EXEC stdout line:
<i-0f23419597c809a60> EXEC stdout line: Starting session with SessionId: <redacted>
<i-0f23419597c809a60> EXEC remaining: 60
<i-0f23419597c809a60> EXEC remaining: 59
<i-0f23419597c809a60> EXEC stdout line: This session is encrypted using AWS KMS.
<i-0f23419597c809a60> EXEC remaining: 57
<i-0f23419597c809a60> EXEC stdout line: $ stty -echo
<i-0f23419597c809a60> EXEC stdout line: PS1=''
<i-0f23419597c809a60> EXEC stdout line:  echo MTOdARDmFuDpeRKtikhLktnMyP; ( umask 77 && mkdir -p "` echo /tmp/.ansible-ssm `"&& mkdir -p "` echo /tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153 `" && echo ansible-tmp-1668593900.396902-90-55430003099153="` echo /tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153 `" ); echo $'\n'$?;  echo iMfEzpqcrufFFIFDmExbSyTqnr;
<i-0f23419597c809a60> EXEC stdout line: $ MTOdARDmFuDpeRKtikhLktnMyP
<i-0f23419597c809a60> EXEC stdout line: ansible-tmp-1668593900.396902-90-55430003099153=/tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153
<i-0f23419597c809a60> EXEC stdout line: $
<i-0f23419597c809a60> EXEC stdout line: 0
<i-0f23419597c809a60> EXEC stdout line: iMfEzpqcrufFFIFDmExbSyTqnr
<i-0f23419597c809a60> POST_PROCESS: ansible-tmp-1668593900.396902-90-55430003099153=/tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153
$
0
<i-0f23419597c809a60> (0, 'ansible-tmp-1668593900.396902-90-55430003099153=/tmp/.ansible-ssm/ansible-tmp-1668593900.396902-90-55430003099153\r\r', '')

```

