### PR TITLE
SNS: content-based deduplication

### DIFF
--- a/changelogs/fragments/20221125-sns-content-based-deduplication.yml
+++ b/changelogs/fragments/20221125-sns-content-based-deduplication.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- sns_topic - add support for `content_based_deduplication` parameter (https://github.com/ansible-collections/community.aws/pull/1602).
+
+trivial:
+- sns_topic_info - add doc for `content_based_deduplication` return parameter

--- a/changelogs/fragments/20221125-sns-content-based-deduplication.yml
+++ b/changelogs/fragments/20221125-sns-content-based-deduplication.yml
@@ -1,3 +1,6 @@
+major_changes:
+- sns_topic - facts now report `sns_topic.name` for fifo queues including ".fifo" reflecting reality in AWS (https://github.com/ansible-collections/community.aws/pull/1602).
+
 minor_changes:
 - sns_topic - add support for `content_based_deduplication` parameter (https://github.com/ansible-collections/community.aws/pull/1602).
 

--- a/plugins/module_utils/sns.py
+++ b/plugins/module_utils/sns.py
@@ -62,6 +62,7 @@ def topic_arn_lookup(client, module, name, is_fifo: bool):
         if topic.endswith(lookup_topic):
             return topic
 
+
 def compare_delivery_policies(policy_a, policy_b):
     _policy_a = copy.deepcopy(policy_a)
     _policy_b = copy.deepcopy(policy_b)

--- a/plugins/module_utils/sns.py
+++ b/plugins/module_utils/sns.py
@@ -54,10 +54,10 @@ def list_topics(client, module):
     return [t['TopicArn'] for t in topics]
 
 
-def topic_arn_lookup(client, module, name, is_fifo: bool):
+def topic_arn_lookup(client, module, name):
     # topic names cannot have colons, so this captures the full topic name
     all_topics = list_topics(client, module)
-    lookup_topic = ':%s' % (name + ".fifo" if is_fifo else name)
+    lookup_topic = ':%s' % name
     for topic in all_topics:
         if topic.endswith(lookup_topic):
             return topic

--- a/plugins/module_utils/sns.py
+++ b/plugins/module_utils/sns.py
@@ -54,14 +54,13 @@ def list_topics(client, module):
     return [t['TopicArn'] for t in topics]
 
 
-def topic_arn_lookup(client, module, name):
+def topic_arn_lookup(client, module, name, isfifo: bool):
     # topic names cannot have colons, so this captures the full topic name
     all_topics = list_topics(client, module)
-    lookup_topic = ':%s' % name
+    lookup_topic = ':%s' % (name + ".fifo" if isfifo else name)
     for topic in all_topics:
         if topic.endswith(lookup_topic):
             return topic
-
 
 def compare_delivery_policies(policy_a, policy_b):
     _policy_a = copy.deepcopy(policy_a)
@@ -93,6 +92,7 @@ def get_info(connection, module, topic_arn):
     state = module.params.get('state')
     subscriptions = module.params.get('subscriptions')
     purge_subscriptions = module.params.get('purge_subscriptions')
+    content_based_deduplication = module.params.get('content_based_deduplication')
     subscriptions_existing = module.params.get('subscriptions_existing', [])
     subscriptions_deleted = module.params.get('subscriptions_deleted', [])
     subscriptions_added = module.params.get('subscriptions_added', [])
@@ -111,6 +111,7 @@ def get_info(connection, module, topic_arn):
         'subscriptions_deleted': subscriptions_deleted,
         'subscriptions_added': subscriptions_added,
         'subscriptions_purge': purge_subscriptions,
+        'content_based_deduplication': content_based_deduplication,
         'check_mode': check_mode,
         'topic_created': topic_created,
         'topic_deleted': topic_deleted,

--- a/plugins/module_utils/sns.py
+++ b/plugins/module_utils/sns.py
@@ -124,4 +124,7 @@ def get_info(connection, module, topic_arn):
             info['delivery_policy'] = info.pop('effective_delivery_policy')
         info['subscriptions'] = [camel_dict_to_snake_dict(sub) for sub in list_topic_subscriptions(connection, module, topic_arn)]
 
+    if info['topic_type'] == 'fifo' and not name.endswith('.fifo'):
+        info['name'] += '.fifo'
+
     return info

--- a/plugins/module_utils/sns.py
+++ b/plugins/module_utils/sns.py
@@ -54,10 +54,10 @@ def list_topics(client, module):
     return [t['TopicArn'] for t in topics]
 
 
-def topic_arn_lookup(client, module, name, isfifo: bool):
+def topic_arn_lookup(client, module, name, is_fifo: bool):
     # topic names cannot have colons, so this captures the full topic name
     all_topics = list_topics(client, module)
-    lookup_topic = ':%s' % (name + ".fifo" if isfifo else name)
+    lookup_topic = ':%s' % (name + ".fifo" if is_fifo else name)
     for topic in all_topics:
         if topic.endswith(lookup_topic):
             return topic

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -153,7 +153,6 @@ options:
     description:
       - Whether to enable content-based deduplication for this topic.
         Ignored if topic_type is not "fifo".
-    default: disabled
     choices: ["disabled", "enabled"]
     type: str
 extends_documentation_fragment:

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -590,7 +590,7 @@ class SnsTopicManager(object):
             self.topic_arn = self.name
         else:
             name = self.name
-            if self.topic_type == 'fifo':
+            if self.topic_type == 'fifo' and not name.endswith('.fifo'):
                 name += ".fifo"
             self.topic_arn = topic_arn_lookup(self.connection, self.module, name)
 

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -435,6 +435,7 @@ class SnsTopicManager(object):
 
         # Set content-based deduplication attribute. Ignore if topic_type is not fifo.
         if ("FifoTopic" in topic_attributes and topic_attributes["FifoTopic"] == "true") and \
+                self.content_based_deduplication and \
                 (self.content_based_deduplication != (topic_attributes['ContentBasedDeduplication'] in 'true')):
             changed = True
             self.attributes_set.append('content_based_deduplication')

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -149,6 +149,12 @@ options:
         Blame Amazon."
     default: true
     type: bool
+  content_based_deduplication:
+    description:
+      - Whether to enable content-based deduplication for this topic. 
+        Ignored if topic_type is not "fifo".
+    default: false
+    type: bool
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -227,6 +233,11 @@ sns_topic:
       returned: always
       type: bool
       sample: false
+    content_based_deduplication:
+      description: Whether or not content_based_deduplication was set
+      returned: always
+      type: bool
+      sample: true
     delivery_policy:
       description: Delivery policy for the SNS topic
       returned: when topic is owned by this AWS account
@@ -349,6 +360,7 @@ class SnsTopicManager(object):
                  delivery_policy,
                  subscriptions,
                  purge_subscriptions,
+                 content_based_deduplication: bool,
                  check_mode):
 
         self.connection = module.client('sns')
@@ -366,6 +378,7 @@ class SnsTopicManager(object):
         self.subscriptions_attributes_set = []
         self.desired_subscription_attributes = dict()
         self.purge_subscriptions = purge_subscriptions
+        self.content_based_deduplication = content_based_deduplication
         self.check_mode = check_mode
         self.topic_created = False
         self.topic_deleted = False
@@ -419,6 +432,18 @@ class SnsTopicManager(object):
                                                          AttributeValue=json.dumps(self.policy))
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Couldn't set topic policy")
+
+        # Set content-based deduplication attribute. Ignore if topic_type is not fifo.
+        if ("FifoTopic" in topic_attributes and topic_attributes["FifoTopic"] == "true") and \
+            (self.content_based_deduplication != (topic_attributes['ContentBasedDeduplication'] in 'true')):
+            changed = True
+            self.attributes_set.append('content_based_deduplication')
+            if not self.check_mode:
+                try:
+                    self.connection.set_topic_attributes(TopicArn=self.topic_arn, AttributeName='ContentBasedDeduplication',
+                                                         AttributeValue=str(self.content_based_deduplication).lower())
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                    self.module.fail_json_aws(e, msg="Couldn't set content-based deduplication")
 
         if self.delivery_policy and ('DeliveryPolicy' not in topic_attributes or
                                      compare_delivery_policies(self.delivery_policy, json.loads(topic_attributes['DeliveryPolicy']))):
@@ -531,10 +556,7 @@ class SnsTopicManager(object):
 
     def ensure_ok(self):
         changed = False
-        if self._name_is_arn():
-            self.topic_arn = self.name
-        else:
-            self.topic_arn = topic_arn_lookup(self.connection, self.module, self.name)
+        self.populate_topic_arn()
         if not self.topic_arn:
             changed = self._create_topic()
         if self.topic_arn in list_topics(self.connection, self.module):
@@ -553,10 +575,7 @@ class SnsTopicManager(object):
 
     def ensure_gone(self):
         changed = False
-        if self._name_is_arn():
-            self.topic_arn = self.name
-        else:
-            self.topic_arn = topic_arn_lookup(self.connection, self.module, self.name)
+        self.populate_topic_arn()
         if self.topic_arn:
             if self.topic_arn not in list_topics(self.connection, self.module):
                 self.module.fail_json(msg="Cannot use state=absent with third party ARN. Use subscribers=[] to unsubscribe")
@@ -564,6 +583,11 @@ class SnsTopicManager(object):
             changed |= self._delete_topic()
         return changed
 
+    def populate_topic_arn(self):
+        if self._name_is_arn():
+            self.topic_arn = self.name
+        else:
+            self.topic_arn = topic_arn_lookup(self.connection, self.module, self.name)
 
 def main():
     # We're kinda stuck with CamelCase here, it would be nice to switch to
@@ -600,6 +624,7 @@ def main():
         delivery_policy=dict(type='dict', options=delivery_args),
         subscriptions=dict(default=[], type='list', elements='dict'),
         purge_subscriptions=dict(type='bool', default=True),
+        content_based_deduplication=dict(type='bool', default=False)
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
@@ -613,6 +638,7 @@ def main():
     delivery_policy = module.params.get('delivery_policy')
     subscriptions = module.params.get('subscriptions')
     purge_subscriptions = module.params.get('purge_subscriptions')
+    content_based_deduplication = module.params.get('content_based_deduplication')
     check_mode = module.check_mode
 
     sns_topic = SnsTopicManager(module,
@@ -624,11 +650,11 @@ def main():
                                 delivery_policy,
                                 subscriptions,
                                 purge_subscriptions,
+                                content_based_deduplication,
                                 check_mode)
 
     if state == 'present':
         changed = sns_topic.ensure_ok()
-
     elif state == 'absent':
         changed = sns_topic.ensure_gone()
 

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -151,7 +151,7 @@ options:
     type: bool
   content_based_deduplication:
     description:
-      - Whether to enable content-based deduplication for this topic. 
+      - Whether to enable content-based deduplication for this topic.
         Ignored if topic_type is not "fifo".
     default: false
     type: bool
@@ -435,7 +435,7 @@ class SnsTopicManager(object):
 
         # Set content-based deduplication attribute. Ignore if topic_type is not fifo.
         if ("FifoTopic" in topic_attributes and topic_attributes["FifoTopic"] == "true") and \
-            (self.content_based_deduplication != (topic_attributes['ContentBasedDeduplication'] in 'true')):
+                (self.content_based_deduplication != (topic_attributes['ContentBasedDeduplication'] in 'true')):
             changed = True
             self.attributes_set.append('content_based_deduplication')
             if not self.check_mode:

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -587,7 +587,11 @@ class SnsTopicManager(object):
         if self._name_is_arn():
             self.topic_arn = self.name
         else:
-            self.topic_arn = topic_arn_lookup(self.connection, self.module, self.name)
+            name = self.name
+            if self.topic_type == 'fifo':
+              name += ".fifo"
+            self.topic_arn = topic_arn_lookup(self.connection, self.module, name)
+
 
 def main():
     # We're kinda stuck with CamelCase here, it would be nice to switch to

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -54,6 +54,11 @@ result:
         type: complex
         returned: always
         contains:
+            content_based_deduplication:
+              description: Whether or not content_based_deduplication was set
+              returned: always
+              type: bool
+              sample: true
             delivery_policy:
                 description: Delivery policy for the SNS topic.
                 returned: when topic is owned by this AWS account

--- a/plugins/modules/sns_topic_info.py
+++ b/plugins/modules/sns_topic_info.py
@@ -57,8 +57,8 @@ result:
             content_based_deduplication:
               description: Whether or not content_based_deduplication was set
               returned: always
-              type: bool
-              sample: true
+              type: str
+              sample: "true"
             delivery_policy:
                 description: Delivery policy for the SNS topic.
                 returned: when topic is owned by this AWS account

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -114,7 +114,7 @@
       that:
       - sns_fifo_topic.changed
       - sns_fifo_topic.sns_topic.topic_type == 'fifo'
-      - sns_fifo_topic.sns_topic.name == '{{ sns_topic_topic_name }}-fifo'
+      - sns_fifo_topic.sns_topic.name == '{{ sns_topic_topic_name }}-fifo.fifo'
 
   - name: Run create a FIFO topic again for idempotence test
     sns_topic:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds the missing option of "content-based deduplication" for fifo topics.

Also fixes looking up fifo topic ARNs, which resulted in changing always be `True`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

* module_utils:sns.py
* modules:sns_topic.py
* modules:sns_topic_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
