### PR TITLE
s3_lifecycle - ability to set the number of newest noncurrent versions to retain

### DIFF
--- a/changelogs/fragments/1606-s3_lifecycle_add_number_of_versions_to_retain.yml
+++ b/changelogs/fragments/1606-s3_lifecycle_add_number_of_versions_to_retain.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- s3_lifecycle - add parameter `noncurrent_version_keep_newer` to set the number of newest noncurrent versions to retain

--- a/tests/integration/targets/s3_lifecycle/meta/main.yml
+++ b/tests/integration/targets/s3_lifecycle/meta/main.yml
@@ -1,1 +1,4 @@
-dependencies: []
+dependencies:
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: "1.23.12"

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -423,13 +423,64 @@
         that:
           - output is changed
 
-  # ============================================================
     - name: Create a lifecycle policy, with expired_object_delete_marker  (idempotency)
       s3_lifecycle:
         name: '{{ bucket_name }}'
         expire_object_delete_marker: True
         prefix: /something
       register: output
+
+    - assert:
+        that:
+          - output is not changed
+
+  # ============================================================
+    - name: Update lifecycle policy, with noncurrent_version_expiration_days
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        noncurrent_version_expiration_days: 5
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: Update lifecycle policy, with noncurrent_version_expiration_days (idempotency)
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        noncurrent_version_expiration_days: 5
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+
+  # ============================================================
+    - name: Update lifecycle policy, with noncurrent_version_keep_newer
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        noncurrent_version_expiration_days: 10
+        noncurrent_version_keep_newer: 6
+        prefix: /something
+      register: output
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: Update lifecycle policy, with noncurrent_version_keep_newer (idempotency)
+      s3_lifecycle:
+        name: '{{ bucket_name }}'
+        noncurrent_version_expiration_days: 10
+        noncurrent_version_keep_newer: 6
+        prefix: /something
+      register: output
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:


### PR DESCRIPTION
##### SUMMARY
Adds the ability to set "Number of newer versions to retain"

![image](https://user-images.githubusercontent.com/1944663/204082250-7823d952-ba14-49c6-8365-fe6c1d56d07b.png)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
s3_lifecycle

##### ADDITIONAL INFORMATION
See: https://docs.aws.amazon.com/AmazonS3/latest/API/API_NoncurrentVersionExpiration.html

Previously only the `NoncurrentDays` parameter was supported, this PR adds support for `NewerNoncurrentVersions`
