### PR TITLE
Disable networkfirewall_rule_group integration tests

### DIFF
--- a/changelogs/fragments/1634-networkfirewall_rule_group-tests.yml
+++ b/changelogs/fragments/1634-networkfirewall_rule_group-tests.yml
@@ -1,0 +1,2 @@
+trivial:
+- disable networkfirewall_rule_group integration tests, they're failing due to an idempotency issue. 

--- a/tests/integration/targets/networkfirewall_rule_group/aliases
+++ b/tests/integration/targets/networkfirewall_rule_group/aliases
@@ -1,4 +1,6 @@
 time=18m
 cloud/aws
+# Idempotency issues - https://github.com/ansible-collections/community.aws/issues/1634
+disabled
 
 networkfirewall_rule_group_info


### PR DESCRIPTION
##### SUMMARY

Tests seem broken due to some kind of idempotency issue

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

networkfirewall_rule_group

##### ADDITIONAL INFORMATION
