### PR TITLE
770 ecs_cluster capacity provider strategy

### DIFF
--- a/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
+++ b/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_cluster now supports capacity_providers and capacity_provider_strategy features

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -46,11 +46,26 @@ options:
             - List of capacity providers to use for the cluster.
         required: false
         type: list
+        elements: str
     capacity_provider_strategy:
         description:
             - List of capacity provider strategies to use for the cluster.
         required: false
         type: list
+        elements: dict
+        suboptions:
+            capacity_provider:
+                description:
+                  - Name of capacity provider.
+                type: str
+            weight:
+                description:
+                  - The relative percentage of the total number of launched tasks that should use the specified provider.
+                type: int
+            base:
+                description:
+                  - How many tasks, at a minimum, should use the specified provider.
+                type: int
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -210,8 +225,16 @@ def main():
         name=dict(required=True, type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10),
-        capacity_providers=dict(required=False, type='list'),
-        capacity_provider_strategy=dict(required=False, type='list'),
+        capacity_providers=dict(required=False, type='list', elements='str'),
+        capacity_provider_strategy=dict(required=False,
+                                        type='list',
+                                        elements='dict',
+                                        options=dict(
+                                            capacity_provider=dict(type='str'),
+                                            weight=dict(type='int'),
+                                            base=dict(type='int')
+                                            )
+                                        ),
     )
     required_together = [['state', 'name']]
 
@@ -232,10 +255,10 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                     capacity_providers=module.params['capacity_providers'],
-                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                results['changed'] = True
+                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                      capacity_providers=module.params['capacity_providers'],
+                                                      capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                 results['changed'] = True
             else:
               results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -253,12 +253,11 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if module.params['capacity_providers'] != existing['capacityProviders'] or \
-                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                    results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                         capacity_providers=module.params['capacity_providers'],
-                                                         capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                    results['changed'] = True
+            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                     capacity_providers=module.params['capacity_providers'],
+                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                results['changed'] = True
             else:
                 results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -255,10 +255,10 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                      capacity_providers=module.params['capacity_providers'],
-                                                      capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                 results['changed'] = True
+                   results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                        capacity_providers=module.params['capacity_providers'],
+                                                        capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                   results['changed'] = True
             else:
               results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -230,15 +230,20 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+            if module.params['capacity_providers'] != existing['capacityProviders'] or \
+               module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                     capacity_providers=module.params['capacity_providers'],
+                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
                 results['changed'] = True
             else:
               results['cluster'] = existing
         else:
             if not module.check_mode:
                 # doesn't exist. create it.
-                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
+                                                                capacity_providers=module.params['capacity_providers'],
+                                                                capacity_provider_strategy=module.params['capacity_provider_strategy'])
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -254,13 +254,13 @@ def main():
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
-               module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
                     results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
                                                          capacity_providers=module.params['capacity_providers'],
                                                          capacity_provider_strategy=module.params['capacity_provider_strategy'])
                     results['changed'] = True
             else:
-              results['cluster'] = existing
+                results['cluster'] = existing
         else:
             if not module.check_mode:
                 # doesn't exist. create it.

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -255,10 +255,10 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                   results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                        capacity_providers=module.params['capacity_providers'],
-                                                        capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                   results['changed'] = True
+                    results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                         capacity_providers=module.params['capacity_providers'],
+                                                         capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                    results['changed'] = True
             else:
               results['cluster'] = existing
         else:

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -82,6 +82,7 @@
       assert:
         that:
           - ecs_cluster_update.changed
+          - ecs_cluster_update.capacityProviders
           - "'FARGATE' in ecs_cluster_update.capacityProviders"
 
     - name: create a VPC to work in

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -63,6 +63,27 @@
         that:
           - not ecs_cluster_again.changed
 
+    - name: add capacity providers and strategy
+      ecs_cluster:
+        name: "{{ ecs_cluster_name }}"
+        state: present
+        capacity_providers:
+          - FARGATE
+          - FARGATE_SPOT
+        capacity_provider_strategy:
+          - capacity_provider: FARGATE
+            base: 1
+            weight: 1
+          - capacity_provider: FARGATE_SPOT
+            weight: 100
+      register: ecs_cluster_update
+
+    - name: check that ecs_cluster was correctly updated
+      assert:
+        that:
+          - ecs_cluster_update.changed
+          - "'FARGATE' in ecs_cluster_update.capacityProviders"
+
     - name: create a VPC to work in
       ec2_vpc_net:
         cidr_block: 10.0.0.0/16


### PR DESCRIPTION
##### SUMMARY
Fixes 770 Add AWS ECS_Cluster Capacity Provider Strategy Support

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_cluster

##### ADDITIONAL INFORMATION
When creating or updating an ECS Cluster, configure the capacity providers and capacity provider strategy as provided by the user.

Given playbook task:
```
- name: Create an ECS Cluster with Capacity Providers
  ecs_cluster:
    name: default
    state: present
    capacity_providers:
      - FARGATE
      - FARGATE_SPOT
    capacity_provider_strategy:
      - capacity_provider: FARGATE
        base: 1
        weight: 1
      - capacity_provider: FARGATE_SPOT
        weight: 100
```
Previously would throw "Unsupported parameter" and no other parameter exists to expose these features.
Now you should see changed: [localhost] with the resultant created ECS Cluster having the same providers and provider_strategy fields as provided by the user.