### PR TITLE
ecs_cluster capacity provider strategy

### DIFF
--- a/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
+++ b/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- ecs_cluster now supports capacity_providers and capacity_provider_strategy features (https://github.com/ansible-collections/community.aws/pull/1640).
+- ecs_cluster - add support for ``capacity_providers`` and ``capacity_provider_strategy`` features (https://github.com/ansible-collections/community.aws/pull/1640).

--- a/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
+++ b/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- ecs_cluster now supports capacity_providers and capacity_provider_strategy features
+- ecs_cluster now supports capacity_providers and capacity_provider_strategy features (https://github.com/ansible-collections/community.aws/pull/1640).

--- a/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
+++ b/changelogs/fragments/770-ecs-capacity-provider-strategy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_cluster now supports capacity_providers and capacity_provider_strategy features

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -255,13 +255,13 @@ def main():
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
-               module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
                     results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
                                                          capacity_providers=module.params['capacity_providers'],
                                                          capacity_provider_strategy=module.params['capacity_provider_strategy'])
                     results['changed'] = True
             else:
-              results['cluster'] = existing
+                results['cluster'] = existing
         else:
             if not module.check_mode:
                 # doesn't exist. create it.

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -254,12 +254,11 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if module.params['capacity_providers'] != existing['capacityProviders'] or \
-                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                    results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                         capacity_providers=module.params['capacity_providers'],
-                                                         capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                    results['changed'] = True
+            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                     capacity_providers=module.params['capacity_providers'],
+                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                results['changed'] = True
             else:
                 results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -280,9 +280,9 @@ def main():
                     strategy['base'] = 0
                 if snake_dict_to_camel_dict(strategy) not in existing_cps:
                     cps_update_needed = True
-        for strategy in existing_cps:
-            if camel_dict_to_snake_dict(strategy) not in requested_cps:
-                cps_update_needed = True
+            for strategy in existing_cps:
+                if camel_dict_to_snake_dict(strategy) not in requested_cps:
+                    cps_update_needed = True
 
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             # If either the providers or strategy differ, update the cluster.

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -264,27 +264,29 @@ def main():
         requested_cps = module.params['capacity_provider_strategy']
         existing_cp = existing['capacityProviders']
         existing_cps = existing['defaultCapacityProviderStrategy']
-        if requested_cp is None:
-            requested_cp = []
-
-        # Unless purge_capacity_providers is true, we use the existing providers and strategy.
-        if purge_capacity_providers == False:
-            requested_cp = existing_cp
-            requested_cps = existing_cps
-
-        # Check if capacity provider strategy needs to trigger an update.
-        cps_update_needed = False
-        if requested_cps is not None:
-            for strategy in requested_cps:
-                if strategy['base'] is None:
-                    strategy['base'] = 0
-                if snake_dict_to_camel_dict(strategy) not in existing_cps:
-                    cps_update_needed = True
-            for strategy in existing_cps:
-                if camel_dict_to_snake_dict(strategy) not in requested_cps:
-                    cps_update_needed = True
-
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
+            if requested_cp is None:
+                requested_cp = []
+
+            # Unless purge_capacity_providers is true, we use the existing providers and strategy.
+            if purge_capacity_providers == False:
+                requested_cp = existing_cp
+                requested_cps = existing_cps
+
+            # Check if capacity provider strategy needs to trigger an update.
+            cps_update_needed = False
+            if requested_cps is not None:
+                for strategy in requested_cps:
+                    if strategy['base'] is None:
+                        strategy['base'] = 0
+                    if snake_dict_to_camel_dict(strategy) not in existing_cps:
+                        cps_update_needed = True
+                for strategy in existing_cps:
+                    if camel_dict_to_snake_dict(strategy) not in requested_cps:
+                        cps_update_needed = True
+            elif requested_cps is None and existing_cps != []:
+                cps_update_needed = True
+
             # If either the providers or strategy differ, update the cluster.
             if requested_cp != existing_cp or cps_update_needed:
                 if not module.check_mode:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -268,7 +268,6 @@ def main():
                     if snake_dict_to_camel_dict(strategy) not in existing_cps:
                         cps_update_needed = True
 
-            
             # If either the providers or strategy differ, update the cluster.
             if requested_cp != existing_cp or cps_update_needed:
                 if not module.check_mode:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -267,7 +267,7 @@ def main():
             requested_cp = []
 
         # Unless purge_capacity_providers is true, we use the existing providers and strategy.
-        if purge_capacity_providers:
+        if purge_capacity_providers == False:
             requested_cp = existing_cp
             requested_cps = existing_cps
 
@@ -279,6 +279,9 @@ def main():
                     strategy['base'] = 0
                 if snake_dict_to_camel_dict(strategy) not in existing_cps:
                     cps_update_needed = True
+        for strategy in existing_cps:
+            if camel_dict_to_snake_dict(strategy) not in requested_cps:
+                cps_update_needed = True
 
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             # If either the providers or strategy differ, update the cluster.

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -46,11 +46,26 @@ options:
             - List of capacity providers to use for the cluster.
         required: false
         type: list
+        elements: str
     capacity_provider_strategy:
         description:
             - List of capacity provider strategies to use for the cluster.
         required: false
         type: list
+        elements: dict
+        suboptions:
+            capacity_provider:
+                description:
+                  - Name of capacity provider.
+                type: str
+            weight:
+                description:
+                  - The relative percentage of the total number of launched tasks that should use the specified provider.
+                type: int
+            base:
+                description:
+                  - How many tasks, at a minimum, should use the specified provider.
+                type: int
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -211,8 +226,16 @@ def main():
         name=dict(required=True, type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10),
-        capacity_providers=dict(required=False, type='list'),
-        capacity_provider_strategy=dict(required=False, type='list'),
+        capacity_providers=dict(required=False, type='list', elements='str'),
+        capacity_provider_strategy=dict(required=False,
+                                        type='list',
+                                        elements='dict',
+                                        options=dict(
+                                            capacity_provider=dict(type='str'),
+                                            weight=dict(type='int'),
+                                            base=dict(type='int')
+                                            )
+                                        ),
     )
     required_together = [['state', 'name']]
 
@@ -233,10 +256,10 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                     capacity_providers=module.params['capacity_providers'],
-                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                results['changed'] = True
+                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                      capacity_providers=module.params['capacity_providers'],
+                                                      capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                 results['changed'] = True
             else:
               results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -245,7 +245,7 @@ def main():
                                         elements='dict',
                                         options=dict(capacity_provider=dict(type='str'),
                                                      weight=dict(type='int'),
-                                                     base=dict(type='int')
+                                                     base=dict(type='int', default=0)
                                                      )
                                         ),
     )
@@ -284,8 +284,6 @@ def main():
             cps_update_needed = False
             if requested_cps is not None:
                 for strategy in requested_cps:
-                    if strategy['base'] is None:
-                        strategy['base'] = 0
                     if snake_dict_to_camel_dict(strategy) not in existing_cps:
                         cps_update_needed = True
                 for strategy in existing_cps:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -253,14 +253,27 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
+            # Pull requested and existing capacity providers and strategies.
             requested_cp = module.params['capacity_providers']
             requested_cps = module.params['capacity_provider_strategy']
             existing_cp = existing['capacityProviders']
             existing_cps = existing['defaultCapacityProviderStrategy']
-            if requested_cp != existing_cp or requested_cps != existing_cps:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                     capacity_providers=requested_cp,
-                                                     capacity_provider_strategy=requested_cps)
+            if requested_cp is None:
+                requested_cp = []
+
+            # Check if capacity providers or strategy need to trigger an update.
+            cps_update_needed = False
+            if requested_cps is not None:
+                try:
+                    assert [strategy for strategy in requested_cps if snake_dict_to_camel_dict(strategy) not in existing_cps] == []
+                except AssertionError:
+                    cps_update_needed = True
+
+            # If either the providers or strategy differ, update the cluster.
+            if requested_cp != existing_cp or cps_update_needed:
+                results['cluster'] = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                                capacity_providers=requested_cp,
+                                                                capacity_provider_strategy=requested_cps)
                 results['changed'] = True
             else:
                 results['cluster'] = existing

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -231,15 +231,20 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+            if module.params['capacity_providers'] != existing['capacityProviders'] or \
+               module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                     capacity_providers=module.params['capacity_providers'],
+                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
                 results['changed'] = True
             else:
               results['cluster'] = existing
         else:
             if not module.check_mode:
                 # doesn't exist. create it.
-                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
+                                                                capacity_providers=module.params['capacity_providers'],
+                                                                capacity_provider_strategy=module.params['capacity_provider_strategy'])
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -270,9 +270,10 @@ def main():
         purge_capacity_providers = module.params['purge_capacity_providers']
         requested_cp = module.params['capacity_providers']
         requested_cps = module.params['capacity_provider_strategy']
-        existing_cp = existing['capacityProviders']
-        existing_cps = existing['defaultCapacityProviderStrategy']
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
+            existing_cp = existing['capacityProviders']
+            existing_cps = existing['defaultCapacityProviderStrategy']
+
             if requested_cp is None:
                 requested_cp = []
 

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -261,13 +261,12 @@ def main():
             if requested_cp is None:
                 requested_cp = []
 
-            # Check if capacity providers or strategy need to trigger an update.
+            # Check if capacity provider strategy needs to trigger an update.
             cps_update_needed = False
             if requested_cps is not None:
-                try:
-                    assert [strategy for strategy in requested_cps if snake_dict_to_camel_dict(strategy) not in existing_cps] == []
-                except AssertionError:
-                    cps_update_needed = True
+                for strategy in requested_cps:
+                    if snake_dict_to_camel_dict(strategy) not in existing_cps:
+                        cps_update_needed = True
 
             # If either the providers or strategy differ, update the cluster.
             if requested_cp != existing_cp or cps_update_needed:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -226,20 +226,16 @@ def main():
         name=dict(required=True, type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10),
-<<<<<<< HEAD
         capacity_providers=dict(required=False, type='list', elements='str'),
         capacity_provider_strategy=dict(required=False,
                                         type='list',
                                         elements='dict',
-                                        options=dict(capacity_provider=dict(type='str'),
-                                                     weight=dict(type='int'),
-                                                     base=dict(type='int')
-                                                     )
+                                        options=dict(
+                                            capacity_provider=dict(type='str'),
+                                            weight=dict(type='int'),
+                                            base=dict(type='int')
+                                            )
                                         ),
-=======
-        capacity_providers=dict(required=False, type='list'),
-        capacity_provider_strategy=dict(required=False, type='list'),
->>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
     )
     required_together = [['state', 'name']]
 
@@ -258,8 +254,6 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-<<<<<<< HEAD
-<<<<<<< HEAD
             # Pull requested and existing capacity providers and strategies.
             requested_cp = module.params['capacity_providers']
             requested_cps = module.params['capacity_provider_strategy']
@@ -275,11 +269,13 @@ def main():
                     if snake_dict_to_camel_dict(strategy) not in existing_cps:
                         cps_update_needed = True
 
+            
             # If either the providers or strategy differ, update the cluster.
             if requested_cp != existing_cp or cps_update_needed:
-                results['cluster'] = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                                capacity_providers=requested_cp,
-                                                                capacity_provider_strategy=requested_cps)
+                if not module.check_mode:
+                    results['cluster'] = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                                    capacity_providers=requested_cp,
+                                                                    capacity_provider_strategy=requested_cps)
                 results['changed'] = True
             else:
                 results['cluster'] = existing
@@ -289,30 +285,6 @@ def main():
                 results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
                                                                 capacity_providers=module.params['capacity_providers'],
                                                                 capacity_provider_strategy=module.params['capacity_provider_strategy'])
-=======
-            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
-=======
-            if module.params['capacity_providers'] != existing['capacityProviders'] or \
-               module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                     capacity_providers=module.params['capacity_providers'],
-                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
->>>>>>> a8c40fa5 (Some lines are too long.)
-                results['changed'] = True
-            else:
-              results['cluster'] = existing
-        else:
-            if not module.check_mode:
-                # doesn't exist. create it.
-<<<<<<< HEAD
-                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
->>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
-=======
-                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
-                                                                capacity_providers=module.params['capacity_providers'],
-                                                                capacity_provider_strategy=module.params['capacity_provider_strategy'])
->>>>>>> a8c40fa5 (Some lines are too long.)
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -41,6 +41,16 @@ options:
         required: false
         type: int
         default: 10
+    capacity_providers:
+        description:
+            - List of capacity providers to use for the cluster.
+        required: false
+        type: list
+    capacity_provider_strategy:
+        description:
+            - List of capacity provider strategies to use for the cluster.
+        required: false
+        type: list
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -55,6 +65,20 @@ EXAMPLES = '''
   community.aws.ecs_cluster:
     name: default
     state: present
+
+- name: Cluster creation with capacity providers and strategies.
+  community.aws.ecs_cluster:
+    name: default
+    state: present
+    capacity_providers:
+      - FARGATE
+      - FARGATE_SPOT
+    capacity_provider_strategy:
+      - capacity_provider: FARGATE
+        base: 1
+        weight: 1
+      - capacity_provider: FARGATE_SPOT
+        weight: 100
 
 - name: Cluster deletion
   community.aws.ecs_cluster:
@@ -75,6 +99,14 @@ activeServicesCount:
     description: how many services are active in this cluster
     returned: 0 if a new cluster
     type: int
+capacityProviders:
+    description: list of capacity providers used in this cluster
+    returned: always
+    type: list
+defaultCapacityProviderStrategy:
+    description: list of capacity provider strategies used in this cluster
+    returned: always
+    type: list
 clusterArn:
     description: the ARN of the cluster just created
     type: str
@@ -112,6 +144,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 
 class EcsClusterManager:
@@ -145,8 +178,26 @@ class EcsClusterManager:
                 return c
         raise Exception("Unknown problem describing cluster %s." % cluster_name)
 
-    def create_cluster(self, clusterName='default'):
-        response = self.ecs.create_cluster(clusterName=clusterName)
+    def create_cluster(self, cluster_name, capacity_providers, capacity_provider_strategy):
+        params = dict(clusterName=cluster_name)
+        if capacity_providers:
+            params['capacityProviders'] = snake_dict_to_camel_dict(capacity_providers)
+        if capacity_provider_strategy:
+            params['defaultCapacityProviderStrategy'] = snake_dict_to_camel_dict(capacity_provider_strategy)
+        response = self.ecs.create_cluster(**params)
+        return response['cluster']
+
+    def update_cluster(self, cluster_name, capacity_providers, capacity_provider_strategy):
+        params = dict(cluster=cluster_name)
+        if capacity_providers:
+            params['capacityProviders'] = snake_dict_to_camel_dict(capacity_providers)
+        else:
+            params['capacityProviders'] = []
+        if capacity_provider_strategy:
+            params['defaultCapacityProviderStrategy'] = snake_dict_to_camel_dict(capacity_provider_strategy)
+        else:
+            params['defaultCapacityProviderStrategy'] = []
+        response = self.ecs.put_cluster_capacity_providers(**params)
         return response['cluster']
 
     def delete_cluster(self, clusterName):
@@ -159,7 +210,9 @@ def main():
         state=dict(required=True, choices=['present', 'absent', 'has_instances']),
         name=dict(required=True, type='str'),
         delay=dict(required=False, type='int', default=10),
-        repeat=dict(required=False, type='int', default=10)
+        repeat=dict(required=False, type='int', default=10),
+        capacity_providers=dict(required=False, type='list'),
+        capacity_provider_strategy=dict(required=False, type='list'),
     )
     required_together = [['state', 'name']]
 
@@ -178,11 +231,15 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            results['cluster'] = existing
+            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                results['changed'] = True
+            else:
+              results['cluster'] = existing
         else:
             if not module.check_mode:
                 # doesn't exist. create it.
-                results['cluster'] = cluster_mgr.create_cluster(module.params['name'])
+                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -260,8 +260,8 @@ def main():
             existing_cps = existing['defaultCapacityProviderStrategy']
             if requested_cp != existing_cp or requested_cps != existing_cps:
                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                    capacity_providers=requested_cp,
-                                                    capacity_provider_strategy=requested_cps)
+                                                     capacity_providers=requested_cp,
+                                                     capacity_provider_strategy=requested_cps)
                 results['changed'] = True
             else:
                 results['cluster'] = existing

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -266,6 +266,11 @@ def main():
         if requested_cp is None:
             requested_cp = []
 
+        # Unless purge_capacity_providers is true, we use the existing providers and strategy.
+        if purge_capacity_providers:
+            requested_cp = existing_cp
+            requested_cps = existing_cps
+
         # Check if capacity provider strategy needs to trigger an update.
         cps_update_needed = False
         if requested_cps is not None:
@@ -278,13 +283,6 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             # If either the providers or strategy differ, update the cluster.
             if requested_cp != existing_cp or cps_update_needed:
-                if purge_capacity_providers is None:
-                    module.warn('Cluster exists and purge_capacity_providers argument not provided. The capacity providers will not be updated.')
-                    capacity_providers = existing_cp
-                    capacity_provider_strategy = existing_cps
-                elif purge_capacity_providers != True:
-                    capacity_providers = existing_cp
-                    capacity_provider_strategy = existing_cps
                 if not module.check_mode:
                     results['cluster'] = cluster_mgr.update_cluster(cluster_name=module.params['name'],
                                                                     capacity_providers=requested_cp,

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -294,8 +294,8 @@ def main():
             if not module.check_mode:
                 # doesn't exist. create it.
                 results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
-                                                                capacity_providers=module.params['capacity_providers'],
-                                                                capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                                                                capacity_providers=requested_cp,
+                                                                capacity_provider_strategy=requested_cps)
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -117,10 +117,12 @@ activeServicesCount:
     returned: 0 if a new cluster
     type: int
 capacityProviders:
+    version_added: 5.2.0
     description: list of capacity providers used in this cluster
     returned: always
     type: list
 defaultCapacityProviderStrategy:
+    version_added: 5.2.0
     description: list of capacity provider strategies used in this cluster
     returned: always
     type: list

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -74,6 +74,7 @@ options:
             - Toggle overwriting of existing capacity providers or strategy. This is needed for backwards compatibility.
         required: false
         type: bool
+        default: false
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -276,7 +277,7 @@ def main():
                 requested_cp = []
 
             # Unless purge_capacity_providers is true, we use the existing providers and strategy.
-            if purge_capacity_providers == False:
+            if not purge_capacity_providers:
                 requested_cp = existing_cp
                 requested_cps = existing_cps
 

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -292,8 +292,9 @@ def main():
 
             # Unless purge_capacity_providers is true, we will not be updating the providers or strategy.
             if not purge_capacity_providers:
-                module.warn('In order to maintain backwards compatibility, the capacity providers and strategy will not be changed by default.')
-                module.warn('Set purge_capacity_providers to True to override this behavior.')
+                module.deprecate('After 2024-06-01 the default value of purge_capacity_providers will change from false to true.'
+                                 ' To maintain the existing behaviour explicitly set purge_capacity_providers=true',
+                                 date='2024-06-01', collection_name='community.aws')
                 cps_update_needed = False
                 requested_cp = existing_cp
                 requested_cps = existing_cps

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -46,12 +46,16 @@ options:
             - List of capacity providers to use for the cluster.
         required: false
         type: list
+<<<<<<< HEAD
         elements: str
+=======
+>>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
     capacity_provider_strategy:
         description:
             - List of capacity provider strategies to use for the cluster.
         required: false
         type: list
+<<<<<<< HEAD
         elements: dict
         suboptions:
             capacity_provider:
@@ -66,6 +70,8 @@ options:
                 description:
                   - How many tasks, at a minimum, should use the specified provider.
                 type: int
+=======
+>>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -226,6 +232,7 @@ def main():
         name=dict(required=True, type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10),
+<<<<<<< HEAD
         capacity_providers=dict(required=False, type='list', elements='str'),
         capacity_provider_strategy=dict(required=False,
                                         type='list',
@@ -235,6 +242,10 @@ def main():
                                                      base=dict(type='int')
                                                      )
                                         ),
+=======
+        capacity_providers=dict(required=False, type='list'),
+        capacity_provider_strategy=dict(required=False, type='list'),
+>>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
     )
     required_together = [['state', 'name']]
 
@@ -253,6 +264,7 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
+<<<<<<< HEAD
             # Pull requested and existing capacity providers and strategies.
             requested_cp = module.params['capacity_providers']
             requested_cps = module.params['capacity_provider_strategy']
@@ -282,6 +294,17 @@ def main():
                 results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
                                                                 capacity_providers=module.params['capacity_providers'],
                                                                 capacity_provider_strategy=module.params['capacity_provider_strategy'])
+=======
+            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                results['changed'] = True
+            else:
+              results['cluster'] = existing
+        else:
+            if not module.check_mode:
+                # doesn't exist. create it.
+                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+>>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -256,10 +256,10 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                      capacity_providers=module.params['capacity_providers'],
-                                                      capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                 results['changed'] = True
+                   results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                        capacity_providers=module.params['capacity_providers'],
+                                                        capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                   results['changed'] = True
             else:
               results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -42,6 +42,7 @@ options:
         type: int
         default: 10
     capacity_providers:
+        version_added: 5.2.0
         description:
             - List of capacity providers to use for the cluster.
         required: false

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -72,6 +72,7 @@ options:
         version_added: 5.2.0
         description:
             - Toggle overwriting of existing capacity providers or strategy. This is needed for backwards compatibility.
+            - By default I(purge_capacity_providers=false).  In a release after 2024-06-01 this will be changed to I(purge_capacity_providers=true).
         required: false
         type: bool
         default: false

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -230,11 +230,10 @@ def main():
         capacity_provider_strategy=dict(required=False,
                                         type='list',
                                         elements='dict',
-                                        options=dict(
-                                            capacity_provider=dict(type='str'),
-                                            weight=dict(type='int'),
-                                            base=dict(type='int')
-                                            )
+                                        options=dict(capacity_provider=dict(type='str'),
+                                                     weight=dict(type='int'),
+                                                     base=dict(type='int')
+                                                     )
                                         ),
     )
     required_together = [['state', 'name']]

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -254,10 +254,14 @@ def main():
     results = dict(changed=False)
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+            requested_cp = module.params['capacity_providers']
+            requested_cps = module.params['capacity_provider_strategy']
+            existing_cp = existing['capacityProviders']
+            existing_cps = existing['defaultCapacityProviderStrategy']
+            if requested_cp != existing_cp or requested_cps != existing_cps:
                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                     capacity_providers=module.params['capacity_providers'],
-                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                                                    capacity_providers=requested_cp,
+                                                    capacity_provider_strategy=requested_cps)
                 results['changed'] = True
             else:
                 results['cluster'] = existing

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -164,6 +164,7 @@ except ImportError:
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
 class EcsClusterManager:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -256,10 +256,10 @@ def main():
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
             if module.params['capacity_providers'] != existing['capacityProviders'] or \
                module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
-                   results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
-                                                        capacity_providers=module.params['capacity_providers'],
-                                                        capacity_provider_strategy=module.params['capacity_provider_strategy'])
-                   results['changed'] = True
+                    results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                         capacity_providers=module.params['capacity_providers'],
+                                                         capacity_provider_strategy=module.params['capacity_provider_strategy'])
+                    results['changed'] = True
             else:
               results['cluster'] = existing
         else:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -278,6 +278,8 @@ def main():
 
             # Unless purge_capacity_providers is true, we use the existing providers and strategy.
             if not purge_capacity_providers:
+                module.warn('In order to maintain backwards compatibility, the capacity providers and strategy will not be changed by default.')
+                module.warn('Set purge_capacity_providers to True to override this behavior.')
                 requested_cp = existing_cp
                 requested_cps = existing_cps
 

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -277,13 +277,6 @@ def main():
             if requested_cp is None:
                 requested_cp = []
 
-            # Unless purge_capacity_providers is true, we use the existing providers and strategy.
-            if not purge_capacity_providers:
-                module.warn('In order to maintain backwards compatibility, the capacity providers and strategy will not be changed by default.')
-                module.warn('Set purge_capacity_providers to True to override this behavior.')
-                requested_cp = existing_cp
-                requested_cps = existing_cps
-
             # Check if capacity provider strategy needs to trigger an update.
             cps_update_needed = False
             if requested_cps is not None:
@@ -295,6 +288,14 @@ def main():
                         cps_update_needed = True
             elif requested_cps is None and existing_cps != []:
                 cps_update_needed = True
+
+            # Unless purge_capacity_providers is true, we will not be updating the providers or strategy.
+            if not purge_capacity_providers:
+                module.warn('In order to maintain backwards compatibility, the capacity providers and strategy will not be changed by default.')
+                module.warn('Set purge_capacity_providers to True to override this behavior.')
+                cps_update_needed = False
+                requested_cp = existing_cp
+                requested_cps = existing_cps
 
             # If either the providers or strategy differ, update the cluster.
             if requested_cp != existing_cp or cps_update_needed:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -68,6 +68,12 @@ options:
                 description:
                   - How many tasks, at a minimum, should use the specified provider.
                 type: int
+    purge_capacity_providers:
+        version_added: 5.2.0
+        description:
+            - Toggle overwriting of existing capacity providers or strategy. This is needed for backwards compatibility.
+        required: false
+        type: bool
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -96,6 +102,7 @@ EXAMPLES = '''
         weight: 1
       - capacity_provider: FARGATE_SPOT
         weight: 100
+    purge_capacity_providers: True
 
 - name: Cluster deletion
   community.aws.ecs_cluster:

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -46,16 +46,12 @@ options:
             - List of capacity providers to use for the cluster.
         required: false
         type: list
-<<<<<<< HEAD
         elements: str
-=======
->>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
     capacity_provider_strategy:
         description:
             - List of capacity provider strategies to use for the cluster.
         required: false
         type: list
-<<<<<<< HEAD
         elements: dict
         suboptions:
             capacity_provider:
@@ -70,8 +66,6 @@ options:
                 description:
                   - How many tasks, at a minimum, should use the specified provider.
                 type: int
-=======
->>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -265,6 +259,7 @@ def main():
     if module.params['state'] == 'present':
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
 <<<<<<< HEAD
+<<<<<<< HEAD
             # Pull requested and existing capacity providers and strategies.
             requested_cp = module.params['capacity_providers']
             requested_cps = module.params['capacity_provider_strategy']
@@ -297,14 +292,27 @@ def main():
 =======
             if module.params['capacity_providers'] != existing['capacityProviders'] or module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
                 results = cluster_mgr.update_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
+=======
+            if module.params['capacity_providers'] != existing['capacityProviders'] or \
+               module.params['capacity_provider_strategy'] != existing['defaultCapacityProviderStrategy']:
+                results = cluster_mgr.update_cluster(cluster_name=module.params['name'],
+                                                     capacity_providers=module.params['capacity_providers'],
+                                                     capacity_provider_strategy=module.params['capacity_provider_strategy'])
+>>>>>>> a8c40fa5 (Some lines are too long.)
                 results['changed'] = True
             else:
               results['cluster'] = existing
         else:
             if not module.check_mode:
                 # doesn't exist. create it.
+<<<<<<< HEAD
                 results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'], capacity_providers=module.params['capacity_providers'], capacity_provider_strategy=module.params['capacity_provider_strategy'])
 >>>>>>> b4d98bd4 (770 - ecs_cluster - Add Capacity Providers and Capacity Provider Strategy.)
+=======
+                results['cluster'] = cluster_mgr.create_cluster(cluster_name=module.params['name'],
+                                                                capacity_providers=module.params['capacity_providers'],
+                                                                capacity_provider_strategy=module.params['capacity_provider_strategy'])
+>>>>>>> a8c40fa5 (Some lines are too long.)
             results['changed'] = True
 
     # delete the cluster

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -49,6 +49,7 @@ options:
         type: list
         elements: str
     capacity_provider_strategy:
+        version_added: 5.2.0
         description:
             - List of capacity provider strategies to use for the cluster.
         required: false

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -67,6 +67,7 @@
       ecs_cluster:
         name: "{{ ecs_cluster_name }}"
         state: present
+        purge_capacity_providers: True
         capacity_providers:
           - FARGATE
           - FARGATE_SPOT

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -82,6 +82,7 @@
       assert:
         that:
           - ecs_cluster_update.changed
+          - ecs_cluster_update.capacityProviders
           - "'FARGATE' in ecs_cluster_update.capacityProviders"
 
     - name: create a VPC to work in

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -63,6 +63,27 @@
         that:
           - not ecs_cluster_again.changed
 
+    - name: add capacity providers and strategy
+      ecs_cluster:
+        name: "{{ ecs_cluster_name }}"
+        state: present
+        capacity_providers:
+          - FARGATE
+          - FARGATE_SPOT
+        capacity_provider_strategy:
+          - capacity_provider: FARGATE
+            base: 1
+            weight: 1
+          - capacity_provider: FARGATE_SPOT
+            weight: 100
+      register: ecs_cluster_update
+
+    - name: check that ecs_cluster was correctly updated
+      assert:
+        that:
+          - ecs_cluster_update.changed
+          - "'FARGATE' in ecs_cluster_update.capacityProviders"
+
     - name: create a VPC to work in
       ec2_vpc_net:
         cidr_block: 10.0.0.0/16

--- a/tests/integration/targets/ecs_cluster/tasks/main.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/main.yml
@@ -82,8 +82,9 @@
       assert:
         that:
           - ecs_cluster_update.changed
-          - ecs_cluster_update.capacityProviders
-          - "'FARGATE' in ecs_cluster_update.capacityProviders"
+          - ecs_cluster_update.cluster is defined
+          - ecs_cluster_update.cluster.capacityProviders is defined
+          - "'FARGATE' in ecs_cluster_update.cluster.capacityProviders"
 
     - name: create a VPC to work in
       ec2_vpc_net:


### PR DESCRIPTION
##### SUMMARY
Fixes #770 - Add AWS ECS_Cluster Capacity Provider Strategy Support

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_cluster

##### ADDITIONAL INFORMATION
When creating or updating an ECS Cluster, configure the capacity providers and capacity provider strategy as provided by the user.

Given playbook task:
```
- name: Create an ECS Cluster with Capacity Providers
  ecs_cluster:
    name: default
    state: present
    capacity_providers:
      - FARGATE
      - FARGATE_SPOT
    capacity_provider_strategy:
      - capacity_provider: FARGATE
        base: 1
        weight: 1
      - capacity_provider: FARGATE_SPOT
        weight: 100
```
Previously would throw "Unsupported parameter" and no other parameter exists to expose these features.
Now you should see changed: [localhost] with the resultant created ECS Cluster having the same providers and provider_strategy fields as provided by the user.