### PR TITLE
[6.0.0] codebuild_project - update tags param to use dict rather than list of dicts

### DIFF
--- a/changelogs/fragments/1643-codebuild_project.yml
+++ b/changelogs/fragments/1643-codebuild_project.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- codebuild_project - ``tags`` parameter now accepts a dict representing the tags, rather than the boto3 format (https://github.com/ansible-collections/community.aws/pull/1643).

--- a/tests/integration/targets/codebuild_project/tasks/main.yml
+++ b/tests/integration/targets/codebuild_project/tasks/main.yml
@@ -48,7 +48,7 @@
           environment_variables:
             - { name: 'FOO_ENV', value: 'other' }
         tags:
-          - { key: 'purpose', value: 'ansible-test' }
+          purpose: 'ansible-test'
         state: present
       register: output
       retries: 10
@@ -83,7 +83,7 @@
           environment_variables:
             - { name: 'FOO_ENV', value: 'other' }
         tags:
-          - { key: 'purpose', value: 'ansible-test' }
+          purpose: 'ansible-test'
         state: present
       register: rerun_test_output
 

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,1 @@
 plugins/modules/cloudfront_distribution_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/codebuild_project.py pylint:collection-deprecated-version # https://github.com/ansible-collections/community.aws/issues/1546

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,2 +1,1 @@
 plugins/modules/cloudfront_distribution_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/codebuild_project.py pylint:collection-deprecated-version # https://github.com/ansible-collections/community.aws/issues/1546

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,2 +1,1 @@
 plugins/modules/cloudfront_distribution_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/codebuild_project.py pylint:collection-deprecated-version # https://github.com/ansible-collections/community.aws/issues/1546

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,2 +1,1 @@
 plugins/modules/cloudfront_distribution_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/codebuild_project.py pylint:collection-deprecated-version # https://github.com/ansible-collections/community.aws/issues/1546

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,2 +1,1 @@
 plugins/modules/cloudfront_distribution_info.py pylint:unnecessary-comprehension # (new test) Should be an easy fix, but testing is a challenge - test are broken and aliases require a wildcard cert in ACM
-plugins/modules/codebuild_project.py pylint:collection-deprecated-version # https://github.com/ansible-collections/community.aws/issues/1546

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,1 +1,0 @@
-plugins/modules/iam_role.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

Passing list of dicts was deprecated, move it to dict

fixes: #1546 
Originally deprecated in https://github.com/ansible-collections/community.aws/pull/1221 as part of the tagging cleanup.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

codebuild_project

##### ADDITIONAL INFORMATION