### PR TITLE
aws_ssm - Add gather_facts to integration tests for connection plugins

### DIFF
--- a/changelogs/fragments/aws_ssm-facts.yml
+++ b/changelogs/fragments/aws_ssm-facts.yml
@@ -1,0 +1,2 @@
+trivial:
+- aws_ssm - Added gather_facts to connection plugin tests.

--- a/tests/integration/targets/connection/test_connection.yml
+++ b/tests/integration/targets/connection/test_connection.yml
@@ -10,6 +10,10 @@
 
   ### test wait_for_connection plugin
   - wait_for_connection:
+      timeout: 100
+
+  - name: Gather facts
+    ansible.builtin.setup:
 
   ### raw with unicode arg and output
 

--- a/tests/integration/targets/connection_aws_ssm_addressing/aliases
+++ b/tests/integration/targets/connection_aws_ssm_addressing/aliases
@@ -1,4 +1,4 @@
-time=20m
+time=10m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_amazon/aliases
+++ b/tests/integration/targets/connection_aws_ssm_amazon/aliases
@@ -1,4 +1,4 @@
-time=20m
+time=10m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_encrypted_s3/aliases
+++ b/tests/integration/targets/connection_aws_ssm_encrypted_s3/aliases
@@ -1,4 +1,4 @@
-time=20m
+time=10m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_fedora/aliases
+++ b/tests/integration/targets/connection_aws_ssm_fedora/aliases
@@ -1,4 +1,4 @@
-time=20m
+time=10m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_ssm_document/aliases
+++ b/tests/integration/targets/connection_aws_ssm_ssm_document/aliases
@@ -1,4 +1,4 @@
-time=20m
+time=10m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_ubuntu/aliases
+++ b/tests/integration/targets/connection_aws_ssm_ubuntu/aliases
@@ -1,4 +1,4 @@
-time=20m
+time=10m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_windows/aliases
+++ b/tests/integration/targets/connection_aws_ssm_windows/aliases
@@ -1,5 +1,4 @@
-time=20m
+time=10m
 
-unstable
 cloud/aws
 connection_aws_ssm


### PR DESCRIPTION
##### SUMMARY

gather_facts stalling out was one of the examples given for things broken with aws_ssm

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_ssm

##### ADDITIONAL INFORMATION
