### PR TITLE
ecs_service -- with force_new_deployment user can specify taskdef or not

### DIFF
--- a/changelogs/fragments/1680-ecs_service-force_redeploy_taskdef_optional.yml
+++ b/changelogs/fragments/1680-ecs_service-force_redeploy_taskdef_optional.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ecs_service - When force_new_deployment is True, task_definition is no longer required. (https://github.com/ansible-collections/community.aws/pull/1680)

--- a/changelogs/fragments/1680-ecs_service-force_redeploy_taskdef_optional.yml
+++ b/changelogs/fragments/1680-ecs_service-force_redeploy_taskdef_optional.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- ecs_service - When force_new_deployment is True, task_definition is no longer required. (https://github.com/ansible-collections/community.aws/pull/1680)
+- ecs_service - ``task_definition`` is now optional when ``force_new_deployment`` is ``True`` (https://github.com/ansible-collections/community.aws/pull/1680).

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -44,7 +44,7 @@ options:
     task_definition:
         description:
           - The task definition the service will run.
-          - This parameter is required when I(state=present).
+          - This parameter is required when I(state=present) unless I(force_new_deployment=True).
           - This parameter is ignored when updating a service with a C(CODE_DEPLOY) deployment controller in which case
             the task definition is managed by Code Pipeline and cannot be updated.
         required: false

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -971,14 +971,15 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True,
-                              required_if=[('state', 'present', ['task_definition']),
-                                           ('launch_type', 'FARGATE', ['network_configuration'])],
+                              required_if=[('launch_type', 'FARGATE', ['network_configuration'])],
                               required_together=[['load_balancers', 'role']],
                               mutually_exclusive=[['launch_type', 'capacity_provider_strategy']])
 
-    if module.params['state'] == 'present' and module.params['scheduling_strategy'] == 'REPLICA':
-        if module.params['desired_count'] is None:
+    if module.params['state'] == 'present':
+        if module.params['scheduling_strategy'] == 'REPLICA' and module.params['desired_count'] is None:
             module.fail_json(msg='state is present, scheduling_strategy is REPLICA; missing desired_count')
+        if module.params['task_definition'] is None and not module.params['force_new_deployment']:
+            module.fail_json(msg='Either task_definition or force_new_deployment is required when status is present.')
 
     if len(module.params['capacity_provider_strategy']) > 6:
         module.fail_json(msg='AWS allows a maximum of six capacity providers in the strategy.')
@@ -1074,6 +1075,9 @@ def main():
                         module.fail_json(msg="It is not currently supported to change tags of an existing service")
 
                     updatedLoadBalancers = loadBalancers if existing['deploymentController']['type'] == 'ECS' else []
+
+                    if task_definition is None and module.params['force_new_deployment']:
+                        task_definition = existing['taskDefinition']
 
                     # update required
                     response = service_mgr.update_service(module.params['name'],

--- a/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
@@ -112,6 +112,30 @@
     that:
       - ecs_service_again.changed
 
+- name: force_new_deployment should work without providing a task_definition
+  ecs_service:
+    state: present
+    force_new_deployment: yes
+    name: "{{ ecs_service_name }}"
+    cluster: "{{ ecs_cluster_name }}"
+    desired_count: 1
+    deployment_configuration: "{{ ecs_service_deployment_configuration }}"
+    placement_strategy: "{{ ecs_service_placement_strategy }}"
+    placement_constraints:
+      - type: distinctInstance
+    health_check_grace_period_seconds: "{{ ecs_service_health_check_grace_period }}"
+    load_balancers:
+      - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+        containerName: "{{ ecs_task_name }}"
+        containerPort: "{{ ecs_task_container_port }}"
+    role: "{{ ecs_service_role_name }}"
+  register: ecs_service_notaskdef
+
+- name: check that ECS service changed again due to force_new_deployment with no task definition
+  assert:
+    that:
+      - ecs_service_notaskdef.changed
+
 - name: attempt to use ECS network configuration on task definition without awsvpc network_mode (expected to fail)
   vars:
     ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"

--- a/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
@@ -113,6 +113,8 @@
       - ecs_service_again.changed
 
 - name: force_new_deployment should work without providing a task_definition
+  vars:
+    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   ecs_service:
     state: present
     force_new_deployment: yes


### PR DESCRIPTION
##### SUMMARY
Fixes #1106
Support force_new_deployment without having to specify a task definition.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_service

##### ADDITIONAL INFORMATION
Previously task_definition was required when state was present; regardless of whether force_new_deployment was set or not.
Previous error was along the lines of "state is present but all of the following are missing: task_definition".
New behavior enforces either task_definition or force_new_deployment is set.
If both are provided, the user's task_definition will be sent through to boto.
If only task_definition is defined, original behavior resumes.
If only force_new_deployment is set, pull the taskDefinition from existing and pass it through to boto.