### PR TITLE
Fix copying of empty file

### DIFF
--- a/changelogs/fragments/1690-fix-copying-empty-file.yml
+++ b/changelogs/fragments/1690-fix-copying-empty-file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - fix copying empty file with older curl versions (https://github.com/ansible-collections/community.aws/issues/1686).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -893,13 +893,13 @@ class Connection(ConnectionBase):
 
         try:
             if ssm_action == 'get':
-                (returncode, stdout, stderr) = self._exec_transport_commands(put_commands)
+                (returncode, stdout, stderr) = self._exec_transport_commands(in_path, out_path, put_commands)
                 with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb') as data:
                     client.download_fileobj(bucket_name, s3_path, data)
             else:
                 with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as data:
                     client.upload_fileobj(data, bucket_name, s3_path, ExtraArgs=put_args)
-                (returncode, stdout, stderr) = self._exec_transport_commands(get_commands)
+                (returncode, stdout, stderr) = self._exec_transport_commands(in_path, out_path, get_commands)
             return (returncode, stdout, stderr)
         finally:
             # Remove the files from the bucket after they've been transferred

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -849,6 +849,15 @@ class Connection(ConnectionBase):
                     f"-o '{out_path}' "
                     f"'{get_url}'"
                 ),
+                # Due to https://github.com/curl/curl/issues/183 earlier
+                # versions of curl did not create the output file, when the
+                # response was empty. Although this issue was fixed in 2015,
+                # some actively maintained operating systems still use older
+                # versions of it (e.g. CentOS 7)
+                (
+                    "touch "
+                    f"'{out_path}'"
+                )
             ]
 
         return get_commands, put_commands, put_args

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -872,7 +872,7 @@ class Connection(ConnectionBase):
                 raise AnsibleError(
                     f"failed to transfer file to {in_path} {out_path}:\n"
                     f"{stdout}\n{stderr}")
-            
+
             stdout_combined += stdout
             stderr_combined += stderr
 
@@ -904,7 +904,6 @@ class Connection(ConnectionBase):
         finally:
             # Remove the files from the bucket after they've been transferred
             client.delete_object(Bucket=bucket_name, Key=s3_path)
-
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''

--- a/tests/integration/targets/connection/test_connection.yml
+++ b/tests/integration/targets/connection/test_connection.yml
@@ -6,6 +6,7 @@
     local_file: '{{ local_dir }}/汉语.txt'
     remote_dir: '{{ remote_tmp }}-汉语'
     remote_file: '{{ remote_dir }}/汉语.txt'
+    remote_empty_file: '{{ remote_dir }}/empty.txt'
   tasks:
 
   ### test wait_for_connection plugin
@@ -77,3 +78,15 @@
           - root
         loop_control:
           loop_var: user_name
+  
+  ### copy an empty file
+  - name: copy an empty file
+    action: "{{ action_prefix }}copy content= dest={{ remote_empty_file }}"
+  - name: stat empty file
+    action: "{{ action_prefix }}stat path={{ remote_empty_file }}"
+    register: stat_empty_file_cmd
+  - name: check that empty file exists
+    assert:
+      that:
+        - stat_empty_file_cmd.stat.isreg # it is a regular file
+        - stat_empty_file_cmd.stat.size == 0


### PR DESCRIPTION
##### SUMMARY
Fixes #1686.

Basically it is a workaround for curl, which did not create empty files when using the `-o` flag (https://github.com/curl/curl/issues/183). Although this issue was fixed in 2015, 'actively maintained operating systems' still use older of it (e.g. CentOS 7)

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
aws_ssm

##### ADDITIONAL INFORMATION
I was not able to test it yet in a relevant environment (e.g. with CentOS 7), will do so shortly.