### PR TITLE
elasticache: use an up to date node type in example

### DIFF
--- a/changelogs/fragments/elasticache-use-up-to-date-node-type-in-example.yaml
+++ b/changelogs/fragments/elasticache-use-up-to-date-node-type-in-example.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "elasticache - Use the ``cache.t3.small`` node type in the example. ``cache.m1.small`` is not deprecated."

--- a/plugins/modules/elasticache.py
+++ b/plugins/modules/elasticache.py
@@ -113,7 +113,7 @@ EXAMPLES = r"""
     state: present
     engine: memcached
     cache_engine_version: 1.4.14
-    node_type: cache.m1.small
+    node_type: cache.m3.small
     num_nodes: 1
     cache_port: 11211
     cache_security_groups:


### PR DESCRIPTION
The `cache.m1.small` node type is deprecated. It's not replaced by
`cache.t3.small`.

See: https://aws.amazon.com/elasticache/previous-generation/
