### PR TITLE
fixed unneeded `state` in module docs.

### DIFF
--- a/changelogs/fragments/1728_remove_state.yml
+++ b/changelogs/fragments/1728_remove_state.yml
@@ -1,0 +1,2 @@
+trivial: 
+- documentation - removed 'state' keyword

--- a/changelogs/fragments/1728_remove_state.yml
+++ b/changelogs/fragments/1728_remove_state.yml
@@ -1,2 +1,2 @@
 trivial: 
-- documentation - removed 'state' keyword
+- ec2_transit_gateway_vpc_attachement_info - removed incorrect ``state`` keyword from example (https://github.com/ansible-collections/community.aws/pull/1728).

--- a/plugins/modules/ec2_transit_gateway_vpc_attachment_info.py
+++ b/plugins/modules/ec2_transit_gateway_vpc_attachment_info.py
@@ -49,18 +49,15 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Describe a specific Transit Gateway attachment.
 - community.aws.ec2_transit_gateway_vpc_attachment_info:
-    state: present
     id: 'tgw-attach-0123456789abcdef0'
 
 # Describe all attachments attached to a transit gateway.
 - community.aws.ec2_transit_gateway_vpc_attachment_info:
-    state: present
     filters:
       transit-gateway-id: tgw-0fedcba9876543210'
 
 # Describe all attachments in an account.
 - community.aws.ec2_transit_gateway_vpc_attachment_info:
-    state: present
     filters:
       transit-gateway-id: tgw-0fedcba9876543210'
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
removed `state` as it does not work in the info part
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
"Unsupported parameters for (community.aws.ec2_transit_gateway_vpc_attachment_info) module: state. Supported parameters include: access_key, aws_ca_bundle, aws_config, debug_botocore_endpoint_logs, endpoint_url, filters, id, include_deleted, name, profile, region, secret_key, session_token, validate_certs (access_token, attachment_id, aws_access_key, aws_access_key_id, aws_endpoint_url, aws_profile, aws_region, aws_secret_access_key, aws_secret_key, aws_security_token, aws_session_token, ec2_access_key, ec2_region, ec2_secret_key, ec2_url, s3_url, security_token).",
```
