### PR TITLE
ses: fix clearing notification topic

### DIFF
--- a/changelogs/fragments/1730-ses-identity-fix-clearing-notification-topic.yml
+++ b/changelogs/fragments/1730-ses-identity-fix-clearing-notification-topic.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ses_identity - fix clearing notification topic (https://github.com/ansible-collections/community.aws/issues/150).

--- a/plugins/modules/ses_identity.py
+++ b/plugins/modules/ses_identity.py
@@ -304,22 +304,32 @@ def update_notification_topic(connection, module, identity, identity_notificatio
     if identity_notifications is None:
         # If there is no configuration for notifications cannot be being sent to topics
         # hence assume None as the current state.
-        current = None
+        current_topic = None
     elif topic_key in identity_notifications:
-        current = identity_notifications[topic_key]
+        current_topic = identity_notifications[topic_key]
     else:
         # If there is information on the notifications setup but no information on the
         # particular notification topic it's pretty safe to assume there's no topic for
         # this notification. AWS API docs suggest this information will always be
         # included but best to be defensive
-        current = None
+        current_topic = None
 
-    required = desired_topic(module, notification_type)
+    required_topic = desired_topic(module, notification_type)
 
-    if current != required:
+    if current_topic != required_topic:
         try:
             if not module.check_mode:
-                connection.set_identity_notification_topic(Identity=identity, NotificationType=notification_type, SnsTopic=required, aws_retry=True)
+                request_kwargs = {
+                    'Identity': identity,
+                    'NotificationType': notification_type,
+                    'aws_retry': True,
+                }
+
+                # The topic has to be omitted from the request to disable the notification.
+                if required_topic is not None:
+                    request_kwargs['SnsTopic'] = required_topic
+
+                connection.set_identity_notification_topic(**request_kwargs)
         except (BotoCoreError, ClientError) as e:
             module.fail_json_aws(e, msg='Failed to set identity notification topic for {identity} {notification_type}'.format(
                 identity=identity,

--- a/plugins/modules/ses_identity.py
+++ b/plugins/modules/ses_identity.py
@@ -291,10 +291,6 @@ def get_identity_notifications(connection, module, identity, retries=0, retryDel
     return notification_attributes[identity]
 
 
-def has_notification_configuration(module, notification_type):
-    return f"{notification_type.lower()}_notifications" in module.params
-
-
 def desired_topic(module, notification_type):
     arg_dict = module.params.get(notification_type.lower() + '_notifications')
     if arg_dict:
@@ -305,7 +301,7 @@ def desired_topic(module, notification_type):
 
 def update_notification_topic(connection, module, identity, identity_notifications, notification_type):
     # Not passing the parameter should not cause any changes.
-    if not has_notification_configuration(module, notification_type):
+    if module.params.get(f"{notification_type.lower()}_notifications") is None:
         return False
 
     topic_key = notification_type + 'Topic'

--- a/plugins/modules/ses_identity.py
+++ b/plugins/modules/ses_identity.py
@@ -291,6 +291,10 @@ def get_identity_notifications(connection, module, identity, retries=0, retryDel
     return notification_attributes[identity]
 
 
+def has_notification_configuration(module, notification_type):
+    return f'{notification_type.lower()}_notifications' in module.params
+
+
 def desired_topic(module, notification_type):
     arg_dict = module.params.get(notification_type.lower() + '_notifications')
     if arg_dict:
@@ -300,6 +304,10 @@ def desired_topic(module, notification_type):
 
 
 def update_notification_topic(connection, module, identity, identity_notifications, notification_type):
+    # Not passing the parameter should not cause any changes.
+    if not has_notification_configuration(module, notification_type):
+        return False
+
     topic_key = notification_type + 'Topic'
     if identity_notifications is None:
         # If there is no configuration for notifications cannot be being sent to topics

--- a/plugins/modules/ses_identity.py
+++ b/plugins/modules/ses_identity.py
@@ -292,7 +292,7 @@ def get_identity_notifications(connection, module, identity, retries=0, retryDel
 
 
 def has_notification_configuration(module, notification_type):
-    return f'{notification_type.lower()}_notifications' in module.params
+    return f"{notification_type.lower()}_notifications" in module.params
 
 
 def desired_topic(module, notification_type):
@@ -328,14 +328,14 @@ def update_notification_topic(connection, module, identity, identity_notificatio
         try:
             if not module.check_mode:
                 request_kwargs = {
-                    'Identity': identity,
-                    'NotificationType': notification_type,
-                    'aws_retry': True,
+                    "Identity": identity,
+                    "NotificationType": notification_type,
+                    "aws_retry": True,
                 }
 
                 # The topic has to be omitted from the request to disable the notification.
                 if required_topic is not None:
-                    request_kwargs['SnsTopic'] = required_topic
+                    request_kwargs["SnsTopic"] = required_topic
 
                 connection.set_identity_notification_topic(**request_kwargs)
         except (BotoCoreError, ClientError) as e:

--- a/tests/integration/targets/ses_identity/tasks/main.yaml
+++ b/tests/integration/targets/ses_identity/tasks/main.yaml
@@ -370,6 +370,40 @@
           identity: "{{ email_identity }}"
           state: absent
   # ============================================================
+  - name: test clear notification settings
+    block:
+      - name: test topic
+        sns_topic:
+          name: "{{ notification_queue_name }}-{{ item }}"
+          state: present
+        register: topic_info
+        with_items:
+          - bounce
+          - complaint
+          - delivery
+      - name: register email identity
+        aws_ses_identity:
+          identity: "{{ email_identity }}"
+          state: present
+          bounce_notifications:
+            topic: "{{ topic_info.results[0].sns_arn }}"
+          complaint_notifications:
+            topic: "{{ topic_info.results[1].sns_arn }}"
+          delivery_notifications:
+            topic: "{{ topic_info.results[2].sns_arn }}"
+      - name: clear notification settings
+        aws_ses_identity:
+          identity: "{{ email_identity }}"
+          state: present
+        register: result
+      - name: assert notification settings
+        assert:
+          that:
+            - result.changed == True
+            - "'bounce_topic' not in result.notification_attributes"
+            - "'delivery_topic' not in result.notification_attributes"
+            - "'complaint_topic' not in result.notification_attributes"
+  # ============================================================
   - name: test change notification settings check mode
     block:
       - name: test topic

--- a/tests/integration/targets/ses_identity/tasks/main.yaml
+++ b/tests/integration/targets/ses_identity/tasks/main.yaml
@@ -138,23 +138,23 @@
           state: present
         register: result
         check_mode: True
-  
+
       - name: assert changed is True
         assert:
           that:
             - result.changed == True
-  
+
       - import_tasks: assert_defaults.yaml
         vars:
           identity: "{{ email_identity }}"
-  
+
     always:
       - name: cleanup email identity
         aws_ses_identity:
           identity: "{{ email_identity }}"
           state: absent
         register: result
-  
+
       - name: assert nothing to clean up since check mode
         assert:
           that:
@@ -168,23 +168,23 @@
           state: present
         register: result
         check_mode: True
-  
+
       - name: assert changed is True
         assert:
           that:
             - result.changed == True
-  
+
       - import_tasks: assert_defaults.yaml
         vars:
           identity: "{{ domain_identity }}"
-  
+
     always:
       - name: cleanup domain identity
         aws_ses_identity:
           identity: "{{ domain_identity }}"
           state: absent
         register: result
-  
+
       - name: assert nothing to clean up since check mode
         assert:
           that:
@@ -217,14 +217,14 @@
           identity: "{{ email_identity }}"
           state: present
         register: result
-  
+
       - name: remove email identity check mode
         aws_ses_identity:
           identity: "{{ email_identity }}"
           state: absent
         register: result
         check_mode: True
-  
+
       - name: assert changed is True
         assert:
           that:
@@ -235,7 +235,7 @@
           identity: "{{ email_identity }}"
           state: absent
         register: result
-  
+
       - name: assert something to clean up since remove was check mode
         assert:
           that:
@@ -248,14 +248,14 @@
           identity: "{{ domain_identity }}"
           state: present
         register: result
-  
+
       - name: remove domain identity check mode
         aws_ses_identity:
           identity: "{{ domain_identity }}"
           state: absent
         register: result
         check_mode: True
-  
+
       - name: assert changed is True
         assert:
           that:
@@ -266,7 +266,7 @@
           identity: "{{ domain_identity }}"
           state: absent
         register: result
-  
+
       - name: assert something to clean up since remove was check mode
         assert:
           that:
@@ -391,6 +391,16 @@
             topic: "{{ topic_info.results[1].sns_arn }}"
           delivery_notifications:
             topic: "{{ topic_info.results[2].sns_arn }}"
+      - name: Make no change to identity
+        aws_ses_identity:
+          identity: "{{ email_identity }}"
+          state: present
+        register: result
+      - name: assert no change
+        assert:
+          that:
+            - result.changed == False
+
       - name: clear notification settings
         aws_ses_identity:
           identity: "{{ email_identity }}"
@@ -431,12 +441,12 @@
           - bounce
           - complaint
           - delivery
-  
+
       - name: register email identity
         aws_ses_identity:
           identity: "{{ email_identity }}"
           state: present
-  
+
       - name: set notification settings check mode
         aws_ses_identity:
           identity: "{{ email_identity }}"
@@ -453,12 +463,12 @@
           feedback_forwarding: No
         register: result
         check_mode: True
-  
+
       - name: assert changed is True
         assert:
           that:
             - result.changed == True
-  
+
       - name: assert notification settings
         assert:
           that:
@@ -469,13 +479,13 @@
             - result.notification_attributes.complaint_topic == topic_info.results[1].sns_arn
             - result.notification_attributes.headers_in_complaint_notifications_enabled == True
             - result.notification_attributes.forwarding_enabled == False
-  
+
       - name: re-register base email identity
         aws_ses_identity:
           identity: "{{ email_identity }}"
           state: present
         register: result
-  
+
       - name: assert no change since notifications were check mode
         assert:
           that:
@@ -487,7 +497,6 @@
             - "'complaint_topic' not in result.notification_attributes"
             - result.notification_attributes.headers_in_complaint_notifications_enabled == False
             - result.notification_attributes.forwarding_enabled == True
-  
     always:
       - name: cleanup topics
         sns_topic:
@@ -497,7 +506,7 @@
           - bounce
           - complaint
           - delivery
-  
+
       - name: cleanup email identity
         aws_ses_identity:
           identity: "{{ email_identity }}"

--- a/tests/integration/targets/ses_identity/tasks/main.yaml
+++ b/tests/integration/targets/ses_identity/tasks/main.yaml
@@ -403,6 +403,19 @@
             - "'bounce_topic' not in result.notification_attributes"
             - "'delivery_topic' not in result.notification_attributes"
             - "'complaint_topic' not in result.notification_attributes"
+    always:
+      - name: cleanup topics
+        sns_topic:
+          name: "{{ notification_queue_name }}-{{ item }}"
+          state: absent
+        with_items:
+          - bounce
+          - complaint
+          - delivery
+      - name: cleanup email identity
+        aws_ses_identity:
+          identity: "{{ email_identity }}"
+          state: absent
   # ============================================================
   - name: test change notification settings check mode
     block:

--- a/tests/integration/targets/ses_identity/tasks/main.yaml
+++ b/tests/integration/targets/ses_identity/tasks/main.yaml
@@ -370,7 +370,7 @@
           identity: "{{ email_identity }}"
           state: absent
   # ============================================================
-  - name: test clear notification settings
+  - name: test clear notification configuration
     block:
       - name: test topic
         sns_topic:
@@ -395,6 +395,9 @@
         aws_ses_identity:
           identity: "{{ email_identity }}"
           state: present
+          bounce_notifications: {}
+          complaint_notifications: {}
+          delivery_notifications: {}
         register: result
       - name: assert notification settings
         assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.aws/issues/150. As per [the docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.set_identity_notification_topic), the `SnsTopic` parameter has to be omitted from the request in order to clear the notification setting.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ses_identity`
