### PR TITLE
Add initial configuration for darker/black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+skip-string-normalization = false
+line-length = 120
+target-version = ['py37', 'py38']
+extend-exclude = '''
+/(
+  | plugins/module_utils/_version.py
+)/
+'''
+
+[tool.darker]
+revision = "origin/main.."
+
+src = [
+    "plugins",
+    "tests/unit",
+    "tests/integration",
+]


### PR DESCRIPTION
##### SUMMARY

Copies the "darker" / "black" configuration from amazon.aws

This does *not* add the GitHub action, this just adds some configuration so that black/darker will do the right thing if someone uses them: Mostly just sets line-length and Python 3.7 compatibility.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

pyproject.toml

##### ADDITIONAL INFORMATION
