### PR TITLE
Add http3 support in cloudfront_distribution module

### DIFF
--- a/changelogs/fragments/1753-cloudfront-add-http3.yml
+++ b/changelogs/fragments/1753-cloudfront-add-http3.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cloudfront_distribution - add http3 support (https://github.com/ansible-collections/community.aws/pull/1753).

--- a/changelogs/fragments/1753-cloudfront-add-http3.yml
+++ b/changelogs/fragments/1753-cloudfront-add-http3.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cloudfront_distribution - add http3 support (https://github.com/ansible-collections/community.aws/pull/1753).
+  - cloudfront_distribution - add ``http3`` suppoert via parameter value ``http2and3`` for parameter ``http_version`` (https://github.com/ansible-collections/community.aws/pull/1753).

--- a/changelogs/fragments/1753-cloudfront-add-http3.yml
+++ b/changelogs/fragments/1753-cloudfront-add-http3.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cloudfront_distribution - add ``http3`` suppoert via parameter value ``http2and3`` for parameter ``http_version`` (https://github.com/ansible-collections/community.aws/pull/1753).
+  - cloudfront_distribution - add ``http3`` support via parameter value ``http2and3`` for parameter ``http_version`` (https://github.com/ansible-collections/community.aws/pull/1753).

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -568,7 +568,7 @@ options:
       description:
         - The version of the http protocol to use for the distribution.
         - AWS defaults this to C(http2).
-        - Valid values are C(http1.1), C(http2), C(http2) and C(http2and3).
+        - Valid values are C(http1.1), C(http2), C(http3) and C(http2and3).
       type: str
 
     ipv6_enabled:

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1617,37 +1617,16 @@ class CloudFrontValidationManager(object):
             self.__valid_methods_cached_methods[1],
             self.__valid_methods
         ]
-        self.__valid_lambda_function_association_event_types = set([
-            'viewer-request',
-            'viewer-response',
-            'origin-request',
-            'origin-response'
-        ])
-        self.__valid_viewer_certificate_ssl_support_methods = set([
-            'sni-only',
-            'vip'
-        ])
-        self.__valid_viewer_certificate_minimum_protocol_versions = set([
-            'SSLv3',
-            'TLSv1',
-            'TLSv1_2016',
-            'TLSv1.1_2016',
-            'TLSv1.2_2018',
-            'TLSv1.2_2019',
-            'TLSv1.2_2021'
-        ])
-        self.__valid_viewer_certificate_certificate_sources = set([
-            'cloudfront',
-            'iam',
-            'acm'
-        ])
-        self.__valid_http_versions = set([
-            'http1.1',
-            'http2',
-            'http3',
-            'http2and3'
-        ])
-        self.__s3_bucket_domain_identifier = '.s3.amazonaws.com'
+        self.__valid_lambda_function_association_event_types = set(
+            ["viewer-request", "viewer-response", "origin-request", "origin-response"]
+        )
+        self.__valid_viewer_certificate_ssl_support_methods = set(["sni-only", "vip"])
+        self.__valid_viewer_certificate_minimum_protocol_versions = set(
+            ["SSLv3", "TLSv1", "TLSv1_2016", "TLSv1.1_2016", "TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021"]
+        )
+        self.__valid_viewer_certificate_certificate_sources = set(["cloudfront", "iam", "acm"])
+        self.__valid_http_versions = set(["http1.1", "http2", "http3", "http2and3"])
+        self.__s3_bucket_domain_identifier = ".s3.amazonaws.com"
 
     def add_missing_key(self, dict_object, key_to_set, value_to_set):
         if key_to_set not in dict_object and value_to_set is not None:

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -568,7 +568,7 @@ options:
       description:
         - The version of the http protocol to use for the distribution.
         - AWS defaults this to C(http2).
-        - Valid values are C(http1.1) and C(http2).
+        - Valid values are C(http1.1), C(http2), C(http2) and C(http2and3).
       type: str
 
     ipv6_enabled:
@@ -1643,7 +1643,9 @@ class CloudFrontValidationManager(object):
         ])
         self.__valid_http_versions = set([
             'http1.1',
-            'http2'
+            'http2',
+            'http3',
+            'http2and3'
         ])
         self.__s3_bucket_domain_identifier = '.s3.amazonaws.com'
 

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -86,6 +86,24 @@
         # - not cf_update_ipv6.changed
         - cf_update_ipv6.is_ipv6_enabled
   
+  - name: Ensure that default value of 'http_version' is 'http2'
+    assert:
+      that:
+        - cf_update_ipv6.http_version == 'http2'
+
+  - name: Update the distribution http_version to http2and3
+    cloudfront_distribution:
+      state: present
+      distribution_id: "{{ distribution_id }}"
+      http_version: http2and3
+    register: cf_update_http_version
+
+  - name: Ensure that default value of 'http_version' is 'http2and3'
+    assert:
+      that:
+        - cf_update_http_version.changed
+        - cf_update_http_version.http_version == 'http2and3'
+
   # - name: re-run cloudfront distribution with same defaults
   #   cloudfront_distribution:
   #     distribution_id: "{{ distribution_id }}"


### PR DESCRIPTION
##### SUMMARY
Add http3 support to `cloudfront_distribution` module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`cloudfront_distribution.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Tests failure seem to be unrelated to this PR.