### PR TITLE
Add version_description to ec2_launch_template

### DIFF
--- a/changelogs/fragments/1763-ec2-launch-template-add-version-description.yml
+++ b/changelogs/fragments/1763-ec2-launch-template-add-version-description.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ec2_launch_template - Add argument to config `VersionDescription` of a EC2 launch template.
+  - ec2_launch_template - Add parameter ``version_description`` (https://github.com/ansible-collections/community.aws/pull/1763).

--- a/changelogs/fragments/1763-ec2-launch-template-add-version-description.yml
+++ b/changelogs/fragments/1763-ec2-launch-template-add-version-description.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_launch_template - Add argument to config `VersionDescription` of a EC2 launch template.

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -582,7 +582,10 @@ def create_or_update(module, template_options):
         out['changed'] = True
     elif template and template_versions:
         most_recent = sorted(template_versions, key=lambda x: x['VersionNumber'])[-1]
-        if lt_data == most_recent['LaunchTemplateData'] and module.params['version_description'] == most_recent['VersionDescription']:
+        if (
+            lt_data == most_recent['LaunchTemplateData']
+            and module.params['version_description'] == most_recent.get('VersionDescription', '')
+        ):
             out['changed'] = False
             return out
         try:

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -582,7 +582,7 @@ def create_or_update(module, template_options):
         out['changed'] = True
     elif template and template_versions:
         most_recent = sorted(template_versions, key=lambda x: x['VersionNumber'])[-1]
-        if lt_data == most_recent['LaunchTemplateData']:
+        if lt_data == most_recent['LaunchTemplateData'] and module.params['version_description'] == most_recent['VersionDescription']:
             out['changed'] = False
             return out
         try:

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -38,6 +38,11 @@ options:
     - Which version should be the default when users spin up new instances based on this template? By default, the latest version will be made the default.
     type: str
     default: latest
+  version_description:
+    description:
+    - The description of a launch template version.
+    default: ""
+    type: str
   state:
     description:
     - Whether the launch template should exist or not.
@@ -586,6 +591,7 @@ def create_or_update(module, template_options):
                     LaunchTemplateId=template['LaunchTemplateId'],
                     LaunchTemplateData=lt_data,
                     ClientToken=uuid4().hex,
+                    VersionDescription=str(module.params['version_description']),
                     aws_retry=True,
                 )
             elif module.params.get('source_version') == 'latest':
@@ -594,6 +600,7 @@ def create_or_update(module, template_options):
                     LaunchTemplateData=lt_data,
                     ClientToken=uuid4().hex,
                     SourceVersion=str(most_recent['VersionNumber']),
+                    VersionDescription=str(module.params['version_description']),
                     aws_retry=True,
                 )
             else:
@@ -610,6 +617,7 @@ def create_or_update(module, template_options):
                     LaunchTemplateData=lt_data,
                     ClientToken=uuid4().hex,
                     SourceVersion=str(source_version['VersionNumber']),
+                    VersionDescription=str(module.params['version_description']),
                     aws_retry=True,
                 )
 
@@ -786,7 +794,8 @@ def main():
         template_name=dict(aliases=['name']),
         template_id=dict(aliases=['id']),
         default_version=dict(default='latest'),
-        source_version=dict(default='latest')
+        source_version=dict(default='latest'),
+        version_description=dict(default=''),
     )
 
     arg_spec.update(template_options)

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -582,10 +582,9 @@ def create_or_update(module, template_options):
         template, template_versions = existing_templates(module)
         out['changed'] = True
     elif template and template_versions:
-        most_recent = sorted(template_versions, key=lambda x: x['VersionNumber'])[-1]
-        if (
-            lt_data == most_recent['LaunchTemplateData']
-            and module.params['version_description'] == most_recent.get('VersionDescription', '')
+        most_recent = sorted(template_versions, key=lambda x: x["VersionNumber"])[-1]
+        if lt_data == most_recent["LaunchTemplateData"] and module.params["version_description"] == most_recent.get(
+            "VersionDescription", ""
         ):
             out['changed'] = False
             return out
@@ -595,7 +594,7 @@ def create_or_update(module, template_options):
                     LaunchTemplateId=template['LaunchTemplateId'],
                     LaunchTemplateData=lt_data,
                     ClientToken=uuid4().hex,
-                    VersionDescription=str(module.params['version_description']),
+                    VersionDescription=str(module.params["version_description"]),
                     aws_retry=True,
                 )
             elif module.params.get('source_version') == 'latest':
@@ -603,8 +602,8 @@ def create_or_update(module, template_options):
                     LaunchTemplateId=template['LaunchTemplateId'],
                     LaunchTemplateData=lt_data,
                     ClientToken=uuid4().hex,
-                    SourceVersion=str(most_recent['VersionNumber']),
-                    VersionDescription=str(module.params['version_description']),
+                    SourceVersion=str(most_recent["VersionNumber"]),
+                    VersionDescription=str(module.params["version_description"]),
                     aws_retry=True,
                 )
             else:
@@ -620,8 +619,8 @@ def create_or_update(module, template_options):
                     LaunchTemplateId=template['LaunchTemplateId'],
                     LaunchTemplateData=lt_data,
                     ClientToken=uuid4().hex,
-                    SourceVersion=str(source_version['VersionNumber']),
-                    VersionDescription=str(module.params['version_description']),
+                    SourceVersion=str(source_version["VersionNumber"]),
+                    VersionDescription=str(module.params["version_description"]),
                     aws_retry=True,
                 )
 
@@ -794,12 +793,12 @@ def main():
     )
 
     arg_spec = dict(
-        state=dict(choices=['present', 'absent'], default='present'),
-        template_name=dict(aliases=['name']),
-        template_id=dict(aliases=['id']),
-        default_version=dict(default='latest'),
-        source_version=dict(default='latest'),
-        version_description=dict(default=''),
+        state=dict(choices=["present", "absent"], default="present"),
+        template_name=dict(aliases=["name"]),
+        template_id=dict(aliases=["id"]),
+        default_version=dict(default="latest"),
+        source_version=dict(default="latest"),
+        version_description=dict(default=""),
     )
 
     arg_spec.update(template_options)

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -39,6 +39,7 @@ options:
     type: str
     default: latest
   version_description:
+    version_added: 5.5.0
     description:
     - The description of a launch template version.
     default: ""

--- a/tests/integration/targets/ec2_launch_template/tasks/versions.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/versions.yml
@@ -69,6 +69,21 @@
         - lt.latest_version == 4
         - lt.latest_template.launch_template_data.instance_type == "c4.large"
 
+  - name: update simple instance template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-simple"
+      version_description: "Fix something."
+    register: lt
+
+  - name: instance with cpu_options created with the right options
+    assert:
+      that:
+        - lt is success
+        - lt is changed
+        - lt.default_version == 5
+        - lt.latest_version == 5
+        - lt.latest_template.version_description == "Fix something."
+
   always:
   - name: delete the template
     ec2_launch_template:


### PR DESCRIPTION
##### SUMMARY
Add `version_description` to ec2_launch_template module, which allows user update the `VersionDescription` of a launch template.

Fix #1762
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_launch_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
