### PR TITLE
elasticache_info: ignore CacheClusterNotFound exeption during tag collect

### DIFF
--- a/changelogs/fragments/elasticache_info-ignore-CacheClusterNotFound-when-reading-tags.yaml
+++ b/changelogs/fragments/elasticache_info-ignore-CacheClusterNotFound-when-reading-tags.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "elasticache_info - Ignore the CacheClusterNotFound exception when collecting tags (https://github.com/ansible-collections/community.aws/pull/1777)."

--- a/plugins/modules/elasticache_info.py
+++ b/plugins/modules/elasticache_info.py
@@ -471,7 +471,7 @@ def get_elasticache_clusters(client, module):
         arn = "arn:aws:elasticache:%s:%s:cluster:%s" % (region, account_id, cluster['cache_cluster_id'])
         try:
             tags = get_elasticache_tags_with_backoff(client, arn)
-        except is_boto3_error_code('CacheClusterNotFound'):
+        except is_boto3_error_code("CacheClusterNotFound"):
             # e.g: Cluster was listed but is in deleting state
             continue
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/plugins/modules/elasticache_info.py
+++ b/plugins/modules/elasticache_info.py
@@ -471,6 +471,9 @@ def get_elasticache_clusters(client, module):
         arn = "arn:aws:elasticache:%s:%s:cluster:%s" % (region, account_id, cluster['cache_cluster_id'])
         try:
             tags = get_elasticache_tags_with_backoff(client, arn)
+        except is_boto3_error_code('CacheClusterNotFound'):
+            # e.g: Cluster was listed but is in deleting state
+            continue
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Couldn't get tags for cluster %s")
 


### PR DESCRIPTION
If we call `get_elasticache_tags_with_backoff()` on a cluster with an invalid
state (eg: deleting), AWS will trigger an `CacheClusterNotFound`.

With this change, `elasticache_info` will ignore the cluster and continue with
the next one.
