### PR TITLE
eks_nodegroup - fixing remote access and added to integration tests

### DIFF
--- a/changelogs/fragments/1771-remote-access.yml
+++ b/changelogs/fragments/1771-remote-access.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - eks_nodegroup - fix parameter options of ``remote_access`` (https://github.com/ansible-collections/community.aws/issues/1771).

--- a/plugins/modules/eks_nodegroup.py
+++ b/plugins/modules/eks_nodegroup.py
@@ -515,7 +515,11 @@ def create_or_update_nodegroups(client, module):
     if module.params['release_version'] is not None:
         params['releaseVersion'] = module.params['release_version']
     if module.params['remote_access'] is not None:
-        params['remoteAccess'] = module.params['remote_access']
+        params['remoteAccess'] = dict()
+        if module.params['remote_access']['ec2_ssh_key'] is not None:
+            params['remoteAccess']['ec2SshKey'] = module.params['remote_access']['ec2_ssh_key']
+        if module.params['remote_access']['source_sg'] is not None:
+            params['remoteAccess']['sourceSecurityGroups'] = module.params['remote_access']['source_sg']
     if module.params['capacity_type'] is not None:
         params['capacityType'] = module.params['capacity_type'].upper()
     if module.params['labels'] is not None:

--- a/tests/integration/targets/eks_nodegroup/tasks/cleanup.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/cleanup.yml
@@ -37,6 +37,19 @@
   with_items: '{{ eks_security_groups|reverse|list + additional_eks_sg }}'
   ignore_errors: 'yes'
 
+- name: Delete securitygroup for node access
+  amazon.aws.ec2_security_group:
+    name: 'ansible-test-eks_nodegroup'
+    description: "SSH access"
+    vpc_id: '{{ setup_vpc.vpc.id }}'
+    rules: []
+    state: absent
+
+- name: Delete Keypair for Access to Nodegroup nodes
+  amazon.aws.ec2_key:
+    name: "ansible-test-eks_nodegroup"
+    state: absent
+
 - name: remove Route Tables
   ec2_vpc_route_table:
     state: absent

--- a/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
@@ -106,3 +106,20 @@
     default_version: 1
     instance_type: t3.micro
   register: lt
+
+- name: Create securitygroup for node access
+  amazon.aws.ec2_security_group:
+    name: 'ansible-test-eks_nodegroup'
+    description: "SSH access"
+    vpc_id: '{{ setup_vpc.vpc.id }}'
+    rules:
+      - proto: tcp
+        ports:
+          - 22
+        cidr_ip: 0.0.0.0/0
+  register: securitygroup_eks_nodegroup
+
+- name: Create Keypair for Access to Nodegroup nodes
+  amazon.aws.ec2_key:
+    name: "ansible-test-eks_nodegroup"
+  register: ec2_key_eks_nodegroup

--- a/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
@@ -80,6 +80,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
   check_mode: True
@@ -114,6 +118,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
 
@@ -147,6 +155,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
   check_mode: True
@@ -181,6 +193,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
   check_mode: True
@@ -255,6 +271,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
   check_mode: True
@@ -289,6 +309,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
 
@@ -322,6 +346,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
   check_mode: True
@@ -356,6 +384,10 @@
     capacity_type: 'SPOT'
     tags:
       'foo': 'bar'
+    remote_access:
+      ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
+      source_sg:
+        - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
   register: eks_nodegroup_result
 


### PR DESCRIPTION
##### SUMMARY

**This was incorrectly merged directly into stable-5 rather than main.**

Fixes https://github.com/ansible-collections/community.aws/issues/1771

Handling remote_access configuration the right way that boto understands it. Also included it to integration tests.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

eks_nodegroup

##### ADDITIONAL INFORMATION

This is pulling #1773 from stable-5 into main
Reviewed-by: Markus Bergholz
Reviewed-by: Thomas Bruckmann
Reviewed-by: Mark Chappell
