### PR TITLE
aws_config_delivery_channel - Add support for KMS encryption

### DIFF
--- a/changelogs/fragments/20230424-config-delivery-channel.yml
+++ b/changelogs/fragments/20230424-config-delivery-channel.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - aws_config_delivery_channel - add support for encrypted objects in S3 via KMS key.

--- a/changelogs/fragments/20230424-config-delivery-channel.yml
+++ b/changelogs/fragments/20230424-config-delivery-channel.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - aws_config_delivery_channel - add support for encrypted objects in S3 via KMS key.
+  - aws_config_delivery_channel - add support for encrypted objects in S3 via KMS key (https://github.com/ansible-collections/community.aws/pull/1786).

--- a/plugins/modules/config_delivery_channel.py
+++ b/plugins/modules/config_delivery_channel.py
@@ -93,19 +93,23 @@ from ansible_collections.community.aws.plugins.module_utils.modules import Ansib
 # this waits for an IAM role to become fully available, at the cost of
 # taking a long time to fail when the IAM role/policy really is invalid
 retry_unavailable_iam_on_put_delivery = AWSRetry.jittered_backoff(
-    catch_extra_error_codes=['InsufficientDeliveryPolicyException'],
+    catch_extra_error_codes=["InsufficientDeliveryPolicyException"],
 )
 
 
 def resource_exists(client, module, params):
     try:
         channel = client.describe_delivery_channels(
-            DeliveryChannelNames=[params['name']],
-            aws_retry=True,)
-        return channel['DeliveryChannels'][0]
-    except is_boto3_error_code('NoSuchDeliveryChannelException'):
+            DeliveryChannelNames=[params["name"]],
+            aws_retry=True,
+        )
+        return channel["DeliveryChannels"][0]
+    except is_boto3_error_code("NoSuchDeliveryChannelException"):
         return
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except (
+        botocore.exceptions.ClientError,
+        botocore.exceptions.BotoCoreError,
+    ) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
 
 
@@ -116,48 +120,58 @@ def create_resource(client, module, params, result):
         )(
             DeliveryChannel=params,
         )
-        result['changed'] = True
-        result['channel'] = camel_dict_to_snake_dict(resource_exists(client, module, params))
+        result["changed"] = True
+        result["channel"] = camel_dict_to_snake_dict(resource_exists(client, module, params))
         return result
-    except is_boto3_error_code('InvalidS3KeyPrefixException') as e:
+    except is_boto3_error_code("InvalidS3KeyPrefixException") as e:
         module.fail_json_aws(e, msg="The `s3_prefix` parameter was invalid. Try '/' for no prefix")
-    except is_boto3_error_code('InsufficientDeliveryPolicyException') as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="The `s3_prefix` or `s3_bucket` parameter is invalid. "
-                             "Make sure the bucket exists and is available")
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
+    except is_boto3_error_code("InsufficientDeliveryPolicyException") as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(
+            e,
+            msg="The `s3_prefix` or `s3_bucket` parameter is invalid. " "Make sure the bucket exists and is available",
+        )
+    except (
+        botocore.exceptions.ClientError,
+        botocore.exceptions.BotoCoreError,
+    ) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Couldn't create AWS Config delivery channel")
 
 
 def update_resource(client, module, params, result):
     current_params = client.describe_delivery_channels(
-        DeliveryChannelNames=[params['name']],
-        aws_retry=True,)
+        DeliveryChannelNames=[params["name"]],
+        aws_retry=True,
+    )
 
-    if params != current_params['DeliveryChannels'][0]:
+    if params != current_params["DeliveryChannels"][0]:
         try:
             retry_unavailable_iam_on_put_delivery(
                 client.put_delivery_channel,
             )(
                 DeliveryChannel=params,
             )
-            result['changed'] = True
-            result['channel'] = camel_dict_to_snake_dict(resource_exists(client, module, params))
+            result["changed"] = True
+            result["channel"] = camel_dict_to_snake_dict(resource_exists(client, module, params))
             return result
-        except is_boto3_error_code('InvalidS3KeyPrefixException') as e:
+        except is_boto3_error_code("InvalidS3KeyPrefixException") as e:
             module.fail_json_aws(e, msg="The `s3_prefix` parameter was invalid. Try '/' for no prefix")
-        except is_boto3_error_code('InsufficientDeliveryPolicyException') as e:  # pylint: disable=duplicate-except
-            module.fail_json_aws(e, msg="The `s3_prefix` or `s3_bucket` parameter is invalid. "
-                                 "Make sure the bucket exists and is available")
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
+        except is_boto3_error_code("InsufficientDeliveryPolicyException") as e:  # pylint: disable=duplicate-except
+            module.fail_json_aws(
+                e,
+                msg="The `s3_prefix` or `s3_bucket` parameter is invalid. "
+                "Make sure the bucket exists and is available",
+            )
+        except (
+            botocore.exceptions.ClientError,
+            botocore.exceptions.BotoCoreError,
+        ) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Couldn't create AWS Config delivery channel")
 
 
 def delete_resource(client, module, params, result):
     try:
-        response = client.delete_delivery_channel(
-            DeliveryChannelName=params['name']
-        )
-        result['changed'] = True
+        response = client.delete_delivery_channel(DeliveryChannelName=params["name"])
+        result["changed"] = True
         return result
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't delete AWS Config delivery channel")
@@ -166,64 +180,53 @@ def delete_resource(client, module, params, result):
 def main():
     module = AnsibleAWSModule(
         argument_spec={
-            'name': dict(type='str', required=True),
-            'state': dict(type='str', choices=['present', 'absent'], default='present'),
-            's3_bucket': dict(type='str', required=True),
-            's3_prefix': dict(type='str'),
-            'kms_key_arn': dict(type='str', no_log=True),
-            'sns_topic_arn': dict(type='str'),
-            'delivery_frequency': dict(
-                type='str',
-                choices=[
-                    'One_Hour',
-                    'Three_Hours',
-                    'Six_Hours',
-                    'Twelve_Hours',
-                    'TwentyFour_Hours'
-                ]
+            "name": dict(type="str", required=True),
+            "state": dict(type="str", choices=["present", "absent"], default="present"),
+            "s3_bucket": dict(type="str", required=True),
+            "s3_prefix": dict(type="str"),
+            "kms_key_arn": dict(type="str", no_log=True),
+            "sns_topic_arn": dict(type="str"),
+            "delivery_frequency": dict(
+                type="str", choices=["One_Hour", "Three_Hours", "Six_Hours", "Twelve_Hours", "TwentyFour_Hours"]
             ),
         },
         supports_check_mode=False,
     )
 
-    result = {
-        'changed': False
-    }
+    result = {"changed": False}
 
-    name = module.params.get('name')
-    state = module.params.get('state')
+    name = module.params.get("name")
+    state = module.params.get("state")
 
     params = {}
     if name:
-        params['name'] = name
-    if module.params.get('s3_bucket'):
-        params['s3BucketName'] = module.params.get('s3_bucket')
-    if module.params.get('s3_prefix'):
-        params['s3KeyPrefix'] = module.params.get('s3_prefix')
-    if module.params.get('kms_key_arn'):
-        params['s3KmsKeyArn'] = module.params.get('kms_key_arn')
-    if module.params.get('sns_topic_arn'):
-        params['snsTopicARN'] = module.params.get('sns_topic_arn')
-    if module.params.get('delivery_frequency'):
-        params['configSnapshotDeliveryProperties'] = {
-            'deliveryFrequency': module.params.get('delivery_frequency')
-        }
+        params["name"] = name
+    if module.params.get("s3_bucket"):
+        params["s3BucketName"] = module.params.get("s3_bucket")
+    if module.params.get("s3_prefix"):
+        params["s3KeyPrefix"] = module.params.get("s3_prefix")
+    if module.params.get("kms_key_arn"):
+        params["s3KmsKeyArn"] = module.params.get("kms_key_arn")
+    if module.params.get("sns_topic_arn"):
+        params["snsTopicARN"] = module.params.get("sns_topic_arn")
+    if module.params.get("delivery_frequency"):
+        params["configSnapshotDeliveryProperties"] = {"deliveryFrequency": module.params.get("delivery_frequency")}
 
-    client = module.client('config', retry_decorator=AWSRetry.jittered_backoff())
+    client = module.client("config", retry_decorator=AWSRetry.jittered_backoff())
     resource_status = resource_exists(client, module, params)
 
-    if state == 'present':
+    if state == "present":
         if not resource_status:
             create_resource(client, module, params, result)
         if resource_status:
             update_resource(client, module, params, result)
 
-    if state == 'absent':
+    if state == "absent":
         if resource_status:
             delete_resource(client, module, params, result)
 
     module.exit_json(**result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/config_delivery_channel.py
+++ b/plugins/modules/config_delivery_channel.py
@@ -170,7 +170,7 @@ def main():
             'state': dict(type='str', choices=['present', 'absent'], default='present'),
             's3_bucket': dict(type='str', required=True),
             's3_prefix': dict(type='str'),
-            'kms_key_arn': dict(type='str'),
+            'kms_key_arn': dict(type='str', no_log=True),
             'sns_topic_arn': dict(type='str'),
             'delivery_frequency': dict(
                 type='str',

--- a/plugins/modules/config_delivery_channel.py
+++ b/plugins/modules/config_delivery_channel.py
@@ -74,6 +74,7 @@ EXAMPLES = '''
     kms_key_arn: 'arn:aws:kms:us-east-1:123456789012:key/160f41cb-e660-4fa0-8bf6-976f53bf7851
     sns_topic_arn: 'arn:aws:sns:us-east-1:123456789012:aws_config_topic:1234ab56-cdef-7g89-01hi-2jk34l5m67no'
     delivery_frequency: 'Twelve_Hours'
+"""
 
 RETURN = r"""#"""
 

--- a/plugins/modules/config_delivery_channel.py
+++ b/plugins/modules/config_delivery_channel.py
@@ -57,8 +57,6 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 - name: Create a delivery channel for AWS Config
-EXAMPLES = '''
-- name: Create a delivery channel for AWS Config
   community.aws.config_delivery_channel:
     name: test_delivery_channel
     state: present

--- a/plugins/modules/config_delivery_channel.py
+++ b/plugins/modules/config_delivery_channel.py
@@ -69,7 +69,7 @@ EXAMPLES = r"""
     name: test_delivery_channel
     state: present
     s3_bucket: 'test_aws_config_bucket'
-    kms_key_arn: 'arn:aws:kms:us-east-1:123456789012:key/160f41cb-e660-4fa0-8bf6-976f53bf7851
+    kms_key_arn: 'arn:aws:kms:us-east-1:123456789012:key/160f41cb-e660-4fa0-8bf6-976f53bf7851'
     sns_topic_arn: 'arn:aws:sns:us-east-1:123456789012:aws_config_topic:1234ab56-cdef-7g89-01hi-2jk34l5m67no'
     delivery_frequency: 'Twelve_Hours'
 """

--- a/tests/integration/targets/config/defaults/main.yaml
+++ b/tests/integration/targets/config/defaults/main.yaml
@@ -1,4 +1,5 @@
 ---
 config_s3_bucket: '{{ resource_prefix }}-config-records'
+config_kms_key: '{{ resource_prefix }}-kms'
 config_sns_name: '{{ resource_prefix }}-delivery-channel-test-topic'
 config_role_name: 'ansible-test-{{ resource_prefix }}'

--- a/tests/integration/targets/config/tasks/main.yaml
+++ b/tests/integration/targets/config/tasks/main.yaml
@@ -13,6 +13,13 @@
     # ============================================================
     # Prerequisites
     # ============================================================
+    - name: get ARN of calling user
+      aws_caller_info:
+      register: aws_caller_info
+
+    - name: Store Account ID for later use
+      set_fact:
+        aws_account_id: "{{ aws_caller_info.account }}"
 
     - name: ensure IAM role exists
       iam_role:
@@ -21,7 +28,7 @@
         state: present
         create_instance_profile: no
         managed_policy:
-        - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
+        - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
       register: config_iam_role
 
     - name: ensure SNS topic exists
@@ -36,6 +43,12 @@
     - name: ensure S3 bucket exists
       s3_bucket:
         name: "{{ config_s3_bucket }}"
+
+    - name: ensure KMS key exists
+      kms_key:
+        alias: "{{ config_kms_key }}"
+        policy: "{{ lookup('template', 'config-kms-policy.json.j2') }}"
+      register: kms_key
 
     - name: ensure S3 access for IAM role
       iam_policy:
@@ -184,6 +197,21 @@
         that:
           - output.changed
 
+    - name: Create Delivery Channel for AWS Config with a KMS key
+      aws_config_delivery_channel:
+        name: '{{ resource_prefix }}-channel'
+        state: present
+        s3_bucket: "{{ config_s3_bucket }}"
+        s3_prefix: "foo/bar"
+        kms_key_arn: "{{ kms_key.key_arn }}"
+        sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        delivery_frequency: 'Twelve_Hours'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
     - name: Create Config Rule for AWS Config
       aws_config_rule:
         name: '{{ resource_prefix }}-rule'
@@ -256,6 +284,20 @@
         state: present
         s3_bucket: "{{ config_s3_bucket }}"
         sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        delivery_frequency: 'TwentyFour_Hours'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    - name: Update Delivery Channel with KMS key
+      aws_config_delivery_channel:
+        name: '{{ resource_prefix }}-channel'
+        state: present
+        s3_bucket: "{{ config_s3_bucket }}"
+        sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        kms_key_arn: "{{ kms_key.key_arn }}"
         delivery_frequency: 'TwentyFour_Hours'
       register: output
 
@@ -397,7 +439,7 @@
         name: '{{ resource_prefix }}-recorder'
         state: absent
       register: output
-      ignore_errors: yes
+      ignore_errors: true
 
 #    - assert:
 #        that:
@@ -411,7 +453,7 @@
         sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
         delivery_frequency: 'TwentyFour_Hours'
       register: output
-      ignore_errors: yes
+      ignore_errors: true
 
 #    - assert:
 #        that:
@@ -429,7 +471,7 @@
             owner: AWS
             identifier: 'S3_BUCKET_PUBLIC_READ_PROHIBITED'
       register: output
-      ignore_errors: yes
+      ignore_errors: true
 
 #    - assert:
 #        that:
@@ -445,23 +487,29 @@
         policy_name: AwsConfigRecorderTestRoleS3Policy
         state: absent
         policy_json: "{{ lookup( 'template', 'config-s3-policy.json.j2') }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove IAM role
       iam_role:
         name: '{{ config_role_name }}'
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove SNS topic
       sns_topic:
         name: '{{ config_sns_name }}'
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove S3 bucket
       s3_bucket:
         name: "{{ config_s3_bucket }}"
         state: absent
-        force: yes
-      ignore_errors: yes
+        force: true
+      ignore_errors: true
+
+    - name: remove KMS key
+      kms_key:
+        alias: "{{ config_kms_key }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/config/templates/config-kms-policy.json.j2
+++ b/tests/integration/targets/config/templates/config-kms-policy.json.j2
@@ -1,0 +1,51 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::{{ aws_account_id }}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow use of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig",
+                ]
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow attachment of persistent resources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::{{ aws_account_id }}:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig",
+                ]
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
##### SUMMARY
Add support for KMS keys when creating an AWS  Config delivery channel


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->


- Feature Pull Request


##### COMPONENT NAME
`aws_config_delivery_channel`

##### ADDITIONAL INFORMATION
AWS added support for KMS encryption of objects stored in S3. This adds that option via a new `kms_key_arn` module option.
