### PR TITLE
cloudformation_stack_set - Add a waiter to ensure that running operations against existing stacksets complete

### DIFF
--- a/changelogs/fragments/20230424-cloudformation_stack_set.yml
+++ b/changelogs/fragments/20230424-cloudformation_stack_set.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cloudformation_stack_set - add a waiter to ensure that update operation complete before adding stack instances (https://github.com/ansible-collections/community.aws/issues/1608).

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -679,9 +679,12 @@ def main():
             changed |= update_stack_set(module, stack_params, cfn)
 
             await_stack_set_operation(
-                module, cfn, operation_id=stack_params['OperationId'],
-                stack_set_name=stack_params['StackSetName'],
-                max_wait=module.params.get('wait_timeout'),)
+                module,
+                cfn,
+                operation_id=stack_params["OperationId"],
+                stack_set_name=stack_params["StackSetName"],
+                max_wait=module.params.get("wait_timeout"),
+            )
 
         # now create/update any appropriate stack instances
         new_stack_instances, existing_stack_instances, unspecified_stack_instances = compare_stack_instances(

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -655,6 +655,11 @@ def main():
                 stack_params["OperationPreferences"] = get_operation_preferences(module)
             changed |= update_stack_set(module, stack_params, cfn)
 
+            await_stack_set_operation(
+                module, cfn, operation_id=stack_params['OperationId'],
+                stack_set_name=stack_params['StackSetName'],
+                max_wait=module.params.get('wait_timeout'),)
+
         # now create/update any appropriate stack instances
         new_stack_instances, existing_stack_instances, unspecified_stack_instances = compare_stack_instances(
             cfn,

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -182,9 +182,11 @@ EXAMPLES = r"""
     description: Test stack in two accounts
     state: present
     template_url: https://s3.amazonaws.com/my-bucket/cloudformation.template
-    accounts: [1234567890, 2345678901]
+    accounts:
+      - 123456789012
+      - 234567890123
     regions:
-    - us-east-1
+      - us-east-1
 
 - name: on subsequent calls, templates are optional but parameters and tags can be altered
   community.aws.cloudformation_stack_set:
@@ -195,9 +197,11 @@ EXAMPLES = r"""
     tags:
       foo: bar
       test: stack
-    accounts: [1234567890, 2345678901]
+    accounts:
+      - 123456789012
+      - 234567890123
     regions:
-    - us-east-1
+     - us-east-1
 
 - name: The same type of update, but wait for the update to complete in all stacks
   community.aws.cloudformation_stack_set:
@@ -209,7 +213,26 @@ EXAMPLES = r"""
     tags:
       foo: bar
       test: stack
-    accounts: [1234567890, 2345678901]
+    accounts:
+      - 123456789012
+      - 234567890123
+    regions:
+    - us-east-1
+
+- name: Register new accounts (create new stack instances) with an existing stack set.
+  community.aws.cloudformation_stack_set:
+    name: my-stack
+    state: present
+    wait: true
+    parameters:
+      InstanceName: my_restacked_instance
+    tags:
+      foo: bar
+      test: stack
+    accounts:
+      - 123456789012
+      - 234567890123
+      - 345678901234
     regions:
     - us-east-1
 """

--- a/tests/integration/targets/cloudformation_stack_set/tasks/main.yml
+++ b/tests/integration/targets/cloudformation_stack_set/tasks/main.yml
@@ -14,9 +14,9 @@
       aws_secret_key: "{{ secondary_aws_secret_key }}"
       security_token: "{{ secondary_security_token }}"
       region: "{{ aws_region }}"
-  no_log: yes
+  no_log: true
 
-- name: cloudformation_stack_set tests 
+- name: cloudformation_stack_set tests
   collections:
     - amazon.aws
 


### PR DESCRIPTION
##### SUMMARY
Add a waiter to ensure that running operations against existing stacksets complete. Current code would fail in cases where new instances need to be added since the previous `update_stack_set(module, stack_params, cfn)` would still be running.
Fixes #1608 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`cloudformation_stack_set`

##### ADDITIONAL INFORMATION
I initially thought that the module was not idempotent since new instances wouldn't be added to my existing stack sets. Upon closer examination, the issue had to do with the fact that we had prior calls being made before adding new instances to existing stack sets:

```python
raise error_class(parsed_response, operation_name)\nbotocore.errorfactory.OperationInProgressException: 
    An error occurred (OperationInProgressException) when calling the UpdateStackInstances operation:
    Another Operation on StackSet arn:aws:cloudformation:us-east-1:XXXXXX:stackset/aws-config-stackset:2bcb419a-f263-48ca-9fe0-cdef11fb59de is in progress
```

The error got triggered because of a missing waiter after this operation:

```python
changed |= update_stack_set(module, stack_params, cfn)
```

This change add a waiter function after the update operation, which, in turn, ensure that the subsequent call to add stack instances to the stack set properly run.
