### PR TITLE
Fix integration tests trying to install *old* botocore versions

### DIFF
--- a/tests/integration/targets/dynamodb_table/meta/main.yml
+++ b/tests/integration/targets/dynamodb_table/meta/main.yml
@@ -1,4 +1,1 @@
-dependencies:
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.23.18"
+dependencies: []

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -588,8 +588,6 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     check_mode: True
 
   - name: Check results - Create complex table - check_mode
@@ -612,8 +610,6 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - name: Check results - Create complex table
     assert:
@@ -656,8 +652,6 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     check_mode: True
 
   - name: Check results - Create complex table - idempotent - check_mode
@@ -680,8 +674,6 @@
       tags: "{{ tags_default }}"
       indexes: "{{ indexes }}"
     register: create_complex_table
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - name: Check results - Create complex table - idempotent
     assert:
@@ -719,8 +711,6 @@
       name: "{{ table_name }}"
       table_class: "STANDARD"
     register: update_class
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     check_mode: True
 
   - name: Check results - Update table class - check_mode
@@ -734,8 +724,6 @@
       state: present
       name: "{{ table_name }}"
       table_class: "STANDARD"
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
     register: update_class
 
   - name: Check results - Update table class

--- a/tests/integration/targets/networkfirewall_policy/meta/main.yml
+++ b/tests/integration/targets/networkfirewall_policy/meta/main.yml
@@ -1,4 +1,1 @@
-dependencies:
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.23.23"
+dependencies: []

--- a/tests/integration/targets/networkfirewall_policy/tasks/default_order.yml
+++ b/tests/integration/targets/networkfirewall_policy/tasks/default_order.yml
@@ -223,8 +223,6 @@
         stateful_rule_order: strict
       register: default_policy
       ignore_errors: True
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:
@@ -237,8 +235,6 @@
         stateful_rule_order: strict
       register: default_policy
       ignore_errors: True
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:
@@ -1143,8 +1139,6 @@
           - 'aws:drop_strict'
       register: default_policy
       ignore_errors: True
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:
@@ -1158,8 +1152,6 @@
           - 'aws:drop_strict'
       register: default_policy
       ignore_errors: True
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:

--- a/tests/integration/targets/networkfirewall_policy/tasks/main.yml
+++ b/tests/integration/targets/networkfirewall_policy/tasks/main.yml
@@ -27,8 +27,6 @@
 
     # Tests specifically related to policies using 'strict' rule order
     - include_tasks: 'strict_order.yml'
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - include_tasks: 'actions.yml'
 

--- a/tests/integration/targets/networkfirewall_policy/tasks/setup.yml
+++ b/tests/integration/targets/networkfirewall_policy/tasks/setup.yml
@@ -23,9 +23,6 @@
         rule_order: strict
       register: strict_groups
       loop: '{{ range(1,4,1) | list }}'
-      # Setting rule order requires botocore>=1.23.23
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - debug:
         var: default_groups

--- a/tests/integration/targets/networkfirewall_policy/tasks/strict_order.yml
+++ b/tests/integration/targets/networkfirewall_policy/tasks/strict_order.yml
@@ -260,8 +260,6 @@
         stateful_rule_order: default
       register: strict_policy
       ignore_errors: True
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:
@@ -274,8 +272,6 @@
         stateful_rule_order: default
       register: strict_policy
       ignore_errors: True
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:

--- a/tests/integration/targets/s3_lifecycle/meta/main.yml
+++ b/tests/integration/targets/s3_lifecycle/meta/main.yml
@@ -1,4 +1,1 @@
-dependencies:
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.23.12"
+dependencies: []

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -465,8 +465,6 @@
         noncurrent_version_keep_newer: 6
         prefix: /something
       register: output
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:
@@ -479,8 +477,6 @@
         noncurrent_version_keep_newer: 6
         prefix: /something
       register: output
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:


### PR DESCRIPTION
##### SUMMARY

Some integration tests are trying to install an old copy of botocore, which conflicts with our minimum boto3 requirement.  Drop the installation, we now require botocore >= 1.25.0

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

dynamodb_table
networkfirewall_policy
s3_lifecycl

##### ADDITIONAL INFORMATION

