### PR TITLE
Fix s3_sync and s3_logging integration tests

### DIFF
--- a/changelogs/fragments/1797-s3-acls.yml
+++ b/changelogs/fragments/1797-s3-acls.yml
@@ -1,0 +1,3 @@
+trivial:
+- s3_sync - fix tests broken by AWS changing default permissions
+- s3_logging - fix tests broken by AWS changing default permissions

--- a/tests/integration/targets/s3_logging/aliases
+++ b/tests/integration/targets/s3_logging/aliases
@@ -1,4 +1,1 @@
 cloud/aws
-
-# https://github.com/ansible-collections/community.aws/issues/1797
-disabled

--- a/tests/integration/targets/s3_logging/tasks/main.yml
+++ b/tests/integration/targets/s3_logging/tasks/main.yml
@@ -46,6 +46,7 @@
     s3_bucket:
       state: present
       name: '{{ log_bucket_1 }}'
+      object_ownership: BucketOwnerPreferred
     register: output
   - assert:
       that:
@@ -56,6 +57,7 @@
     s3_bucket:
       state: present
       name: '{{ log_bucket_2 }}'
+      object_ownership: BucketOwnerPreferred
     register: output
   - assert:
       that:

--- a/tests/integration/targets/s3_sync/aliases
+++ b/tests/integration/targets/s3_sync/aliases
@@ -1,4 +1,1 @@
 cloud/aws
-
-# https://github.com/ansible-collections/community.aws/issues/1797
-disabled

--- a/tests/integration/targets/s3_sync/tasks/main.yml
+++ b/tests/integration/targets/s3_sync/tasks/main.yml
@@ -15,6 +15,9 @@
       s3_bucket:
         name: "{{ test_bucket }}"
         state: present
+        public_access:
+          block_public_acls: false
+        object_ownership: BucketOwnerPreferred
       register: output
 
     - assert:


### PR DESCRIPTION
##### SUMMARY

See also: https://github.com/ansible-collections/amazon.aws/pull/1511

At the end of April Amazon updated various S3 bucket defaults. Buckets now have public_access blocked by default, and object_owner set to "BucketOwnerEnforced".
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

This change to the defaults resulted in some of our tests failing.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_sync
s3_logging

##### ADDITIONAL INFORMATION

