### PR TITLE
[backport] [stable-5] s3_lifecycle - fix invalid value type for transitions list (#1788)

### DIFF
--- a/changelogs/fragments/20230424-s3_lifecycle.yml
+++ b/changelogs/fragments/20230424-s3_lifecycle.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - s3_lifecycle - fix invalid value type for transitions list (https://github.com/ansible-collections/community.aws/issues/1774)

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -321,13 +321,13 @@ def build_rule(client, module):
             rule['Transitions'] = []
         for transition in transitions:
             t_out = dict()
-            if transition.get('transition_date'):
-                t_out['Date'] = transition['transition_date']
-            elif transition.get('transition_days') is not None:
-                t_out['Days'] = transition['transition_days']
-            if transition.get('storage_class'):
-                t_out['StorageClass'] = transition['storage_class'].upper()
-                rule['Transitions'].append(t_out)
+            if transition.get("transition_date"):
+                t_out["Date"] = transition["transition_date"]
+            elif transition.get("transition_days") is not None:
+                t_out["Days"] = int(transition["transition_days"])
+            if transition.get("storage_class"):
+                t_out["StorageClass"] = transition["storage_class"].upper()
+                rule["Transitions"].append(t_out)
 
     if noncurrent_version_transition_days is not None:
         rule['NoncurrentVersionTransitions'] = [dict(NoncurrentDays=noncurrent_version_transition_days,
@@ -485,9 +485,10 @@ def create_lifecycle_rule(client, module):
             client.put_bucket_lifecycle_configuration(
                 aws_retry=True,
                 Bucket=name,
-                LifecycleConfiguration=lifecycle_configuration)
-        except is_boto3_error_message('At least one action needs to be specified in a rule'):
-            # Amazon interpretted this as not changing anything
+                LifecycleConfiguration=lifecycle_configuration,
+            )
+        except is_boto3_error_message("At least one action needs to be specified in a rule"):
+            # Amazon interpreted this as not changing anything
             changed = False
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, lifecycle_configuration=lifecycle_configuration, name=name, old_lifecycle_rules=old_lifecycle_rules)

--- a/tests/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/tests/integration/targets/s3_lifecycle/tasks/main.yml
@@ -9,7 +9,7 @@
       security_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
     s3_lifecycle:
-      wait: yes
+      wait: true
   block:
 
     # ============================================================
@@ -33,7 +33,7 @@
         prefix: "{{ item }}"
         status: enabled
         state: present
-        wait: yes
+        wait: true
       register: output
       loop:
         - rule_1
@@ -51,7 +51,7 @@
         prefix: "{{ item }}"
         status: enabled
         state: absent
-        wait: yes
+        wait: true
       register: output
       loop:
         - rule_1
@@ -704,6 +704,6 @@
       s3_bucket:
         name: "{{item}}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
       with_items:
         - '{{ bucket_name }}'


### PR DESCRIPTION
Manual backport of #1788

##### SUMMARY

Fixes https://github.com/ansible-collections/community.aws/issues/1774

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_lifecycle

##### ADDITIONAL INFORMATION

Forces casting to integer for the `transition_days` parameter of a `transitions` list.