### PR TITLE
cloudfront_distribution origins: recognise s3 domains with region part

### DIFF
--- a/changelogs/fragments/1819-cloudfront-distribution-s3-domain-recognise.yaml
+++ b/changelogs/fragments/1819-cloudfront-distribution-s3-domain-recognise.yaml
@@ -1,0 +1,2 @@
+bugfix:
+- The origins of cloudfront_distribution now recognise s3 domains with region part

--- a/changelogs/fragments/1819-cloudfront-distribution-s3-domain-recognise.yaml
+++ b/changelogs/fragments/1819-cloudfront-distribution-s3-domain-recognise.yaml
@@ -1,2 +1,2 @@
-bugfix:
+bugfixes:
 - The origins of cloudfront_distribution now recognise s3 domains with region part

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1677,7 +1677,7 @@ class CloudFrontValidationManager(object):
                 "http2and3",
             ]
         )
-        self.__s3_bucket_domain_regex = re.compile("\.s3(?:\.[^.]+)?\.amazonaws\.com$")
+        self.__s3_bucket_domain_regex = re.compile(r"\.s3(?:\.[^.]+)?\.amazonaws\.com$")
 
     def add_missing_key(self, dict_object, key_to_set, value_to_set):
         if key_to_set not in dict_object and value_to_set is not None:

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -1417,6 +1417,7 @@ web_acl_id:
 
 from collections import OrderedDict
 import datetime
+import re
 
 try:
     import botocore
@@ -1676,7 +1677,7 @@ class CloudFrontValidationManager(object):
                 "http2and3",
             ]
         )
-        self.__s3_bucket_domain_identifier = ".s3.amazonaws.com"
+        self.__s3_bucket_domain_regex = re.compile("\.s3(?:\.[^.]+)?\.amazonaws\.com$")
 
     def add_missing_key(self, dict_object, key_to_set, value_to_set):
         if key_to_set not in dict_object and value_to_set is not None:
@@ -1818,7 +1819,7 @@ class CloudFrontValidationManager(object):
                         )
                     else:
                         origin_shield_region = origin_shield_region.lower()
-            if self.__s3_bucket_domain_identifier in origin.get("domain_name").lower():
+            if self.__s3_bucket_domain_regex.search(origin.get("domain_name").lower()):
                 if origin.get("s3_origin_access_identity_enabled") is not None:
                     if origin["s3_origin_access_identity_enabled"]:
                         s3_origin_config = self.validate_s3_origin_configuration(client, existing_config, origin)


### PR DESCRIPTION
##### SUMMARY

Fixes #1819 

As per [Origin Domain Name spec](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesDomainName) now the S3 domain names are in the form `{name}.s3.{region}.amazonaws.com`, so the string fragment `.s3.amazonaws.com` no longer occurs in them, and therefore they aren't recognised as S3 origin domains.

Consequentially, the origin is treated as a custom one, so a `custom_origin_config` member is generated into it, which collides with the `s3_origin_config` and produces an error:

> botocore.errorfactory.InvalidOrigin: An error occurred (InvalidOrigin) when calling the CreateDistribution operation: You must specify either a CustomOrigin or an S3Origin. You cannot specify both.

The backward-compatible way is to recognise both `{name}.s3.amazonaws.com` and `{name}.s3.{domain}.amazonaws.com`, but for this a regular expression is the most effective solution.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`cloudfront_distribution`

##### ADDITIONAL INFORMATION
The breakdown of the regex I used: `\.s3(?:\.[^.]+)?\.amazonaws\.com$`

- `\.s3` matches ".s3"
- `\.[^.]+` would match a dot followed by at least one, possibly more non-dot characters
- `(\.[^]+)` would match the same, just grouped, so we could treat it as an atom
- `(?:\.[^]+)` would match the same, just grouped in a non-capturing fashion (we don't want to extract the matched characters)
- `(?:\.[^]+)?` matches the same, occuring 0 or 1 times
- `\.amazonaws\.com` matches ".amazonaws.com"
- `$` matches the end of the input string

