### PR TITLE
cloudfront_distribution: no longer crashes when waiting for completion of creation

### DIFF
--- a/changelogs/fragments/255-cloudfront_distribution_create_wait_crash.yml
+++ b/changelogs/fragments/255-cloudfront_distribution_create_wait_crash.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cloudfront_distribution - no longer crashes when waiting for completion of creation
+  - cloudfront_distribution - no longer crashes when waiting for completion of creation (https://github.com/ansible-collections/community.aws/issues/255).

--- a/changelogs/fragments/255-cloudfront_distribution_create_wait_crash.yml
+++ b/changelogs/fragments/255-cloudfront_distribution_create_wait_crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudfront_distribution - no longer crashes when waiting for completion of creation

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -2316,7 +2316,8 @@ class CloudFrontValidationManager(object):
 
     def wait_until_processed(self, client, wait_timeout, distribution_id, caller_reference):
         if distribution_id is None:
-            distribution_id = self.validate_distribution_from_caller_reference(caller_reference=caller_reference)["Id"]
+            distribution = self.validate_distribution_from_caller_reference(caller_reference=caller_reference)
+            distribution_id = distribution["Distribution"]["Id"]
 
         try:
             waiter = client.get_waiter("distribution_deployed")


### PR DESCRIPTION
##### SUMMARY

Fixes #255 

[Here](https://github.com/ansible-collections/community.aws/blob/e80bf933412ea5c7ab2a94af945170cb2ebd900f/plugins/modules/cloudfront_distribution.py#L2319) we were referring to the `["Id"]` member of a queried distribution, but there is level of embedding missing: `["Distribution"]["Id"]`

(Just how it's used [here](https://github.com/ansible-collections/community.aws/blob/e80bf933412ea5c7ab2a94af945170cb2ebd900f/plugins/modules/cloudfront_distribution.py#L1491) )

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`cloudfront_distribution`
