### PR TITLE
cloudfront_distribution: now honours the enabled setting

### DIFF
--- a/changelogs/fragments/1823-cloudfront_distribution_always_created_enabled.yml
+++ b/changelogs/fragments/1823-cloudfront_distribution_always_created_enabled.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cloudfront_distribution - now honours the `enabled` setting
+  - cloudfront_distribution - now honours the ``enabled`` setting (https://github.com/ansible-collections/community.aws/issues/1823).

--- a/changelogs/fragments/1823-cloudfront_distribution_always_created_enabled.yml
+++ b/changelogs/fragments/1823-cloudfront_distribution_always_created_enabled.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudfront_distribution - now honours the `enabled` setting

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -2218,7 +2218,7 @@ class CloudFrontValidationManager(object):
                 config["aliases"] = ansible_list_to_cloudfront_list(aliases)
             if logging is not None:
                 config["logging"] = self.validate_logging(logging)
-            config["enabled"] = enabled or config.get("enabled", self.__default_distribution_enabled)
+            config["enabled"] = enabled if enabled is not None else config.get("enabled", self.__default_distribution_enabled)
             if price_class is not None:
                 self.validate_attribute_with_allowed_values(price_class, "price_class", self.__valid_price_classes)
                 config["price_class"] = price_class

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -25,6 +25,12 @@
   - set_fact:
       distribution_id: '{{ cf_distribution.id }}'
 
+  - name: ensure that default value of 'enabled' is 'true'
+    assert:
+      that:
+        - cf_distribution.changed
+        - cf_distribution.enabled
+
   - name: ensure that default value of 'ipv6_enabled' is 'false'
     assert:
       that:
@@ -359,8 +365,9 @@
       wait: true
       state: absent
 
-  - name: create cloudfront distribution with tags
+  - name: create cloudfront distribution with tags and as disabled
     cloudfront_distribution:
+      enabled: false
       origins:
       - domain_name: "{{ resource_prefix }}2.example.com"
         id: "{{ resource_prefix }}2.example.com"
@@ -372,6 +379,12 @@
 
   - set_fact:
       distribution_id: '{{ cf_second_distribution.id }}'
+
+  - name: ensure that the value of 'enabled' is 'false'
+    assert:
+      that:
+        - cf_second_distribution.changed
+        - not cf_second_distribution.enabled
 
   - name: ensure tags were set on creation
     assert:


### PR DESCRIPTION
##### SUMMARY

Fixes: #1823 

The `enabled: false` setting was ignored, because [here](https://github.com/ansible-collections/community.aws/blob/e80bf933412ea5c7ab2a94af945170cb2ebd900f/plugins/modules/cloudfront_distribution.py#L2221) we were falling back to the default `True` not only when the setting was `None`, but also when it was `False`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`cloudfront_distribution`
