### PR TITLE
dynamodb_table: secondary indexes are now created

### DIFF
--- a/changelogs/fragments/1825-dynamodb-table-no-secondary-indexes.yml
+++ b/changelogs/fragments/1825-dynamodb-table-no-secondary-indexes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dynamodb_table - secondary indexes are now created
+  - dynamodb_table - secondary indexes are now created (https://github.com/ansible-collections/community.aws/issues/1825).

--- a/changelogs/fragments/1825-dynamodb-table-no-secondary-indexes.yml
+++ b/changelogs/fragments/1825-dynamodb-table-no-secondary-indexes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dynamodb_table - secondary indexes are now created

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -675,7 +675,6 @@ def _generate_local_indexes():
     indexes = list()
 
     for index in module.params.get("indexes"):
-        index = dict()
         if index.get("type") not in ["all", "include", "keys_only"]:
             continue
         name = index.get("name")

--- a/tests/integration/targets/dynamodb_table/defaults/main.yml
+++ b/tests/integration/targets/dynamodb_table/defaults/main.yml
@@ -36,6 +36,8 @@ indexes:
 local_indexes:
   - name: NamedIndex
     type: include
+    hash_key_name: "id"  ## == table_index
+    hash_key_type: "NUMBER"  ## == table_index_type
     range_key_name: create_time
     includes:
       - other_field
@@ -44,11 +46,15 @@ local_indexes:
     write_capacity: 10
   - name: AnotherIndex
     type: all
+    hash_key_name: id  ## == table_index
+    hash_key_type: "NUMBER"  ## == table_index_type
     range_key_name: bar
     read_capacity: 5
     write_capacity: 5
   - name: KeysOnlyIndex
     type: keys_only
+    hash_key_name: id  ## == table_index
+    hash_key_type: "NUMBER"  ## == table_index_type
     range_key_name: baz
     read_capacity: 2
     write_capacity: 2

--- a/tests/integration/targets/dynamodb_table/defaults/main.yml
+++ b/tests/integration/targets/dynamodb_table/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 table_name: "{{ resource_prefix }}"
+table_name_composite_pk: "{{ resource_prefix }}-composite-pk"
+table_name_composite_pk_local_indexes: "{{ resource_prefix }}-composite-pk-local-indexes"
 table_name_on_demand: "{{ resource_prefix }}-pay-per-request"
 table_name_on_demand_complex: "{{ resource_prefix }}-pay-per-request-complex"
 
@@ -28,6 +30,26 @@ indexes:
   - name: KeysOnlyIndex
     type: global_keys_only
     hash_key_name: create_time
+    read_capacity: 2
+    write_capacity: 2
+
+local_indexes:
+  - name: NamedIndex
+    type: include
+    range_key_name: create_time
+    includes:
+      - other_field
+      - other_field2
+    read_capacity: 10
+    write_capacity: 10
+  - name: AnotherIndex
+    type: all
+    range_key_name: bar
+    read_capacity: 5
+    write_capacity: 5
+  - name: KeysOnlyIndex
+    type: keys_only
+    range_key_name: baz
     read_capacity: 2
     write_capacity: 2
 

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -116,6 +116,7 @@
 
   # ==============================================
   # Attempting to create a table without PK range key but with local indexes will result in an expected failure.
+  # "One or more parameter values were invalid: Table KeySchema does not have a range key, which is required when specifying a LocalSecondaryIndex"
 
   - name: Create table with simple PK with local indexes - test failure
     dynamodb_table:
@@ -123,13 +124,32 @@
       name: "{{ table_name_composite_pk }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
+      indexes: "{{ local_indexes }}"
+    ignore_errors: yes
+    register: create_table
+
+  - name: Check results - Create table with simple PK with local indexes
+    assert:
+      that:
+        - create_table is failed
+
+  # ==============================================
+  # Attempting to create a table with composite PK but with local indexes using different hash key will result in an expected failure.
+  # "One or more parameter values were invalid: Index KeySchema does not have the same leading hash key as table KeySchema for index: NamedIndex. index hash key: id, table hash key: NOT_id"
+
+  - name: Create table with composite PK with mismatching local indexes - test failure
+    dynamodb_table:
+      state: present
+      name: "{{ table_name_composite_pk }}"
+      hash_key_name: "NOT_{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
       range_key_type: "{{ range_index_type }}"
       indexes: "{{ local_indexes }}"
     ignore_errors: yes
     register: create_table
 
-  - name: Check results - Create table with simple PK with local indexes
+  - name: Check results - Create table with composite PK with mismatching local indexes
     assert:
       that:
         - create_table is failed
@@ -156,7 +176,7 @@
   - name: Create table with composite PK
     dynamodb_table:
       state: present
-      name: "{{ table_name }}"
+      name: "{{ table_name_composite_pk }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
@@ -185,13 +205,13 @@
         - create_table.range_key_type == range_index_type
         - create_table.indexes | length == 0
         - create_table.read_capacity == 1
-        - create_table.table_name == table_name
+        - create_table.table_name == table_name_composite_pk
         - create_table.write_capacity == 1
 
   - name: Create table with composite PK - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: "{{ table_name }}"
+      name: "{{ table_name_composite_pk }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
@@ -208,7 +228,7 @@
   - name: Create table with composite PK - idempotent
     dynamodb_table:
       state: present
-      name: "{{ table_name }}"
+      name: "{{ table_name_composite_pk }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
@@ -237,7 +257,7 @@
         - create_table.range_key_type == range_index_type
         - create_table.indexes | length == 0
         - create_table.read_capacity == 1
-        - create_table.table_name == table_name
+        - create_table.table_name == table_name_composite_pk
         - create_table.write_capacity == 1
 
   # ==============================================
@@ -263,7 +283,7 @@
   - name: Create table with composite PK and local indexes
     dynamodb_table:
       state: present
-      name: "{{ table_name }}"
+      name: "{{ table_name_composite_pk_local_indexes  }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
@@ -293,13 +313,13 @@
         - create_table.range_key_type == range_index_type
         - create_table.indexes | length == 3
         - create_table.read_capacity == 1
-        - create_table.table_name == table_name
+        - create_table.table_name == table_name_composite_pk_local_indexes
         - create_table.write_capacity == 1
 
   - name: Create table with composite PK and local indexes - idempotent - check_mode
     dynamodb_table:
       state: present
-      name: "{{ table_name }}"
+      name: "{{ table_name_composite_pk_local_indexes }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
@@ -317,7 +337,7 @@
   - name: Create table with composite PK and local indexes - idempotent
     dynamodb_table:
       state: present
-      name: "{{ table_name }}"
+      name: "{{ table_name_composite_pk_local_indexes }}"
       hash_key_name: "{{ table_index }}"
       hash_key_type: "{{ table_index_type }}"
       range_key_name: "{{ range_index }}"
@@ -347,7 +367,7 @@
         - create_table.range_key_type == range_index_type
         - create_table.indexes | length == 3
         - create_table.read_capacity == 1
-        - create_table.table_name == table_name
+        - create_table.table_name == table_name_composite_pk_local_indexes
         - create_table.write_capacity == 1
 
   # ==============================================
@@ -758,22 +778,6 @@
         - update_indexes.tags == tags_default
 
   # ==============================================
-  # Attempting to add local indexes will result in an expected failure.
-
-  - name: Update table add local indexes - test failure
-    dynamodb_table:
-      state: present
-      name: "{{ table_name_composite_pk }}"
-      indexes: "{{ local_indexes }}"
-    ignore_errors: yes
-    register: add_local_indexes
-
-  - name: Check results - Update table add local indexes
-    assert:
-      that:
-        - add_local_indexes is failed
-
-  # ==============================================
 
   - name: Delete table - check_mode
     dynamodb_table:
@@ -1110,6 +1114,20 @@
       dynamodb_table:
         state: absent
         name: "{{ table_name }}"
+        wait: false
+      register: delete_table
+
+    - name: Delete provisoned table with composite key
+      dynamodb_table:
+        state: absent
+        name: "{{ table_name_composite_pk }}"
+        wait: false
+      register: delete_table
+
+    - name: Delete provisoned table with composite key and local indexes
+      dynamodb_table:
+        state: absent
+        name: "{{ table_name_composite_pk_local_indexes }}"
         wait: false
       register: delete_table
 

--- a/tests/integration/targets/dynamodb_table/tasks/main.yml
+++ b/tests/integration/targets/dynamodb_table/tasks/main.yml
@@ -115,6 +115,242 @@
         - create_table.write_capacity == 1
 
   # ==============================================
+  # Attempting to create a table without PK range key but with local indexes will result in an expected failure.
+
+  - name: Create table with simple PK with local indexes - test failure
+    dynamodb_table:
+      state: present
+      name: "{{ table_name_composite_pk }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+      indexes: "{{ local_indexes }}"
+    ignore_errors: yes
+    register: create_table
+
+  - name: Check results - Create table with simple PK with local indexes
+    assert:
+      that:
+        - create_table is failed
+
+  # ==============================================
+
+  - name: Create table with composite PK - check_mode
+    dynamodb_table:
+      state: present
+      name: "{{ table_name_composite_pk }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+    register: create_table
+    check_mode: True
+
+  - name: Check results - Create table with composite PK - check_mode
+    assert:
+      that:
+        - create_table is successful
+        - create_table is changed
+
+  - name: Create table with composite PK
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+    register: create_table
+
+  - name: Check results - Create table with composite PK
+    assert:
+      that:
+        - create_table is successful
+        - create_table is changed
+        - '"hash_key_name" in create_table'
+        - '"hash_key_type" in create_table'
+        - '"indexes" in create_table'
+        - '"range_key_name" in create_table'
+        - '"range_key_type" in create_table'
+        - '"read_capacity" in create_table'
+        - '"region" in create_table'
+        - '"table_name" in create_table'
+        - '"table_status" in create_table'
+        - '"tags" in create_table'
+        - '"write_capacity" in create_table'
+        - create_table.hash_key_name == table_index
+        - create_table.hash_key_type == table_index_type
+        - create_table.range_key_name == range_index
+        - create_table.range_key_type == range_index_type
+        - create_table.indexes | length == 0
+        - create_table.read_capacity == 1
+        - create_table.table_name == table_name
+        - create_table.write_capacity == 1
+
+  - name: Create table with composite PK - idempotent - check_mode
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+    register: create_table
+    check_mode: True
+
+  - name: Check results - Create table with composite PK - idempotent - check_mode
+    assert:
+      that:
+        - create_table is successful
+        - create_table is not changed
+
+  - name: Create table with composite PK - idempotent
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+    register: create_table
+
+  - name: Check results - Create table with composite PK - idempotent
+    assert:
+      that:
+        - create_table is successful
+        - create_table is not changed
+        - '"hash_key_name" in create_table'
+        - '"hash_key_type" in create_table'
+        - '"indexes" in create_table'
+        - '"range_key_name" in create_table'
+        - '"range_key_type" in create_table'
+        - '"read_capacity" in create_table'
+        - '"region" in create_table'
+        - '"table_name" in create_table'
+        - '"table_status" in create_table'
+        - '"tags" in create_table'
+        - '"write_capacity" in create_table'
+        - create_table.hash_key_name == table_index
+        - create_table.hash_key_type == table_index_type
+        - create_table.range_key_name == range_index
+        - create_table.range_key_type == range_index_type
+        - create_table.indexes | length == 0
+        - create_table.read_capacity == 1
+        - create_table.table_name == table_name
+        - create_table.write_capacity == 1
+
+  # ==============================================
+
+  - name: Create table with composite PK and local indexes - check_mode
+    dynamodb_table:
+      state: present
+      name: "{{ table_name_composite_pk_local_indexes }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+      indexes: "{{ local_indexes }}"
+    register: create_table
+    check_mode: True
+
+  - name: Check results - Create table with composite PK and local indexes - check_mode
+    assert:
+      that:
+        - create_table is successful
+        - create_table is changed
+
+  - name: Create table with composite PK and local indexes
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+      indexes: "{{ local_indexes }}"
+    register: create_table
+
+  - name: Check results - Create table with composite PK and local indexes
+    assert:
+      that:
+        - create_table is successful
+        - create_table is changed
+        - '"hash_key_name" in create_table'
+        - '"hash_key_type" in create_table'
+        - '"indexes" in create_table'
+        - '"range_key_name" in create_table'
+        - '"range_key_type" in create_table'
+        - '"read_capacity" in create_table'
+        - '"region" in create_table'
+        - '"table_name" in create_table'
+        - '"table_status" in create_table'
+        - '"tags" in create_table'
+        - '"write_capacity" in create_table'
+        - create_table.hash_key_name == table_index
+        - create_table.hash_key_type == table_index_type
+        - create_table.range_key_name == range_index
+        - create_table.range_key_type == range_index_type
+        - create_table.indexes | length == 3
+        - create_table.read_capacity == 1
+        - create_table.table_name == table_name
+        - create_table.write_capacity == 1
+
+  - name: Create table with composite PK and local indexes - idempotent - check_mode
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+      indexes: "{{ local_indexes }}"
+    register: create_table
+    check_mode: True
+
+  - name: Check results - Create table with composite PK and local indexes - idempotent - check_mode
+    assert:
+      that:
+        - create_table is successful
+        - create_table is not changed
+
+  - name: Create table with composite PK and local indexes - idempotent
+    dynamodb_table:
+      state: present
+      name: "{{ table_name }}"
+      hash_key_name: "{{ table_index }}"
+      hash_key_type: "{{ table_index_type }}"
+      range_key_name: "{{ range_index }}"
+      range_key_type: "{{ range_index_type }}"
+      indexes: "{{ local_indexes }}"
+    register: create_table
+
+  - name: Check results - Create table with composite PK and local indexes - idempotent
+    assert:
+      that:
+        - create_table is successful
+        - create_table is not changed
+        - '"hash_key_name" in create_table'
+        - '"hash_key_type" in create_table'
+        - '"indexes" in create_table'
+        - '"range_key_name" in create_table'
+        - '"range_key_type" in create_table'
+        - '"read_capacity" in create_table'
+        - '"region" in create_table'
+        - '"table_name" in create_table'
+        - '"table_status" in create_table'
+        - '"tags" in create_table'
+        - '"write_capacity" in create_table'
+        - create_table.hash_key_name == table_index
+        - create_table.hash_key_type == table_index_type
+        - create_table.range_key_name == range_index
+        - create_table.range_key_type == range_index_type
+        - create_table.indexes | length == 3
+        - create_table.read_capacity == 1
+        - create_table.table_name == table_name
+        - create_table.write_capacity == 1
+
+  # ==============================================
 
   - name: Tag table - check_mode
     dynamodb_table:
@@ -488,14 +724,14 @@
         - update_indexes is successful
         - update_indexes is not changed
 
-  - name: Update table add indexes - idempotent
+  - name: Update table add global indexes - idempotent
     dynamodb_table:
       state: present
       name: "{{ table_name }}"
       indexes: "{{ indexes }}"
     register: update_indexes
 
-  - name: Check results - Update table add indexes - idempotent
+  - name: Check results - Update table add global indexes - idempotent
     assert:
       that:
         - update_indexes is successful
@@ -520,6 +756,22 @@
         - update_indexes.table_name == table_name
         - update_indexes.write_capacity == 3
         - update_indexes.tags == tags_default
+
+  # ==============================================
+  # Attempting to add local indexes will result in an expected failure.
+
+  - name: Update table add local indexes - test failure
+    dynamodb_table:
+      state: present
+      name: "{{ table_name_composite_pk }}"
+      indexes: "{{ local_indexes }}"
+    ignore_errors: yes
+    register: add_local_indexes
+
+  - name: Check results - Update table add local indexes
+    assert:
+      that:
+        - add_local_indexes is failed
 
   # ==============================================
 


### PR DESCRIPTION
##### SUMMARY

Fixes: #1825 

Possibly by a typo, the index definition being checked was over-defined by an empty dict [here](https://github.com/ansible-collections/community.aws/blob/e80bf933412ea5c7ab2a94af945170cb2ebd900f/plugins/modules/dynamodb_table.py#L678).
Without that line the index processing proceeds fine.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`dynamodb_table`
