### PR TITLE
AWS Config aggregator

### DIFF
--- a/plugins/modules/config_aggregator.py
+++ b/plugins/modules/config_aggregator.py
@@ -47,7 +47,7 @@ options:
         type: bool
     type: list
     elements: dict
-    required: true
+    required: false
   organization_source:
     description:
       - The region authorized to collect aggregated data.
@@ -66,7 +66,7 @@ options:
           - If true, aggregate existing AWS Config regions and future regions.
         type: bool
     type: dict
-    required: true
+    required: false
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -76,13 +76,21 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 - name: Create cross-account aggregator
   community.aws.config_aggregator:
-    name: test_config_rule
+    name: config_aggregator
     state: present
     account_sources:
-      account_ids:
-      - 1234567890
-      - 0123456789
-      - 9012345678
+      - all_aws_regions: true
+        account_ids:
+          - 1234567890
+          - 0123456789
+          - 9012345678
+
+- name: Create organization aggregator
+  community.aws.config_aggregator:
+    name: organization_aggregator
+    state: present
+    organization_source:
+      role_arn: "arn:aws:iam::012345678910:role/AWSConfigRole"
       all_aws_regions: true
 """
 

--- a/plugins/modules/config_delivery_channel.py
+++ b/plugins/modules/config_delivery_channel.py
@@ -36,6 +36,10 @@ options:
     description:
       - The prefix for the specified Amazon S3 bucket.
     type: str
+  s3_kms_key_arn:
+    description:
+      - The ARN of a KMS key to encrypt objects delivered by Config. The key must belong to the same region as the destination S3 bucket.
+    type: str
   sns_topic_arn:
     description:
       - The Amazon Resource Name (ARN) of the Amazon SNS topic to which AWS Config sends notifications about configuration changes.
@@ -45,6 +49,7 @@ options:
       - The frequency with which AWS Config delivers configuration snapshots.
     choices: ['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours']
     type: str
+
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -57,6 +62,15 @@ EXAMPLES = r"""
     name: test_delivery_channel
     state: present
     s3_bucket: 'test_aws_config_bucket'
+    sns_topic_arn: 'arn:aws:sns:us-east-1:123456789012:aws_config_topic:1234ab56-cdef-7g89-01hi-2jk34l5m67no'
+    delivery_frequency: 'Twelve_Hours'
+
+- name: Create Delivery Channel for AWS Config with encryption
+  community.aws.config_delivery_channel:
+    name: test_delivery_channel
+    state: present
+    s3_bucket: 'test_aws_config_bucket'
+    s3_kms_key_arn: 'arn:aws:kms:us-east-1:123456789012/config_kms_key
     sns_topic_arn: 'arn:aws:sns:us-east-1:123456789012:aws_config_topic:1234ab56-cdef-7g89-01hi-2jk34l5m67no'
     delivery_frequency: 'Twelve_Hours'
 """
@@ -88,8 +102,7 @@ def resource_exists(client, module, params):
     try:
         channel = client.describe_delivery_channels(
             DeliveryChannelNames=[params['name']],
-            aws_retry=True,
-        )
+            aws_retry=True,)
         return channel['DeliveryChannels'][0]
     except is_boto3_error_code('NoSuchDeliveryChannelException'):
         return
@@ -159,6 +172,7 @@ def main():
             'state': dict(type='str', choices=['present', 'absent'], default='present'),
             's3_bucket': dict(type='str', required=True),
             's3_prefix': dict(type='str'),
+            's3_kms_key_arn': dict(tye='str'),
             'sns_topic_arn': dict(type='str'),
             'delivery_frequency': dict(
                 type='str',
@@ -188,6 +202,8 @@ def main():
         params['s3BucketName'] = module.params.get('s3_bucket')
     if module.params.get('s3_prefix'):
         params['s3KeyPrefix'] = module.params.get('s3_prefix')
+    if module.params.get('s3_kms_key_arn'):
+        params['s3_kms_key_arn'] = module.params.get('s3_kms_key_arn')
     if module.params.get('sns_topic_arn'):
         params['snsTopicARN'] = module.params.get('sns_topic_arn')
     if module.params.get('delivery_frequency'):
@@ -196,7 +212,6 @@ def main():
         }
 
     client = module.client('config', retry_decorator=AWSRetry.jittered_backoff())
-
     resource_status = resource_exists(client, module, params)
 
     if state == 'present':

--- a/tests/integration/targets/config/defaults/main.yaml
+++ b/tests/integration/targets/config/defaults/main.yaml
@@ -1,4 +1,5 @@
 ---
 config_s3_bucket: '{{ resource_prefix }}-config-records'
 config_sns_name: '{{ resource_prefix }}-delivery-channel-test-topic'
+config_kms_key: '{{ resource_prefix }}-kms'
 config_role_name: 'ansible-test-{{ resource_prefix }}'

--- a/tests/integration/targets/config/tasks/main.yaml
+++ b/tests/integration/targets/config/tasks/main.yaml
@@ -45,6 +45,10 @@
         state: present
         policy_json: "{{ lookup( 'template', 'config-s3-policy.json.j2') }}"
 
+    - name: ensure KMS key exists
+      amazon.aws.kms_key:
+        alias: "{{ config_kms_key }}"
+
     # ============================================================
     # Module requirement testing
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
The current  [`aws_config_recorder` module](https://docs.ansible.com/ansible/5/collections/community/aws/aws_config_aggregator_module.html) has both `account_sources` and `organization_source` parameters listed as required.
However, the Config service API [doesn't have any of these two parameters as required](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/config/client/put_configuration_aggregator.html). This is because we can either configure an aggregator against a list of accounts or against all accounts in an organization.
This fix allows us to chose which parameters to pass instead of having to pass both.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`aws_config_aggregator`
