### PR TITLE
[manual backport stable-5] cloudfront_distribution: now honours the enabled setting (#1824)

### DIFF
--- a/changelogs/fragments/1823-cloudfront_distribution_always_created_enabled.yml
+++ b/changelogs/fragments/1823-cloudfront_distribution_always_created_enabled.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudfront_distribution - now honours the ``enabled`` setting (https://github.com/ansible-collections/community.aws/issues/1823).

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -2009,8 +2009,8 @@ class CloudFrontValidationManager(object):
                                     if alias not in aliases])
                 config['aliases'] = ansible_list_to_cloudfront_list(aliases)
             if logging is not None:
-                config['logging'] = self.validate_logging(logging)
-            config['enabled'] = enabled or config.get('enabled', self.__default_distribution_enabled)
+                config["logging"] = self.validate_logging(logging)
+            config["enabled"] = enabled if enabled is not None else config.get("enabled", self.__default_distribution_enabled)
             if price_class is not None:
                 self.validate_attribute_with_allowed_values(price_class, 'price_class', self.__valid_price_classes)
                 config['price_class'] = price_class

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -25,6 +25,12 @@
   - set_fact:
       distribution_id: '{{ cf_distribution.id }}'
 
+  - name: ensure that default value of 'enabled' is 'true'
+    assert:
+      that:
+        - cf_distribution.changed
+        - cf_distribution.enabled
+
   - name: ensure that default value of 'ipv6_enabled' is 'false'
     assert:
       that:
@@ -282,8 +288,9 @@
       wait: yes
       state: absent
 
-  - name: create distribution with tags
+  - name: create cloudfront distribution with tags and as disabled
     cloudfront_distribution:
+      enabled: false
       origins:
       - domain_name: "{{ resource_prefix }}2.example.com"
         id: "{{ resource_prefix }}2.example.com"
@@ -295,6 +302,12 @@
 
   - set_fact:
       distribution_id: '{{ cf_second_distribution.id }}'
+
+  - name: ensure that the value of 'enabled' is 'false'
+    assert:
+      that:
+        - cf_second_distribution.changed
+        - not cf_second_distribution.enabled
 
   - name: ensure tags were set on creation
     assert:


### PR DESCRIPTION
cloudfront_distribution: now honours the enabled setting

SUMMARY
Fixes: #1823
The enabled: false setting was ignored, because here we were falling back to the default True not only when the setting was None, but also when it was False. ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
cloudfront_distribution

Reviewed-by: Markus Bergholz <git@osuv.de>
Reviewed-by: Alina Buzachis
(cherry picked from commit 5594769527aee560fb454170f9dde31af3ff8c48)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
