### PR TITLE
[manual backport stable-5] cloudfront_distribution: no longer crashes when waiting for completion of creation (#1822)

### DIFF
--- a/changelogs/fragments/255-cloudfront_distribution_create_wait_crash.yml
+++ b/changelogs/fragments/255-cloudfront_distribution_create_wait_crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudfront_distribution - no longer crashes when waiting for completion of creation (https://github.com/ansible-collections/community.aws/issues/255).

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -2089,7 +2089,8 @@ class CloudFrontValidationManager(object):
 
     def wait_until_processed(self, client, wait_timeout, distribution_id, caller_reference):
         if distribution_id is None:
-            distribution_id = self.validate_distribution_from_caller_reference(caller_reference=caller_reference)['Id']
+            distribution = self.validate_distribution_from_caller_reference(caller_reference=caller_reference)
+            distribution_id = distribution["Distribution"]["Id"]
 
         try:
             waiter = client.get_waiter('distribution_deployed')


### PR DESCRIPTION
cloudfront_distribution: no longer crashes when waiting for completion of creation

SUMMARY
Fixes #255
Here we were referring to the ["Id"] member of a queried distribution, but there is level of embedding missing: ["Distribution"]["Id"] (Just how it's used here )
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
cloudfront_distribution

Reviewed-by: Markus Bergholz <git@osuv.de>
Reviewed-by: Alina Buzachis
(cherry picked from commit dbf6362d642ab504e9b96981ef841dd40ad5b5ab)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
