### PR TITLE
Eliminate escape codes in aws_ssm output from newer versions of Bash

### DIFF
--- a/changelogs/fragments/1839-disable-bracketed-paste.yml
+++ b/changelogs/fragments/1839-disable-bracketed-paste.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - disable `enable-bracketed-paste` to fix issue with amazon linux 2023 and other OSes (https://github.com/ansible-collections/community.aws/issues/1756)

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -627,7 +627,7 @@ class Connection(ConnectionBase):
         disable_prompt_complete = None
         end_mark = "".join([random.choice(string.ascii_letters) for i in xrange(self.MARK_LENGTH)])
         disable_prompt_cmd = to_bytes(
-            "PS1='' ; printf '\\n%s\\n' '" + end_mark + "'\n",
+            "PS1='' ; bind 'set enable-bracketed-paste off'; printf '\\n%s\\n' '" + end_mark + "'\n",
             errors="surrogate_or_strict",
         )
         disable_prompt_reply = re.compile(r"\r\r\n" + re.escape(end_mark) + r"\r\r\n", re.MULTILINE)


### PR DESCRIPTION
##### SUMMARY
aws_ssm - prevent escape codes from interfering with output

Fixes #1756

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
aws_ssm

##### ADDITIONAL INFORMATION

This disables the Readline feature `enable-bracketed-paste` which is enabled by default on Bash 5.1 and above. This was causing escape sequences like `\x1b[?2004h\x1b[?2004l` to get into the output from some operating systems (e.g. Amazon Linux).