### PR TITLE
api_gateway - add parameter name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 
 # Created by https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 # Edit at https://www.gitignore.io/?templates=git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
-
+tests/integration/inventory
 ### dotenv ###
 .env
 

--- a/changelogs/fragments/20230620-api_gateway-add-optional-name.yml
+++ b/changelogs/fragments/20230620-api_gateway-add-optional-name.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - api_gateway - add parameter `name` allowing user to choose the name of the API gateway to create, default to `ansible-temp-api` for backward compatibility.
+

--- a/changelogs/fragments/20230620-api_gateway-add-optional-name.yml
+++ b/changelogs/fragments/20230620-api_gateway-add-optional-name.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - api_gateway - add parameter `name` allowing user to choose the name of the API gateway to create, default to `ansible-temp-api` for backward compatibility.
-
+  - api_gateway - add parameter `name` allowing user to choose the name of the API gateway to create, default to `ansible-temp-api` for backward compatibility (https://github.com/ansible-collections/community.aws/pull/1845).
+  - api_gateway - add parameter `lookup` to create API based on supplied tags (https://github.com/ansible-collections/community.aws/pull/1845).

--- a/changelogs/fragments/20230620-api_gateway-add-optional-name.yml
+++ b/changelogs/fragments/20230620-api_gateway-add-optional-name.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - api_gateway - add parameter `name` allowing user to choose the name of the API gateway to create, default to `ansible-temp-api` for backward compatibility (https://github.com/ansible-collections/community.aws/pull/1845).
-  - api_gateway - add parameter `lookup` to create API based on supplied tags (https://github.com/ansible-collections/community.aws/pull/1845).
+  - api_gateway - add support for parameters `name`, `lookup`, `tags` and `purge_tags` (https://github.com/ansible-collections/community.aws/pull/1845).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -7,6 +7,9 @@ action_groups:
   - acm_certificate_info
   - api_gateway
   - api_gateway_domain
+  - api_gateway_info
+  - apigateway
+  - apigateway_deployment
   - application_autoscaling_policy
   - autoscaling_complete_lifecycle_action
   - autoscaling_instance_refresh_info

--- a/plugins/modules/api_gateway.py
+++ b/plugins/modules/api_gateway.py
@@ -113,6 +113,7 @@ options:
     default: tag
     choices: [ 'tag', 'id' ]
     type: str
+    version_added: 6.2.0
 author:
   - 'Michael De La Rue (@mikedlr)'
 notes:

--- a/plugins/modules/api_gateway.py
+++ b/plugins/modules/api_gateway.py
@@ -272,7 +272,9 @@ def main():
     if state == "absent":
         if api_id is None:
             if lookup != "tag" or not tags:
-                module.fail_json(msg="API gateway id must be supplied to delete API gateway or provided tag with lookup=tag to identify API gateway id.")
+                module.fail_json(
+                    msg="API gateway id must be supplied to delete API gateway or provided tag with lookup=tag to identify API gateway id."
+                )
             rest_api = get_api_by_tags(client, module, name, tags)
             if not rest_api:
                 module.exit_json(changed=False, msg="No API gateway identified with tags provided")
@@ -372,7 +374,6 @@ def ensure_api_in_correct_state(module, client, api_id, api_data):
 
 
 def get_api_by_tags(client, module, name, tags):
-
     count = 0
     result = None
     for api in list_apis(client):

--- a/plugins/modules/api_gateway.py
+++ b/plugins/modules/api_gateway.py
@@ -220,7 +220,7 @@ def main():
         endpoint_type=dict(type="str", default="EDGE", choices=["EDGE", "REGIONAL", "PRIVATE"]),
         name=dict(type="str"),
         lookup=dict(type="str", choices=["tag", "id"], default="tag"),
-        tags=dict(type="dict"),
+        tags=dict(type="dict", aliases=["resource_tags"]),
         purge_tags=dict(default=True, type="bool"),
     )
 

--- a/plugins/modules/api_gateway.py
+++ b/plugins/modules/api_gateway.py
@@ -102,7 +102,7 @@ options:
     description:
       - The name of the RestApi.
     type: str
-    version_added: 6.1.0
+    version_added: 6.2.0
   lookup:
     description:
       - Look up API gateway by either I(tags) (and I(name) if supplied) or by I(api_id).
@@ -119,11 +119,11 @@ options:
       - If the I(tags) parameter is not set then tags will not be modified.
     type: dict
     required: false
-    version_added: 6.1.0
+    version_added: 6.2.0
 author:
   - 'Michael De La Rue (@mikedlr)'
 notes:
-  - 'Tags are used to uniquely identify API gateway when the I(api_id) is not supplied. version_added=6.1.0'
+  - 'Tags are used to uniquely identify API gateway when the I(api_id) is not supplied. version_added=6.2.0'
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules

--- a/plugins/modules/api_gateway_info.py
+++ b/plugins/modules/api_gateway_info.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: api_gateway_info
+version_added: 6.1.0
+short_description: Gather information about ec2 instances in AWS
+description:
+  - Gather information about ec2 instances in AWS
+options:
+  ids:
+    description:
+      - The list of the string identifiers of the associated RestApis.
+    type: list
+    elements: str
+author:
+  - Aubin Bikouo (@abikouo)
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+---
+# List all API gateway
+- name: List all for a specific function
+  community.aws.api_gateway_info:
+
+# Get information for a specific API gateway
+- name: List all for a specific function
+  community.aws.api_gateway_info:
+    ids:
+    - 012345678a
+    - abcdefghij
+"""
+
+RETURN = r"""
+---
+rest_apis:
+    description: A list of API gateway.
+    returned: always
+    type: complex
+    contains:
+        name:
+            description: The name of the API.
+            returned: success
+            type: str
+            sample: 'ansible-tmp-api'
+        id:
+            description: The identifier of the API.
+            returned: success
+            type: str
+            sample: 'abcdefgh'
+        api_key_source:
+            description: The source of the API key for metering requests according to a usage plan.
+            returned: success
+            type: str
+            sample: 'HEADER'
+        created_date:
+            description: The timestamp when the API was created.
+            returned: success
+            type: str
+            sample: "2020-01-01T11:37:59+00:00"
+        description:
+            description: The description of the API.
+            returned: success
+            type: str
+            sample: "Automatic deployment by Ansible."
+        disable_execute_api_endpoint:
+            description: Specifies whether clients can invoke your API by using the default execute-api endpoint.
+            returned: success
+            type: bool
+            sample: False
+        endpoint_configuration:
+            description: The endpoint configuration of this RestApi showing the endpoint types of the API.
+            returned: success
+            type: dict
+            sample: {"types": ["REGIONAL"]}
+        tags:
+            description: The collection of tags.
+            returned: success
+            type: dict
+            sample: {"key": "value"}
+"""
+
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+
+
+@AWSRetry.jittered_backoff()
+def _list_rest_apis(connection, **params):
+    paginator = connection.get_paginator("get_rest_apis")
+    return paginator.paginate(**params).build_full_result().get("items", [])
+
+
+@AWSRetry.jittered_backoff()
+def _describe_rest_api(connection, module, rest_api_id):
+    try:
+        response = connection.get_rest_api(restApiId=rest_api_id)
+        response.pop("ResponseMetadata")
+    except is_boto3_error_code("ResourceNotFoundException"):
+        response = {}
+    except (
+        botocore.exceptions.ClientError,
+        botocore.exceptions.BotoCoreError,
+    ) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Trying to get Rest API '{0}'.".format(rest_api_id))
+    return response
+
+
+def main():
+    argument_spec = dict(
+        ids=dict(type="list", elements="str"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    try:
+        connection = module.client("apigateway")
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to connect to AWS")
+
+    ids = module.params.get("ids")
+    if ids:
+        rest_apis = []
+        for rest_api_id in ids:
+            result = _describe_rest_api(connection, module, rest_api_id)
+            if result:
+                rest_apis.append(result)
+    else:
+        rest_apis = _list_rest_apis(connection)
+
+    # Turn the boto3 result in to ansible_friendly_snaked_names
+    snaked_rest_apis = [camel_dict_to_snake_dict(item) for item in rest_apis]
+    module.exit_json(changed=False, rest_apis=snaked_rest_apis)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/api_gateway/defaults/main.yml
+++ b/tests/integration/targets/api_gateway/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+api_names:
+  - "ansible-api-{{ resource_prefix }}-1"
+  - "ansible-api-{{ resource_prefix }}-2"
+resource_tags:
+  - gateway_name: "ansible-api-{{ resource_prefix }}"
+    ansible_test: "{{ resource_prefix }}-1"
+  - gateway_name: "ansible-api-{{ resource_prefix }}"
+    ansible_test: "{{ resource_prefix }}-2"

--- a/tests/integration/targets/api_gateway/tasks/lookup.yml
+++ b/tests/integration/targets/api_gateway/tasks/lookup.yml
@@ -1,0 +1,211 @@
+---
+- name: Test API gateway creation using lookup=tag
+  vars:
+    api_name: "{{ api_names[0] }}"
+  block:
+    - name: Define API gateway configuration
+      set_fact:
+        apigateway_swagger_text: "{{ lookup('template', 'minimal-swagger-api.yml.j2') }}"
+
+    # Test: create API gateway using check_mode = true
+    - name: Create API gateway (check_mode=true)
+      community.aws.api_gateway:
+        name: "{{ api_name }}"
+        swagger_text: "{{ apigateway_swagger_text }}"
+      check_mode: true
+      register: __create_check_mode
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure using check_mode=true, no API gateway was created
+      assert:
+        that:
+          - __create_check_mode is changed
+          - gateways.rest_apis | selectattr('name', 'equalto', api_name) | list | length == 0
+
+    # Test: create new API gateway using name and tags
+    - name: Create new API gateway
+      community.aws.api_gateway:
+        name: "{{ api_name }}"
+        swagger_text: "{{ apigateway_swagger_text }}"
+        lookup: tag
+        tags: "{{ resource_tags[0] }}"
+      register: __create
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure new API was created
+      assert:
+        that:
+          - __create is changed
+          - gateways.rest_apis | selectattr('name', 'equalto', api_name) | list | length == 1
+
+    # Test: create API gateway idempotency (task reported changed but no new API created)
+    - name: Create same API gateway once again
+      community.aws.api_gateway:
+        name: "{{ api_name }}"
+        swagger_text: "{{ apigateway_swagger_text }}"
+        lookup: tag
+        tags: "{{ resource_tags[0] }}"
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure no new API was created
+      assert:
+        that:
+          - gateways.rest_apis | selectattr('name', 'equalto', api_name) | list | length == 1
+
+    # Test: create new API using existing name but different tags (new API gateway should be created)
+    - name: Create another API gateway with the same name but different tags
+      community.aws.api_gateway:
+        name: "{{ api_name }}"
+        swagger_text: "{{ apigateway_swagger_text }}"
+        lookup: tag
+        tags: "{{ resource_tags[1] }}"
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure new API was created
+      assert:
+        that:
+          - gateways.rest_apis | selectattr('name', 'equalto', api_name) | list | length == 2
+
+  rescue:
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Delete remaining API gateway
+      community.aws.api_gateway:
+        api_id: '{{ item }}'
+        state: absent
+      ignore_errors: true
+      with_items: "{{ gateways.rest_apis | selectattr('name', 'equalto', api_name) | map(attribute='id') | list }}"
+
+- name: Test API gateway deletion
+  block:
+    - name: "Create new API gateway name={{ api_name }}"
+      community.aws.api_gateway:
+        name: "{{ api_name }}"
+        swagger_text: "{{ lookup('template', 'minimal-swagger-api.yml.j2') }}"
+        lookup: tag
+        tags: "{{ resource_tags[0] }}"
+      vars:
+        api_name: "{{ api_names[1] }}"
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure new API was created
+      assert:
+        that:
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[1]) | list | length == 1
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[0]) | list | length == 2
+
+    # Test: Delete with lookup=tag (conflict), should failed
+    - name: Delete API gateway
+      community.aws.api_gateway:
+        lookup: tag
+        tags: "{{ resource_tags[0] }}"
+        state: absent
+      register: __delete_conflict
+      ignore_errors: true
+
+    - name: Ensure task failed
+      assert:
+        that:
+          - __delete_conflict is failed
+          - '__delete_conflict.msg == "Tags provided do not identify a unique API gateway"'
+    
+    # Test: Delete with name only (no api_id)
+    - name: Create same API gateway once again
+      community.aws.api_gateway:
+        name: "{{ api_names[1] }}"
+        state: absent
+      register: __delete_missing_params
+      ignore_errors: true
+
+    - name: Ensure task failed
+      assert:
+        that:
+          - __delete_missing_params is failed
+          - '__delete_missing_params.msg == "API gateway id must be supplied to delete API gateway or provided tag with lookup=tag to identify API gateway id."'
+
+    # Test: Delete (check_mode)
+    - name: Delete API gateway - check mode
+      community.aws.api_gateway:
+        name: "{{ api_names[1] }}"
+        lookup: tag
+        tags: "{{ resource_tags[0] }}"
+        state: absent
+      register: __delete_check_mode
+      check_mode: true
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure running in check mode, API was not deleted.
+      assert:
+        that:
+          - __delete_check_mode is changed
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[1]) | list | length == 1
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[0]) | list | length == 2
+
+    # Test: Delete using name and API gateway
+    - name: Delete API gateway using name and lookup=tag
+      community.aws.api_gateway:
+        name: "{{ api_names[1] }}"
+        lookup: tag
+        tags: "{{ resource_tags[0] }}"
+        state: absent
+      register: __delete
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure matching API gateway was deleted
+      assert:
+        that:
+          - __delete is changed
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[1]) | list | length == 0
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[0]) | list | length == 2
+
+    # Test: Delete using api_id
+    - name: Delete API gateway using api_id
+      community.aws.api_gateway:
+        api_id: "{{ gateways.rest_apis | selectattr('name', 'equalto', api_names[0]) | map(attribute='id') | first }}"
+        state: absent
+      register: __delete
+
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Ensure matching API gateway was deleted
+      assert:
+        that:
+          - __delete is changed
+          - gateways.rest_apis | selectattr('name', 'equalto', api_names[0]) | list | length == 1
+
+  always:
+    - name: List existing API gateway
+      community.aws.api_gateway_info:
+      register: gateways
+
+    - name: Delete remaining API gateway
+      community.aws.api_gateway:
+        api_id: '{{ item }}'
+        state: absent
+      ignore_errors: true
+      with_items: "{{ gateways.rest_apis | selectattr('name', 'in', api_names) | map(attribute='id') | list }}"

--- a/tests/integration/targets/api_gateway/tasks/main.yml
+++ b/tests/integration/targets/api_gateway/tasks/main.yml
@@ -11,7 +11,7 @@
     # ====================== testing failure cases: ==================================
 
     - name: test with no parameters
-      aws_api_gateway:
+      api_gateway:
       register: result
       ignore_errors: true
 
@@ -22,7 +22,7 @@
            - '"no swagger info provided" in result.msg'
 
     - name: test for disallowing multiple swagger sources
-      aws_api_gateway:
+      api_gateway:
         api_id: 'fake-api-doesnt-exist'
         swagger_file: foo.yml
         swagger_text: "this is not really an API"
@@ -42,9 +42,11 @@
       template:
         src: minimal-swagger-api.yml.j2
         dest: "{{output_dir}}/minimal-swagger-api.yml"
+      vars:
+        api_name: "{{ resource_prefix }}-minimal"
 
     - name: deploy new API
-      aws_api_gateway:
+      api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
         endpoint_type: 'REGIONAL'
@@ -81,7 +83,7 @@
           - bad_uri_result is failed
 
     - name: Update API to test params effect
-      aws_api_gateway:
+      api_gateway:
         api_id: '{{create_result.api_id}}'
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         cache_enabled: true
@@ -100,7 +102,7 @@
     # ==== additional create/delete tests ====
 
     - name: deploy first API
-      aws_api_gateway:
+      api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
         cache_enabled: false
@@ -108,7 +110,7 @@
       register: create_result_1
 
     - name: deploy second API rapidly after first
-      aws_api_gateway:
+      api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
         state: present
@@ -124,13 +126,13 @@
           - 'create_result_1.configure_response.endpoint_configuration.types.0 == "EDGE"'
 
     - name: destroy first API
-      aws_api_gateway:
+      api_gateway:
         state: absent
         api_id: '{{create_result_1.api_id}}'
       register: destroy_result_1
 
     - name: destroy second API rapidly after first
-      aws_api_gateway:
+      api_gateway:
         state: absent
         api_id: '{{create_result_2.api_id}}'
       register: destroy_result_2
@@ -143,24 +145,27 @@
            - '"apigateway:DeleteRestApi" in destroy_result_1.resource_actions'
            - '"apigateway:DeleteRestApi" in destroy_result_2.resource_actions'
 
+    # ==== test create/delete using lookup=tag ====
+    - include_tasks: lookup.yml
+
     # ================= end testing ====================================
 
   always:
 
     - name: Ensure cleanup of API deploy
-      aws_api_gateway:
+      api_gateway:
         state: absent
         api_id: '{{create_result.api_id}}'
       ignore_errors: true
 
     - name: Ensure cleanup of API deploy 1
-      aws_api_gateway:
+      api_gateway:
         state: absent
         api_id: '{{create_result_1.api_id}}'
       ignore_errors: true
 
     - name: Ensure cleanup of API deploy 2
-      aws_api_gateway:
+      api_gateway:
         state: absent
         api_id: '{{create_result_2.api_id}}'
       ignore_errors: true

--- a/tests/integration/targets/api_gateway/tasks/main.yml
+++ b/tests/integration/targets/api_gateway/tasks/main.yml
@@ -148,6 +148,9 @@
     # ==== test create/delete using lookup=tag ====
     - include_tasks: lookup.yml
 
+    # ==== Tagging ====
+    - include_tasks: tagging.yml
+
     # ================= end testing ====================================
 
   always:

--- a/tests/integration/targets/api_gateway/tasks/main.yml
+++ b/tests/integration/targets/api_gateway/tasks/main.yml
@@ -60,11 +60,14 @@
           - 'create_result.failed == False'
           - 'create_result.deploy_response.description == "Automatic deployment by Ansible."'
           - 'create_result.configure_response.id == create_result.api_id'
-          - '"apigateway:CreateRestApi" in create_result.resource_actions'
           - 'create_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     - name: check if API endpoint works
-      uri: url="https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/minimal"
+      uri: 
+        url: "https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/minimal"
+      retries: 10
+      delay: 5
+      until: uri_result is successful
       register: uri_result
 
     - name: assert API works success
@@ -73,7 +76,8 @@
           - 'uri_result.status == 200'
 
     - name: check if nonexistent endpoint causes error
-      uri: url="https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/nominal"
+      uri: 
+        url: "https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/nominal"
       register: bad_uri_result
       ignore_errors: true
 
@@ -95,9 +99,7 @@
     - name: assert update result
       assert:
         that:
-          - 'update_result.changed == True'
-          - 'update_result.failed == False'
-          - '"apigateway:PutRestApi" in update_result.resource_actions'
+          - update_result is changed
 
     # ==== additional create/delete tests ====
 
@@ -140,10 +142,8 @@
     - name: assert both APIs deployed successfully
       assert:
         that:
-           - 'destroy_result_1.changed == True'
-           - 'destroy_result_2.changed == True'
-           - '"apigateway:DeleteRestApi" in destroy_result_1.resource_actions'
-           - '"apigateway:DeleteRestApi" in destroy_result_2.resource_actions'
+           - destroy_result_1 is changed
+           - destroy_result_2 is changed
 
     # ==== test create/delete using lookup=tag ====
     - include_tasks: lookup.yml

--- a/tests/integration/targets/api_gateway/tasks/tagging.yml
+++ b/tests/integration/targets/api_gateway/tasks/tagging.yml
@@ -1,0 +1,91 @@
+---
+- name: Test API gateway tagging
+  vars:
+    api_name: "api-{{ resource_prefix }}-tagging"
+    apigateway_tags:
+      resource_prefix: "{{ resource_prefix }}"
+      collection: community.aws
+    new_tag:
+      resource_type: REST
+  block:
+    - name: Define API gateway configuration
+      set_fact:
+        apigateway_swagger_text: "{{ lookup('template', 'minimal-swagger-api.yml.j2') }}"
+
+    - name: Create API gateway
+      community.aws.api_gateway:
+        swagger_text: "{{ apigateway_swagger_text }}"
+        tags: "{{ apigateway_tags }}"
+      register: __api_gateway_create
+
+    - name: Assert resource was created with expected tags
+      assert:
+        that:
+          - __api_gateway_create.configure_response.tags == apigateway_tags
+
+    - name: Define API gateway id
+      ansible.builtin.set_fact:
+        apigateway_id: "{{ __api_gateway_create.api_id }}"
+
+    # Update tags purge_tags=false and check_mode
+    - name: Update tags using check_mode
+      community.aws.api_gateway:
+        api_id: "{{ apigateway_id }}"
+        tags: "{{ apigateway_tags | combine(new_tag) }}"
+        purge_tags: false
+      check_mode: true
+
+    - name: Get API Gateway
+      community.aws.api_gateway_info:
+        ids:
+          - "{{ apigateway_id }}"
+      register: __api_gateway_info
+
+    - name: Ensure tags were not changed
+      assert:
+        that:
+          - __api_gateway_info.rest_apis.0.tags == apigateway_tags
+
+    # Update tags purge_tags=false
+    - name: Update tags
+      community.aws.api_gateway:
+        api_id: "{{ apigateway_id }}"
+        tags: "{{ apigateway_tags | combine(new_tag) }}"
+        purge_tags: false
+
+    - name: Get API Gateway
+      community.aws.api_gateway_info:
+        ids:
+          - "{{ apigateway_id }}"
+      register: __api_gateway_info
+
+    - name: Ensure tags were not changed
+      assert:
+        that:
+          - __api_gateway_info.rest_apis.0.tags == apigateway_tags | combine(new_tag)
+
+    # Update tags purge_tags=true
+    - name: Update tags
+      community.aws.api_gateway:
+        api_id: "{{ apigateway_id }}"
+        tags: "{{ new_tag }}"
+      register: __update_api_gateway
+
+    - name: Get api gateway
+      community.aws.api_gateway_info:
+        ids:
+          - "{{ apigateway_id }}"
+      register: __api_gateway_info
+
+    - name: Ensure tags were not changed
+      assert:
+        that:
+          - __update_api_gateway is changed
+          - __api_gateway_info.rest_apis.0.tags == new_tag
+
+  always:
+    - name: Delete API Gateway
+      community.aws.api_gateway:
+        api_id: "{{ apigateway_id }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/api_gateway/templates/minimal-swagger-api.yml.j2
+++ b/tests/integration/targets/api_gateway/templates/minimal-swagger-api.yml.j2
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   version: "2017-05-11T12:14:59Z"
-  title: "{{resource_prefix}}Empty_API"
+  title: "{{ api_name }}"
 host: "fakeexample.execute-api.us-east-1.amazonaws.com"
 basePath: "/minimal"
 schemes:


### PR DESCRIPTION
##### SUMMARY
`api_gateway` - Add parameter `name` to defined the name of the API gateway to create/update, default to `ansible-temp-api` for backward compatibility

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`api_gateway`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
