### PR TITLE
Various ARN handling fixes

### DIFF
--- a/changelogs/fragments/1846-arn.yml
+++ b/changelogs/fragments/1846-arn.yml
@@ -5,6 +5,6 @@ bugfixes:
 - elasticache_info - remove hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
 - msk_cluster - remove hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
 - redshift - fixed hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
-- sns_topic - refactored ARN validation handling ().
-- iam_role - refactored ARN validation handling ().
-- iam_group - refactored ARN validation handling ().
+- sns_topic - refactored ARN validation handling (https://github.com/ansible-collections/community.aws/pull/1848).
+- iam_role - refactored ARN validation handling (https://github.com/ansible-collections/community.aws/pull/1848).
+- iam_group - refactored ARN validation handling (https://github.com/ansible-collections/community.aws/pull/1848).

--- a/changelogs/fragments/1846-arn.yml
+++ b/changelogs/fragments/1846-arn.yml
@@ -1,0 +1,10 @@
+bugfixes:
+- iam_role - fixed incorrect rejection of Gov Cloud ARNs in ``boundary`` parameter (https://github.com/ansible-collections/community.aws/issues/1846).
+- batch_compute_environment - fixed incorrect handling of Gov Cloud ARNs in ``compute_environment_name`` parameter (https://github.com/ansible-collections/community.aws/issues/1846).
+- ec2_launch_template - fixed incorrect handling of Gov Cloud ARNs in ``compute_environment_name`` parameter (https://github.com/ansible-collections/community.aws/issues/1846).
+- elasticache_info - remove hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
+- msk_cluster - remove hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
+- redshift - fixed hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
+- sns_topic - refactored ARN validation handling ().
+- iam_role - refactored ARN validation handling ().
+- iam_group - refactored ARN validation handling ().

--- a/changelogs/fragments/1846-arn.yml
+++ b/changelogs/fragments/1846-arn.yml
@@ -5,6 +5,7 @@ bugfixes:
 - elasticache_info - remove hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
 - msk_cluster - remove hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
 - redshift - fixed hard coded use of ``aws`` partition (https://github.com/ansible-collections/community.aws/issues/1846).
+minor_changes:
 - sns_topic - refactored ARN validation handling (https://github.com/ansible-collections/community.aws/pull/1848).
 - iam_role - refactored ARN validation handling (https://github.com/ansible-collections/community.aws/pull/1848).
 - iam_group - refactored ARN validation handling (https://github.com/ansible-collections/community.aws/pull/1848).

--- a/plugins/modules/batch_compute_environment.py
+++ b/plugins/modules/batch_compute_environment.py
@@ -233,6 +233,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
+from ansible_collections.amazon.aws.plugins.module_utils.arn import validate_aws_arn
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 
 
@@ -270,7 +271,7 @@ def validate_params(module):
         module.fail_json(
             msg=f"Function compute_environment_name {compute_environment_name} is invalid. Names must contain only alphanumeric characters and underscores."
         )
-    if not compute_environment_name.startswith("arn:aws:batch:"):
+    if not validate_aws_arn(compute_environment_name, service="batch"):
         if len(compute_environment_name) > 128:
             module.fail_json(msg=f'compute_environment_name "{compute_environment_name}" exceeds 128 character limit')
 

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -436,6 +436,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
+from ansible_collections.amazon.aws.plugins.module_utils.arn import validate_aws_arn
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
@@ -446,7 +447,7 @@ from ansible_collections.community.aws.plugins.module_utils.modules import Ansib
 
 
 def determine_iam_role(module, name_or_arn):
-    if re.match(r"^arn:aws:iam::\d+:instance-profile/[\w+=/,.@-]+$", name_or_arn):
+    if validate_aws_arn(name_or_arn, service="iam", resource_type="instance-profile"):
         return {"arn": name_or_arn}
     iam = module.client("iam", retry_decorator=AWSRetry.jittered_backoff())
     try:

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -422,7 +422,6 @@ default_version:
   type: int
 """
 
-import re
 from uuid import uuid4
 
 try:

--- a/plugins/modules/msk_config.py
+++ b/plugins/modules/msk_config.py
@@ -98,6 +98,7 @@ except ImportError:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
+from ansible_collections.amazon.aws.plugins.module_utils.iam import get_aws_account_info
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
@@ -283,7 +284,8 @@ def main():
     # return some useless staff in check mode if configuration doesn't exists
     # can be useful when these options are referenced by other modules during check mode run
     if module.check_mode and not response.get("Arn"):
-        arn = "arn:aws:kafka:region:account:configuration/name/id"
+        account_id, partition = get_aws_account_info(module)
+        arn = f"arn:{partition}:kafka:{module.region}:{account_id}:configuration/{module.params['name']}/id"
         revision = 1
         server_properties = ""
     else:

--- a/plugins/modules/redshift.py
+++ b/plugins/modules/redshift.py
@@ -263,7 +263,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.iam import get_aws_account_id
+from ansible_collections.amazon.aws.plugins.module_utils.iam import get_aws_account_info
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
@@ -275,9 +275,9 @@ from ansible_collections.community.aws.plugins.module_utils.modules import Ansib
 def _ensure_tags(redshift, identifier, existing_tags, module):
     """Compares and update resource tags"""
 
-    account_id = get_aws_account_id(module)
-    region = module.params.get("region")
-    resource_arn = f"arn:aws:redshift:{region}:{account_id}:cluster:{identifier}"
+    account_id, partition = get_aws_account_info(module)
+    region = module.region
+    resource_arn = f"arn:{partition}:redshift:{region}:{account_id}:cluster:{identifier}"
     tags = module.params.get("tags")
     purge_tags = module.params.get("purge_tags")
 

--- a/plugins/modules/sns_topic.py
+++ b/plugins/modules/sns_topic.py
@@ -338,9 +338,10 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
+from ansible_collections.amazon.aws.plugins.module_utils.arn import parse_aws_arn
 from ansible_collections.amazon.aws.plugins.module_utils.policy import compare_policies
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 from ansible_collections.community.aws.plugins.module_utils.sns import list_topics
@@ -579,7 +580,7 @@ class SnsTopicManager(object):
         return True
 
     def _name_is_arn(self):
-        return self.name.startswith("arn:")
+        return bool(parse_aws_arn(self.name))
 
     def ensure_ok(self):
         changed = False


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1619

##### SUMMARY

fixes: https://github.com/ansible-collections/community.aws/issues/1846

Various modules had hard-coded ARN handling which assumed the use of the main  partition.  This causes problems for folks using Gov Cloud (and aws-cn)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/batch_compute_environment.py
plugins/modules/ec2_launch_template.py
plugins/modules/elasticache_info.py
plugins/modules/iam_group.py
plugins/modules/iam_role.py
plugins/modules/msk_config.py
plugins/modules/redshift.py
plugins/modules/sns_topic.py

##### ADDITIONAL INFORMATION
