### PR TITLE
Document the requirement for an S3 bucket for the aws_ssm connection plugin

### DIFF
--- a/changelogs/fragments/1775-aws_ssm-s3-docs.yaml
+++ b/changelogs/fragments/1775-aws_ssm-s3-docs.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- aws_ssm - Updated the documentation to explicitly state that an S3 bucket is required,
+  the behavior of the files in that bucket, and requirements around that. (https://github.com/ansible-collections/community.aws/issues/1775).


### PR DESCRIPTION

##### SUMMARY

Fixes #1775 

This explains why an S3 bucket is needed for the `aws_ssm` plugin, and some considerations relating to that.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
aws_ssm

