### PR TITLE
Add support for Config recording strategies

### DIFF
--- a/changelogs/fragments/20230628-config-recorder.yml
+++ b/changelogs/fragments/20230628-config-recorder.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - aws_config_recorder - add support for Config recording strategies. Requires boto3 >= 1.26.144


### PR DESCRIPTION
##### SUMMARY
Boto3 in `1.26.144` version add support for AWS Config [recording strategies](https://boto3.amazonaws.com/v1/documentation/api/1.26.144/reference/services/config/client/put_configuration_recorder.html#). Recording strategies allow for more granular control on how Config recorders record AWS resources.
This update add support for recording strategies.
Notice that is a "breaking change" because it requires users to update their boto3 package

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`config_recorder`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
``` yaml
- name: Create Configuration Recorder for AWS Config
  community.aws.config_recorder:
    name: test_configuration_recorder
    state: present
    role_arn: 'arn:aws:iam::123456789012:role/AwsConfigRecorder'
    recording_group:
        all_supported: true
        include_global_types: true
```

After:
``` yaml
- name: Define a recording strategy to record global resources defined as resource types
  community.aws.config_recorder:
    name: test_configuration_recorder
    state: present
    role_arn: 'arn:aws:iam::123456789012:role/AwsConfigRecorder'
    resource_types:
      - AWS::EC2::Instance
    recording_group:
        all_supported: false
        include_global_types: false
        recording_strategy: INCLUSION_BY_RESOURCE_TYPES
```
