### PR TITLE
fix(connection): get bucket_region in aws_ssm

### DIFF
--- a/changelogs/fragments/1908-fix_find_out_bucket_region_logic.yml
+++ b/changelogs/fragments/1908-fix_find_out_bucket_region_logic.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssm(connection) - fix find out bucket region logic when region is us-east-1, us-east-1 region bucket_location["LocationConstraint"] is null
+  - ssm(connection) - fix bucket region logic when region is ``us-east-1`` (https://github.com/ansible-collections/community.aws/pull/1908)

--- a/changelogs/fragments/1908-fix_find_out_bucket_region_logic.yml
+++ b/changelogs/fragments/1908-fix_find_out_bucket_region_logic.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssm(connection) - fix find out bucket region logic when region is us-east-1, us-east-1 region bucket_location["LocationConstraint"] is null

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -430,7 +430,10 @@ class Connection(ConnectionBase):
         bucket_location = tmp_s3_client.get_bucket_location(
             Bucket=(self.get_option("bucket_name")),
         )
-        bucket_region = bucket_location["LocationConstraint"]
+        if bucket_location["LocationConstraint"]:
+            bucket_region = bucket_location["LocationConstraint"]
+        else:
+            bucket_region = "us-east-1"
 
         if self.get_option("bucket_endpoint_url"):
             return self.get_option("bucket_endpoint_url"), bucket_region


### PR DESCRIPTION
##### SUMMARY


when bucket is in us-east-1,
`bucket_location["LocationConstraint"]` is null

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
connection

##### ADDITIONAL INFORMATION

add condition for `bucket_region`
