### PR TITLE
opensearch: avoid a KeyError during the DomainConfig reading

### DIFF
--- a/changelogs/fragments/opensearch_domainconfig_no_options.yaml
+++ b/changelogs/fragments/opensearch_domainconfig_no_options.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "opensearch - Don't try to read a non existing key from the domain config (https://github.com/ansible-collections/community.aws/pull/1910)."

--- a/plugins/module_utils/opensearch.py
+++ b/plugins/module_utils/opensearch.py
@@ -61,7 +61,8 @@ def get_domain_config(client, module, domain_name):
     arn = None
     if response is not None:
         for k in response["DomainConfig"]:
-            domain_config[k] = response["DomainConfig"][k]["Options"]
+            if "Options" in response["DomainConfig"][k]:
+                domain_config[k] = response["DomainConfig"][k]["Options"]
         domain_config["DomainName"] = domain_name
         # If ES cluster is attached to the Internet, the "VPCOptions" property is not present.
         if "VPCOptions" in domain_config:


### PR DESCRIPTION
This commit avoids a KeyError exception in `get_domain_config()`.
Some entries from DomainConfig don't have any `Options` key. For instance, `ChangeProgressDetails`.

See:
- https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_DomainConfig.html
- https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_ChangeProgressDetails.html

Closes: #1907