### PR TITLE
[PR#1912/cc5194db][stable-6] Add missing changelogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -806,6 +806,33 @@ New Modules
 - opensearch_info - obtain information about one or more OpenSearch or ElasticSearch domain
 - rds_cluster_snapshot - Manage Amazon RDS snapshots of DB clusters
 
+v3.6.0
+======
+
+Release Summary
+---------------
+
+Following the release of community.aws 5.0.0, 3.6.0 is a bugfix release and the final planned release for the 3.x series.
+
+
+Minor Changes
+-------------
+
+- autoscaling_group_info - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- cloudfront_distribution - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- cloudfront_origin_access_identity - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- cloudtrail - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- ec2_asg_lifecycle_hook - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- ec2_vpc_nacl - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- redshift - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+- s3_bucket_info - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+
+Bugfixes
+--------
+
+- ec2_placement_group - Handle a potential race creation during the creation of a new Placement Group (https://github.com/ansible-collections/community.aws/pull/1477).
+- s3_lifecycle - fix bug when deleting rules with an empty prefix (https://github.com/ansible-collections/community.aws/pull/1398).
+
 v3.5.0
 ======
 
@@ -1117,6 +1144,65 @@ Bugfixes
 --------
 
 - aws_eks - Fix EKS cluster creation with short names (https://github.com/ansible-collections/community.aws/pull/818).
+
+v2.6.1
+======
+
+Release Summary
+---------------
+
+Bump collection from 2.6.0 to 2.6.1 due to a publishing error with 2.6.0.  This release supersedes 2.6.0 entirely, users should skip 2.6.0.
+
+v2.6.0
+======
+
+Release Summary
+---------------
+
+This is the last planned 2.x release of the ``community.aws`` collection.
+Consider upgrading to the latest version of ``community.aws`` soon.
+
+Minor Changes
+-------------
+
+- ecs_service - ``deployment_circuit_breaker`` has been added as a supported feature (https://github.com/ansible-collections/community.aws/pull/1215).
+- ecs_service - add ``service`` alias to address the ecs service name with the same parameter as the ecs_service_info module is doing (https://github.com/ansible-collections/community.aws/pull/1187).
+- ecs_service_info - add ``name`` alias to address the ecs service name with the same parameter as the ecs_service module is doing (https://github.com/ansible-collections/community.aws/pull/1187).
+
+Bugfixes
+--------
+
+- ecs_service - fix broken change detect of ``health_check_grace_period_seconds`` parameter when not specified (https://github.com/ansible-collections/community.aws/pull/1212).
+- ecs_service - use default cluster name of ``default`` when not input (https://github.com/ansible-collections/community.aws/pull/1212).
+- ecs_task - dont require ``cluster`` and use name of ``default`` when not input (https://github.com/ansible-collections/community.aws/pull/1212).
+- wafv2_ip_set - fix bug where incorrect changed state was returned when only changing the description (https://github.com/ansible-collections/community.aws/pull/1211).
+
+v2.5.0
+======
+
+Release Summary
+---------------
+
+This is the minor release of the ``community.aws`` collection.
+
+Minor Changes
+-------------
+
+- iam_policy - update broken examples and add RETURN section to documentation; add extra integration tests for idempotency check mode runs (https://github.com/ansible-collections/community.aws/pull/1093).
+- iam_role - delete inline policies prior to deleting role (https://github.com/ansible-collections/community.aws/pull/1054).
+- iam_role - remove global vars and refactor accordingly (https://github.com/ansible-collections/community.aws/pull/1054).
+
+Bugfixes
+--------
+
+- ecs_service - add missing change detect of ``health_check_grace_period_seconds`` parameter (https://github.com/ansible-collections/community.aws/pull/1145).
+- ecs_service - fix broken compare of ``task_definition`` that results always in a changed task (https://github.com/ansible-collections/community.aws/pull/1145).
+- ecs_service - fix validation for ``placement_constraints``. It's possible to use ``distinctInstance`` placement constraint now (https://github.com/ansible-collections/community.aws/issues/1058)
+- ecs_taskdefinition - fix broken change detect of ``launch_type`` parameter (https://github.com/ansible-collections/community.aws/pull/1145).
+- execute_lambda - fix check mode and update RETURN documentation (https://github.com/ansible-collections/community.aws/pull/1115).
+- iam_policy - require one of ``policy_document`` and ``policy_json`` when state is present to prevent MalformedPolicyDocumentException from being thrown (https://github.com/ansible-collections/community.aws/pull/1093).
+- s3_lifecycle - add support of value *0* for ``transition_days`` (https://github.com/ansible-collections/community.aws/pull/1077).
+- s3_lifecycle - check that configuration is complete before returning (https://github.com/ansible-collections/community.aws/pull/1085).
 
 v2.4.0
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1581,6 +1581,74 @@ releases:
     - 970-redshift_info-boto-import.yml
     - 977-add-backoff-logic-elb-info.yml
     release_date: '2022-03-30'
+  2.5.0:
+    changes:
+      bugfixes:
+      - ecs_service - add missing change detect of ``health_check_grace_period_seconds``
+        parameter (https://github.com/ansible-collections/community.aws/pull/1145).
+      - ecs_service - fix broken compare of ``task_definition`` that results always
+        in a changed task (https://github.com/ansible-collections/community.aws/pull/1145).
+      - ecs_service - fix validation for ``placement_constraints``. It's possible
+        to use ``distinctInstance`` placement constraint now (https://github.com/ansible-collections/community.aws/issues/1058)
+      - ecs_taskdefinition - fix broken change detect of ``launch_type`` parameter
+        (https://github.com/ansible-collections/community.aws/pull/1145).
+      - execute_lambda - fix check mode and update RETURN documentation (https://github.com/ansible-collections/community.aws/pull/1115).
+      - iam_policy - require one of ``policy_document`` and ``policy_json`` when state
+        is present to prevent MalformedPolicyDocumentException from being thrown (https://github.com/ansible-collections/community.aws/pull/1093).
+      - s3_lifecycle - add support of value *0* for ``transition_days`` (https://github.com/ansible-collections/community.aws/pull/1077).
+      - s3_lifecycle - check that configuration is complete before returning (https://github.com/ansible-collections/community.aws/pull/1085).
+      minor_changes:
+      - iam_policy - update broken examples and add RETURN section to documentation;
+        add extra integration tests for idempotency check mode runs (https://github.com/ansible-collections/community.aws/pull/1093).
+      - iam_role - delete inline policies prior to deleting role (https://github.com/ansible-collections/community.aws/pull/1054).
+      - iam_role - remove global vars and refactor accordingly (https://github.com/ansible-collections/community.aws/pull/1054).
+      release_summary: This is the minor release of the ``community.aws`` collection.
+    fragments:
+    - 0000-ecs_taskdefinition_fix.yml
+    - 1054-iam_role-delete-inline-policies-and-refactor.yml
+    - 1077-s3_lifecycle-transition-days-zero.yml
+    - 1085-s3_lifecycle-check-that-configuration-is-complete-before-returning.yml
+    - 1093-iam_policy-update-docs-and-add-required_if.yml
+    - 1115-execute_lambda-checkmode-fix-update-return-docs.yml
+    - 1300-ecs_service-placementConstraints.yml
+    - 2.5.0.yml
+    release_date: '2022-05-30'
+  2.6.0:
+    changes:
+      bugfixes:
+      - ecs_service - fix broken change detect of ``health_check_grace_period_seconds``
+        parameter when not specified (https://github.com/ansible-collections/community.aws/pull/1212).
+      - ecs_service - use default cluster name of ``default`` when not input (https://github.com/ansible-collections/community.aws/pull/1212).
+      - ecs_task - dont require ``cluster`` and use name of ``default`` when not input
+        (https://github.com/ansible-collections/community.aws/pull/1212).
+      - wafv2_ip_set - fix bug where incorrect changed state was returned when only
+        changing the description (https://github.com/ansible-collections/community.aws/pull/1211).
+      minor_changes:
+      - ecs_service - ``deployment_circuit_breaker`` has been added as a supported
+        feature (https://github.com/ansible-collections/community.aws/pull/1215).
+      - ecs_service - add ``service`` alias to address the ecs service name with the
+        same parameter as the ecs_service_info module is doing (https://github.com/ansible-collections/community.aws/pull/1187).
+      - ecs_service_info - add ``name`` alias to address the ecs service name with
+        the same parameter as the ecs_service module is doing (https://github.com/ansible-collections/community.aws/pull/1187).
+      release_summary: 'This is the last planned 2.x release of the ``community.aws``
+        collection.
+
+        Consider upgrading to the latest version of ``community.aws`` soon.'
+    fragments:
+    - 0001-ecs-service-aliases.yml
+    - 1211-wafv2_ip_set-description.yml
+    - 1212-ecs_service-fix-broken-change-detect.yml
+    - 1215-ecs-service-deployment-circuit-breaker-support.yml
+    - 2.6.0.yml
+    release_date: '2022-06-22'
+  2.6.1:
+    changes:
+      release_summary:
+        Bump collection from 2.6.0 to 2.6.1 due to a publishing error with 2.6.0.  This
+        release supersedes 2.6.0 entirely, users should skip 2.6.0.
+    fragments:
+    - 261_increase.yml
+    release_date: '2022-06-22'
   3.0.0:
     changes:
       breaking_changes:
@@ -2063,6 +2131,31 @@ releases:
     - 580-vpc_peer-idempotency.yml
     - 645-aws_config_aggregator-fix-update-and-idempotency.yml
     release_date: '2022-08-03'
+  3.6.0:
+    changes:
+      bugfixes:
+      - ec2_placement_group - Handle a potential race creation during the creation
+        of a new Placement Group (https://github.com/ansible-collections/community.aws/pull/1477).
+      - s3_lifecycle - fix bug when deleting rules with an empty prefix (https://github.com/ansible-collections/community.aws/pull/1398).
+      minor_changes:
+      - autoscaling_group_info - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - cloudfront_distribution - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - cloudfront_origin_access_identity - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - cloudtrail - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - ec2_asg_lifecycle_hook - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - ec2_vpc_nacl - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - redshift - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      - s3_bucket_info - minor sanity test fixes (https://github.com/ansible-collections/community.aws/pull/1410).
+      release_summary: 'Following the release of community.aws 5.0.0, 3.6.0 is a bugfix
+        release and the final planned release for the 3.x series.
+
+        '
+    fragments:
+    - 1398-s3_lifecycle-no-prefix.yml
+    - 1410-linting.yml
+    - RELEASE-3.6.0.yml
+    - ec2_placement_group_race_on_create.yaml
+    release_date: '2022-10-06'
   4.0.0:
     changes:
       breaking_changes:
@@ -3360,8 +3453,7 @@ releases:
       - cloudfront_distribution - add ``http3`` support via parameter value ``http2and3``
         for parameter ``http_version`` (https://github.com/ansible-collections/community.aws/pull/1753).
       - cloudfront_distribution - add ``origin_shield`` options (https://github.com/ansible-collections/community.aws/pull/1557).
-      - cloudfront_distribution - documented ``connection_attempts`` and ``connection_timeout``
-        the module was already capable of using them
+      - cloudfront_distribution - documented ``connection_attempts`` and ``connection_timeout`` the module was already capable of using them
       - community.aws - updated document fragments based on changes in amazon.aws
         (https://github.com/ansible-collections/community.aws/pull/1738).
       - community.aws - updated imports based on changes in amazon.aws (https://github.com/ansible-collections/community.aws/pull/1738).


### PR DESCRIPTION
##### SUMMARY

When we initially released 3.6.0, 2.6.1, 2.6.0 and 2.5.0 we didn't merge the changelog entries into 'main'.

This pulls them in to fill the gaps.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

changelogs/changelog.yml

##### ADDITIONAL INFORMATION

Manual backport of https://github.com/ansible-collections/community.aws/pull/1912