### PR TITLE
Add new purge_stack_instances parameter for the CloudFormation stack set module

### DIFF
--- a/changelogs/fragments/20230814-cloudformation-stack-set.yml
+++ b/changelogs/fragments/20230814-cloudformation-stack-set.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cloudformation_stack_set - add new 'purge_stack_instances' module parameter to remove stack instances when accounts are not present in the list of accounts


### PR DESCRIPTION
##### SUMMARY
This PR extends the `cloudformation_stack_set` module by adding a `purge_stack_instances` module parameter. Currently, the module is not idempotent because removing an account from the list of accounts doesn't instruct CloudFormation to remove account instances from the stack set. This change ensures that CloudFormation keeps stack instances only for the accounts listed in the `accounts` list.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`cloudformation_stack_set`