### PR TITLE
CI: Force PyYAML version that can be installed

### DIFF
--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -5,3 +5,7 @@ botocore==1.25.0
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
 awscli==1.23.0
+
+# AWS CLI depends on PyYAML <5.5,>=3.10; the latest PyYAML release in that range, 5.4.1, fails to install.
+# Use a version in that range that is known to work (https://github.com/yaml/pyyaml/issues/736)
+PyYAML==5.3.1


### PR DESCRIPTION
##### SUMMARY
Currently integration tests with https://github.com/ansible/ansible-zuul-jobs/pull/1816 still fail when installing some requirements:
```
2023-08-22 05:53:46.350742 | TASK [ansible-test : Install python requirements]
[...]

2023-08-22 05:53:53.860850 | controller | Collecting PyYAML<5.5,>=3.10 (from awscli->-r /home/zuul-worker/.ansible/collections/ansible_collections/community/aws/test-requirements.txt (line 19))
2023-08-22 05:53:53.866271 | controller |   Downloading PyYAML-5.4.1.tar.gz (175 kB)
2023-08-22 05:53:53.878160 | controller |      â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â” 175.1/175.1 kB 19.0 MB/s eta 0:00:00
2023-08-22 05:53:54.065094 | controller |   Installing build dependencies: started
2023-08-22 05:53:58.372457 | controller |   Installing build dependencies: finished with status 'done'
2023-08-22 05:53:58.373282 | controller |   Getting requirements to build wheel: started
2023-08-22 05:53:58.680407 | controller |   Getting requirements to build wheel: finished with status 'error'
2023-08-22 05:53:58.689654 | controller |   error: subprocess-exited-with-error
```
(https://b3e35e76f7fc3e0cf6b5-d430d94f79a1de67219002b64dcf7484.ssl.cf1.rackcdn.com/1904/63f02a9c37ef75f9dcf25159fb4033d6edf146ee/check/integration-community.aws-1/b2f8016/job-output.txt)

Tries to work around this problem by pinning the PyYAML version to 5.3.1 (see also https://github.com/yaml/pyyaml/issues/736).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
