### PR TITLE
Fix version_added for route53_wait

### DIFF
--- a/changelogs/fragments/20230906-route53_wait.yml
+++ b/changelogs/fragments/20230906-route53_wait.yml
@@ -1,0 +1,2 @@
+trivial:
+- route53_wait - fix version_added.

--- a/plugins/modules/route53_wait.py
+++ b/plugins/modules/route53_wait.py
@@ -7,7 +7,7 @@
 DOCUMENTATION = r"""
 ---
 module: route53_wait
-version_added: 6.2.0
+version_added: 6.3.0
 short_description: wait for changes in Amazons Route 53 DNS service to propagate
 description:
   - When using M(amazon.aws.route53) with I(wait=false), this module allows to wait for the


### PR DESCRIPTION
##### SUMMARY

We accidentally set version_added to 6.2 instead of 6.3

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

route53_wait

##### ADDITIONAL INFORMATION
