### PR TITLE
community.aws.glue_job: Adjust the Number of Workers and Allocated Capacity

### DIFF
--- a/plugins/modules/glue_job.py
+++ b/plugins/modules/glue_job.py
@@ -124,6 +124,13 @@ EXAMPLES = r"""
 - community.aws.glue_job:
     name: my-glue-job
     state: absent
+
+# Configure Glue job with more workers and higher allocated capacity
+  community.aws.glue_job:
+    name: my-glue-job
+    number_of_workers: 5
+    allocated_capacity: 10
+    state: present
 """
 
 RETURN = r"""


### PR DESCRIPTION

##### SUMMARY
Configure the number of workers and allocated capacity for a Glue job

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
 community.aws.glue_job:
    number_of_workers:
    allocated_capacity: 

