### PR TITLE
[7.0.0] Bump botocore requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,33 @@ Use community.aws 4.x.y if you are using Ansible 2.9 or Ansible Core 2.10.
 
 This collection depends on the AWS SDK for Python (Boto3 and Botocore).  Due to the
 [AWS SDK Python Support Policy](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
-this collection requires Python 3.6 or greater.
+this collection requires Python 3.7 or greater.
 
-Amazon have also announced the end of support for
-[Python less than 3.7](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).
-As such support for Python less than 3.7 by this collection has been deprecated and will be removed in release 7.0.0.
-Additionally, support for Python less than 3.8 is expected to be removed in a release after 2024-12-01 based on currently
-available schedules.
+Amazon have also announced the planned end of support for
+[Python less than 3.8](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).
+As such support for Python less than 3.8 will be removed in a release after 2024-12-01.
+
+<!---
+### End of Support by Python Versions:
+
+| Python Version | AWS SDK | Collection |
+| -------------- | -------- | ---------- |
+| 2.7 | July 2021 | Release 2.0.0 (September 2021) |
+| 3.4 | February 2021 | Release 1.0.0 (June 2020) |
+| 3.5 | February 2021 | Release 2.0.0 (September 2021) |
+| 3.6 | May 2022 | Release 7.0.0 (November 2023) |
+| 3.7 | December 2023 | *After December 2024* |
+| 3.8 | April 2025 | *After April 2026* |
+| 3.9 | April 2026 | *After April 2027* |
+| 3.10 | April 2027 | *After April 2028* |
+| 3.11 | April 2028 | *After April 2029* |
+--->
 
 ## AWS SDK version compatibility
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 6.0.0 of this collection supports `boto3 >= 1.22.0` and `botocore >= 1.25.0`
+Version 7.0.0 of this collection supports `boto3 >= 1.26.0` and `botocore >= 1.29.0`
 
 All support for the original AWS SDK `boto` was removed in release 4.0.0.
 

--- a/changelogs/fragments/botocore.yml
+++ b/changelogs/fragments/botocore.yml
@@ -1,0 +1,6 @@
+breaking_changes:
+- The community.aws collection has dropped support for ``botocore<1.29.0`` and
+  ``boto3<1.26.0``. Most modules will continue to work with older versions of the AWS SDK, however
+  compatability with older versions of the SDK is not guaranteed and will not be tested. When using
+  older versions of the SDK a warning will be emitted by Ansible
+  (https://github.com/ansible-collections/amazon.aws/pull/1763).

--- a/changelogs/fragments/python37.yml
+++ b/changelogs/fragments/python37.yml
@@ -1,0 +1,10 @@
+breaking_changes:
+- community.aws collection - due to the AWS SDKs announcing the end of support
+  for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+  support for Python less than 3.7 by this collection wss been deprecated in release 6.0.0 and removed in release 7.0.0.
+  (https://github.com/ansible-collections/amazon.aws/pull/1763).
+
+# We've already announced the deprecation for <3.8 (with 6.0.0), dropping support for <3.9 on ours side will happen
+# after April 2026.  This is about 2 years + 5 months away assuming a November 7.0.0 release, we could announce
+# the deprecation now, but assuming we release 8.0.0 in about 6 months a just short of 2 year
+# deprecation feels fine given it's predictable.

--- a/plugins/module_utils/networkfirewall.py
+++ b/plugins/module_utils/networkfirewall.py
@@ -513,7 +513,9 @@ class BaseNetworkFirewallManager(BaseResourceManager):
         Removes information from the metadata which can't be updated.
         Returns a *copy* of the metadata dictionary.
         """
-        return deepcopy(metadata)
+        meta = deepcopy(metadata)
+        meta.pop("LastModifiedTime", None)
+        return meta
 
     def _flush_create(self):
         changed = super(BaseNetworkFirewallManager, self)._flush_create()

--- a/plugins/modules/dynamodb_table.py
+++ b/plugins/modules/dynamodb_table.py
@@ -123,7 +123,6 @@ options:
   table_class:
     description:
       - The class of the table.
-      - Requires at least botocore version 1.23.18.
     choices: ['STANDARD', 'STANDARD_INFREQUENT_ACCESS']
     type: str
     version_added: 3.1.0
@@ -1055,9 +1054,6 @@ def main():
         catch_extra_error_codes=["LimitExceededException", "ResourceInUseException", "ResourceNotFoundException"],
     )
     client = module.client("dynamodb", retry_decorator=retry_decorator)
-
-    if module.params.get("table_class"):
-        module.require_botocore_at_least("1.23.18", reason="to set table_class")
 
     current_table = get_dynamodb_table()
     changed = False

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -368,7 +368,6 @@ options:
         type: str
         description: >
           - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
-          - Requires botocore >= 1.21.29
         choices: [enabled, disabled]
         default: 'disabled'
       instance_metadata_tags:
@@ -376,7 +375,6 @@ options:
         type: str
         description:
           - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
-          - Requires botocore >= 1.23.30
         choices: [enabled, disabled]
         default: 'disabled'
 extends_documentation_fragment:
@@ -581,23 +579,6 @@ def create_or_update(module, template_options):
     out = {}
     lt_data = params_to_launch_data(module, dict((k, v) for k, v in module.params.items() if k in template_options))
     lt_data = scrub_none_parameters(lt_data, descend_into_lists=True)
-
-    if lt_data.get("MetadataOptions"):
-        if not module.botocore_at_least("1.23.30"):
-            # fail only if enabled is requested
-            if lt_data["MetadataOptions"].get("InstanceMetadataTags") == "enabled":
-                module.require_botocore_at_least("1.23.30", reason="to set instance_metadata_tags")
-            # pop if it's not requested to keep backwards compatibility.
-            # otherwise the modules failes because parameters are set due default values
-            lt_data["MetadataOptions"].pop("InstanceMetadataTags")
-
-        if not module.botocore_at_least("1.21.29"):
-            # fail only if enabled is requested
-            if lt_data["MetadataOptions"].get("HttpProtocolIpv6") == "enabled":
-                module.require_botocore_at_least("1.21.29", reason="to set http_protocol_ipv6")
-            # pop if it's not requested to keep backwards compatibility.
-            # otherwise the modules failes because parameters are set due default values
-            lt_data["MetadataOptions"].pop("HttpProtocolIpv6")
 
     if not (template or template_versions):
         # create a full new one

--- a/plugins/modules/networkfirewall_policy.py
+++ b/plugins/modules/networkfirewall_policy.py
@@ -76,7 +76,6 @@ options:
         C(aws:alert_strict) and C(aws:alert_established).
       - Only valid for policies where I(strict_rule_order=true).
       - When creating a new policy defaults to C(aws:drop_strict).
-      - I(stateful_default_actions) requires botocore>=1.21.52.
     required: false
     type: list
     elements: str
@@ -86,7 +85,6 @@ options:
       - When I(strict_rule_order='strict') rules and rule groups are evaluated in
         the order that they're defined.
       - Cannot be updated after creation.
-      - I(stateful_rule_order) requires botocore>=1.21.52.
     required: false
     type: str
     choices: ['default', 'strict']
@@ -398,10 +396,6 @@ def main():
     manager.set_wait_timeout(module.params.get("wait_timeout", None))
 
     rule_order = module.params.get("stateful_rule_order")
-    if rule_order and rule_order != "default":
-        module.require_botocore_at_least("1.21.52", reason="to set the rule order")
-    if module.params.get("stateful_default_actions"):
-        module.require_botocore_at_least("1.21.52", reason="to set the default actions for stateful flows")
 
     if state == "absent":
         manager.delete()

--- a/plugins/modules/networkfirewall_rule_group.py
+++ b/plugins/modules/networkfirewall_rule_group.py
@@ -58,7 +58,6 @@ options:
       - Mutually exclusive with I(rule_type=stateless).
       - For more information on how rules are evaluated read the AWS documentation
         U(https://docs.aws.amazon.com/network-firewall/latest/developerguide/suricata-rule-evaluation-order.html).
-      - I(rule_order) requires botocore>=1.23.23.
     type: str
     required: false
     choices: ['default', 'strict']
@@ -772,8 +771,6 @@ def main():
         ],
     )
 
-    module.require_botocore_at_least("1.19.20")
-
     state = module.params.get("state")
     name = module.params.get("name")
     arn = module.params.get("arn")
@@ -788,9 +785,6 @@ def main():
             module.fail_json("rule_list can only be used for stateful rule groups")
         if module.params.get("domain_list"):
             module.fail_json("domain_list can only be used for stateful rule groups")
-
-    if module.params.get("rule_order"):
-        module.require_botocore_at_least("1.23.23", reason="to set the rule order")
 
     manager = NetworkFirewallRuleManager(module, arn=arn, name=name, rule_type=rule_type)
     manager.set_wait(module.params.get("wait", None))

--- a/plugins/modules/networkfirewall_rule_group_info.py
+++ b/plugins/modules/networkfirewall_rule_group_info.py
@@ -36,7 +36,6 @@ options:
       - When I(scope='account') returns a description of all rule groups in the account.
       - When I(scope='managed') returns a list of available managed rule group arns.
       - By default searches only at the account scope.
-      - I(scope='managed') requires botocore>=1.23.23.
     required: false
     choices: ['managed', 'account']
     type: str
@@ -412,15 +411,10 @@ def main():
         ],
     )
 
-    module.require_botocore_at_least("1.19.20")
-
     arn = module.params.get("arn")
     name = module.params.get("name")
     rule_type = module.params.get("rule_type")
     scope = module.params.get("scope")
-
-    if module.params.get("scope") == "managed":
-        module.require_botocore_at_least("1.23.23", reason="to list managed rules")
 
     manager = NetworkFirewallRuleManager(module, name=name, rule_type=rule_type)
 

--- a/plugins/modules/opensearch.py
+++ b/plugins/modules/opensearch.py
@@ -1310,8 +1310,6 @@ def main():
         supports_check_mode=True,
     )
 
-    module.require_botocore_at_least("1.21.38")
-
     try:
         client = module.client("opensearch", retry_decorator=AWSRetry.jittered_backoff())
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/plugins/modules/opensearch_info.py
+++ b/plugins/modules/opensearch_info.py
@@ -514,7 +514,6 @@ def main():
         ),
         supports_check_mode=True,
     )
-    module.require_botocore_at_least("1.21.38")
 
     try:
         client = module.client("opensearch", retry_decorator=AWSRetry.jittered_backoff())

--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -68,7 +68,6 @@ options:
   noncurrent_version_keep_newer:
     description:
       - The minimum number of non-current versions to retain.
-      - Requires C(botocore >= 1.23.12)
       - Requres I(noncurrent_version_expiration_days).
     required: false
     type: int
@@ -637,11 +636,6 @@ def main():
     expiration_date = module.params.get("expiration_date")
     transition_date = module.params.get("transition_date")
     state = module.params.get("state")
-
-    if module.params.get("noncurrent_version_keep_newer"):
-        module.require_botocore_at_least(
-            "1.23.12", reason="to set number of versions to keep with noncurrent_version_keep_newer"
-        )
 
     if state == "present" and module.params["status"] == "enabled":  # allow deleting/disabling a rule by id/prefix
         required_when_present = (

--- a/plugins/modules/wafv2_web_acl.py
+++ b/plugins/modules/wafv2_web_acl.py
@@ -88,7 +88,6 @@ options:
         - A map of custom response keys and content bodies. Define response bodies here and reference them in the rules by providing
         - the key of the body dictionary element.
         - Each element must have a unique dict key and in the dict two keys for I(content_type) and I(content).
-        - Requires botocore >= 1.20.40
       type: dict
       version_added: 3.1.0
     purge_rules:
@@ -503,7 +502,6 @@ def main():
 
     custom_response_bodies = module.params.get("custom_response_bodies")
     if custom_response_bodies:
-        module.require_botocore_at_least("1.20.40", reason="to set custom response bodies")
         custom_response_bodies = {}
 
         for custom_name, body in module.params.get("custom_response_bodies").items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.25.0
-boto3>=1.22.0
+botocore>=1.29.0
+boto3>=1.26.0

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,2 +1,2 @@
 modules:
-    python_requires: '>=3.6'
+    python_requires: '>=3.7'

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,10 +1,10 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.22.0
-botocore==1.25.0
+botocore==1.29.0
+boto3==1.26.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.23.0
+awscli==1.27.0
 
 # AWS CLI depends on PyYAML <5.5,>=3.10; the latest PyYAML release in that range, 5.4.1, fails to install.
 # Use a version in that range that is known to work (https://github.com/yaml/pyyaml/issues/736)

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.22.0
-botocore==1.25.0
+botocore==1.29.0
+boto3==1.26.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.23.0
+awscli==1.27.0


### PR DESCRIPTION
##### SUMMARY

In line with https://github.com/ansible-collections/amazon.aws/pull/1763 bump our botocore requirements for 7.0.0

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
changelogs/fragments/botocore.yml
changelogs/fragments/python37.yml
plugins/modules/dynamodb_table.py
plugins/modules/ec2_launch_template.py
plugins/modules/networkfirewall_policy.py
plugins/modules/networkfirewall_rule_group.py
plugins/modules/networkfirewall_rule_group_info.py
plugins/modules/opensearch.py
plugins/modules/opensearch_info.py
plugins/modules/s3_lifecycle.py
plugins/modules/wafv2_web_acl.py
requirements.txt
tests/config.yml
tests/integration/constraints.txt
tests/unit/constraints.txt

##### ADDITIONAL INFORMATION

Deliberately links to the amazon.aws PR to avoid duplicating the reasons.