### PR TITLE
Set the wait timeout to 900 seconds

### DIFF
--- a/plugins/modules/networkfirewall.py
+++ b/plugins/modules/networkfirewall.py
@@ -140,6 +140,16 @@ EXAMPLES = r"""
 - community.aws.networkfirewall:
     state: absent
     name: 'ExampleFirewall'
+
+# Create an AWS Network Firewall with Wait Timeout
+- community.aws.networkfirewall:
+    name: 'ExampleFirewall'
+    state: present
+    policy: 'ExamplePolicy'
+    subnets:
+      - 'subnet-123456789abcdef01'
+    wait: true
+    wait_timeout: 900   
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
Use the wait_timeout flag within the community.aws.networkfirewall module to specify the maximum time, in seconds, to wait for the AWS Network Firewall to reach the expected state

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
wait_timeout: 
