### PR TITLE
Use HeadBucket instead of GetBucketLocation (#1979)

### DIFF
--- a/changelogs/fragments/1979-use-headbucket.yml
+++ b/changelogs/fragments/1979-use-headbucket.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm - use ``head_bucket`` to access bucket locations in foreign aws accounts (https://github.com/ansible-collections/community.aws/pull/1987).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -427,13 +427,12 @@ class Connection(ConnectionBase):
         )
         # Fetch the location of the bucket so we can open a client against the 'right' endpoint
         # This /should/ always work
-        bucket_location = tmp_s3_client.get_bucket_location(
+        head_bucket = tmp_s3_client.head_bucket(
             Bucket=(self.get_option("bucket_name")),
         )
-        if bucket_location["LocationConstraint"]:
-            bucket_region = bucket_location["LocationConstraint"]
-        else:
-            bucket_region = "us-east-1"
+        bucket_region = head_bucket.get("ResponseMetadata", {}).get("HTTPHeaders", {}).get("x-amz-bucket-region", None)
+        if bucket_region is None:
+          bucket_region = "us-east-1"
 
         if self.get_option("bucket_endpoint_url"):
             return self.get_option("bucket_endpoint_url"), bucket_region

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -432,7 +432,7 @@ class Connection(ConnectionBase):
         )
         bucket_region = head_bucket.get("ResponseMetadata", {}).get("HTTPHeaders", {}).get("x-amz-bucket-region", None)
         if bucket_region is None:
-          bucket_region = "us-east-1"
+            bucket_region = "us-east-1"
 
         if self.get_option("bucket_endpoint_url"):
             return self.get_option("bucket_endpoint_url"), bucket_region


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replacing the call to get_bucket_location with a call to head_bucket in Connection._get_bucket_endpoint(). 

The GetBucketLocation API call only works from the bucket owner account. This enables using a bucket owned by another accout, e.g. a shared organization bucket when running cross-account.

Fixes #1979.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ssm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The [official documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) for the GetBucketLocation API call states it is only supported for backwards compatibility and recomends using HeadBucket instead.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# Before change
PLAY [Minimal playbook] ********************************************************

TASK [Gathering Facts] *********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the GetBucketLocation operation: Access Denied
fatal: [i-00a8cb5930bd5f7dc]: FAILED! => {"msg": "Unexpected failure during module execution: An error occurred (AccessDenied) when calling the GetBucketLocation operation: Access Denied", "stdout": ""}

PLAY RECAP *********************************************************************
i-00a8cb5930bd5f7dc        : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 

# After change
PLAY [Minimal playbook] ********************************************************

TASK [Gathering Facts] *********************************************************
Warning: : Platform linux on host i-00a8cb5930bd5f7dc is using the discovered
Python interpreter at /usr/libexec/platform-python, but future installation of
another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.15/reference_appendices/interpreter_discovery.html for more information.
ok: [i-00a8cb5930bd5f7dc]

TASK [Ping] ********************************************************************
ok: [i-00a8cb5930bd5f7dc]

PLAY RECAP *********************************************************************
i-00a8cb5930bd5f7dc        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
