### PR TITLE
Set etag haslib md5 usedforsecurity to false

### DIFF
--- a/plugins/module_utils/etag.py
+++ b/plugins/module_utils/etag.py
@@ -58,7 +58,7 @@ def calculate_multipart_etag(source_path, chunk_size=DEFAULT_CHUNK_SIZE):
     else:  # > 1
         digests = b"".join(m.digest() for m in md5s)
 
-        new_md5 = hashlib.md5(digests)
+        new_md5 = hashlib.md5(digests, usedforsecurity=False)
         new_etag = f'"{new_md5.hexdigest()}-{len(md5s)}"'
 
     return new_etag


### PR DESCRIPTION
##### SUMMARY
This utility currently fails on FIPS enabled systems due to the use of md5. When calculating the md5s for the chunks usedforsecurity is set to false but not when doing the md5 of all the digests. This commit fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
etag

##### ADDITIONAL INFORMATION
