### PR TITLE
eks_nodegroup - wait for deletion of both node groups

### DIFF
--- a/changelogs/fragments/eks_nodegroup-integration-wait-delete.yml
+++ b/changelogs/fragments/eks_nodegroup-integration-wait-delete.yml
@@ -1,0 +1,4 @@
+trivial:
+- eks_nodegroup - update integration test to wait for both nodegroups to be deleted.
+minor_changes:
+- eks_nodegroup - ensure wait also waits for deletion to complete when ``wait==True`` ().

--- a/tests/integration/targets/eks_nodegroup/tasks/cleanup.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/cleanup.yml
@@ -74,7 +74,7 @@
     state: absent
     vpc_id: '{{ setup_vpc.vpc.id}}'
   ignore_errors: 'yes'
-    
+
 - name: remove setup VPC
   ec2_vpc_net:
     cidr_block: 10.0.0.0/16

--- a/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
@@ -2,7 +2,7 @@
 # This space was a copy by aws_eks_cluster integration test
 - name: ensure IAM instance role exists
   iam_role:
-    name: ansible-test-eks_cluster_role
+    name: ansible-test-{{ tiny_prefix }}-eks_nodegroup-cluster
     assume_role_policy_document: '{{ lookup(''file'',''eks-trust-policy.json'') }}'
     state: present
     create_instance_profile: 'no'
@@ -44,7 +44,7 @@
   community.aws.ec2_vpc_route_table:
     vpc_id: '{{ setup_vpc.vpc.id }}'
     tags:
-      Name: EKS
+      Name: "EKS-ng-{{ tiny_prefix }}"
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     routes:
       - dest: 0.0.0.0/0
@@ -77,9 +77,9 @@
       - eks_create.name == eks_cluster_name
 
 # Dependecies to eks nodegroup
-- name: create IAM instance role 
+- name: create IAM instance role
   iam_role:
-    name: 'ansible-test-eks_nodegroup'
+    name: 'ansible-test-{{ tiny_prefix }}-eks_nodegroup-ng'
     assume_role_policy_document: '{{ lookup(''file'',''eks-nodegroup-trust-policy.json'') }}'
     state: present
     create_instance_profile: no

--- a/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
@@ -445,7 +445,6 @@
     state: absent
     cluster_name: '{{ eks_cluster_name }}'
   register: eks_nodegroup_result
-  check_mode: True
 
 - name: check that eks_nodegroup is not changed (idempotency)
   assert:
@@ -578,7 +577,19 @@
     cluster_name: '{{ eks_cluster_name }}'
     wait: True
   register: eks_nodegroup_result
-  check_mode: True
+
+- name: check that eks_nodegroup is not changed (idempotency)
+  assert:
+    that:
+      - eks_nodegroup_result is not changed
+
+- name: wait for deletion of name_a nodegroup (idempotency)
+  eks_nodegroup:
+    name: '{{ eks_nodegroup_name_a }}'
+    state: absent
+    cluster_name: '{{ eks_cluster_name }}'
+    wait: True
+  register: eks_nodegroup_result
 
 - name: check that eks_nodegroup is not changed (idempotency)
   assert:


### PR DESCRIPTION
##### SUMMARY

Fixes eks_nodegroup integration test.
Ensure eks_nodegroup waits for deletion when `wait=True` including when the node group was already in deletING state.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

eks_nodegroup

##### ADDITIONAL INFORMATION