### PR TITLE
[stable-6] Lock sanity test versions based on what we were testing when 7.0.0 was released

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -5,68 +5,32 @@ on: [workflow_call]  # allow this workflow to be called from other workflows
 
 jobs:
   sanity:
-    uses: ansible-network/github_actions/.github/workflows/sanity.yml@main
+    # stable-6 sanity test versions locked based on tested versions as of 7.0.0 release
+    uses: ansible-network/github_actions/.github/workflows/sanity.yml@b2b68168f3040e55553664b1fbcdc19cf10f49bc
     with:
-      matrix_include: "[]"
+      matrix_include: >-
+          []
       matrix_exclude: >-
           [
+            # devel and milestone are a moving target while we should fix issues in the
+            # main and our current major releases, they're no always appropriate to
+            # backport to older releases.
             {
-              "ansible-version": "stable-2.9"
+              "ansible-version": "milestone"
             },
             {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.11"
-            },
-            {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.11"
+              "ansible-version": "devel"
             },
             {
               "ansible-version": "stable-2.14",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.8"
+              "python-version": "3.12"
             },
             {
               "ansible-version": "stable-2.15",
-              "python-version": "3.7"
+              "python-version": "3.12"
             },
             {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "devel",
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
             }
           ]

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -10,11 +10,11 @@ jobs:
     with:
       matrix_include: >-
           []
+      # devel and milestone are a moving target while we should fix issues in the
+      # main and our current major releases, they're no always appropriate to
+      # backport to older releases.
       matrix_exclude: >-
           [
-            # devel and milestone are a moving target while we should fix issues in the
-            # main and our current major releases, they're no always appropriate to
-            # backport to older releases.
             {
               "ansible-version": "milestone"
             },

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -30,4 +30,4 @@ jobs:
               "python-version": "3.9"
             }
           ]
-      collection_pre_install: 'git+https://github.com/ansible-collections/amazon.aws.git,stable-6'
+      collection_pre_install: "-r source/tests/unit/requirements.yml"

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -5,68 +5,29 @@ on: [workflow_call]  # allow this workflow to be called from other workflows
 
 jobs:
   unit-source:
-    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@main
+    # stable-6 unit test versions locked based on tested versions as of 7.0.0 release
+    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@b2b68168f3040e55553664b1fbcdc19cf10f49bc
     with:
+      # devel and milestone are a moving target while we should fix issues in the
+      # main and our current major releases, they're no always appropriate to
+      # backport to older releases.
       matrix_exclude: >-
           [
+            {
+              "ansible-version": "milestone"
+            },
+            {
+              "ansible-version": "devel"
+            },
             {
               "python-version": "3.11"
             },
             {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.7"
+              "python-version": "3.12"
             },
             {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.12",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "stable-2.13",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.14",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "stable-2.15",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.9"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.7"
-            },
-            {
-              "ansible-version": "devel",
-              "python-version": "3.8"
-            },
-            {
-              "ansible-version": "devel",
+              "ansible-version": "stable-2.16",
               "python-version": "3.9"
             }
           ]
-      collection_pre_install: ''
+      collection_pre_install: 'git+https://github.com/ansible-collections/amazon.aws.git,stable-6'


### PR DESCRIPTION
##### SUMMARY

Now that `stable-6` is primarily security-/bug- fixes only, lock the Ansible/Python versions of the Ansible sanity tests that we run.  Explicitly excludes running against the milestone/devel versions of the tests since they're a moving target.  While we should be applying these fixes to `main`/`stable-7`, many of the fixes are primarily cosmetic in nature and don't warrant backporting all the way into `stable-6` and beyond.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

.github/workflows/sanity.yml

##### ADDITIONAL INFORMATION
