### PR TITLE
Do not use runtimePlatform for non-fargate ECS Task Definitions

### DIFF
--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -897,6 +897,8 @@ class EcsTaskManager:
             params["placementConstraints"] = placement_constraints
         if runtime_platform:
             params["runtimePlatform"] = runtime_platform
+        if launch_type != "FARGATE":
+            params["runtimePlatform"] = {}
 
         try:
             response = self.ecs.register_task_definition(aws_retry=True, **params)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For ECS task definitions, runtime_platform options should be empty for task definitions with non-fargate launch_type (e.g. EC2), because otherwise services will not be able to deploy them. There is no way to avoid this option (`runtimePlatform`) to be set to a value due to the validations and therefore there is no way to use this module to create non-FARGATE task definitions any more.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_taskdefinition

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Create an ECS task definition with launch type EC2. Omit the runtimePlatform option. This will create an ECS Task definition that specifies LINUX/X86_64 as runtime (should be empty, though, because runtimePlatform only affects FARGATE-launched tasks).
2. Create an ECS service which uses this task definition.
3. The deployment will fail

This situation is resolved when runtimePlatform options are not set. This, however, is not possible at the moment. It also breaks backwards compatibility for non-FARGATE task definitions.
