### PR TITLE
setup_sshkey: drop a dep on Crypto

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,8 +17,5 @@ git+https://github.com/ansible-community/pytest-ansible-units.git ; python_versi
 netaddr
 # Sometimes needed where we don't have features we need in modules
 awscli
-# Used for comparing SSH Public keys to the Amazon fingerprints
-# pycrypto is EoL using pycryptodome for now
-pycryptodome
-# Used by ec2_win_password
+# Used for comparing SSH Public keys to the Amazon fingerprints and ec2_win_password
 cryptography

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -8,7 +8,6 @@ virtualenv
 # Sometimes needed where we don't have features we need in modules
 awscli
 # Used for comparing SSH Public keys to the Amazon fingerprints
-# pycrypto is EoL using pycryptodome for now
-pycryptodome
+cryptography
 # Used by ec2_asg_scheduled_action
 python-dateutil

--- a/tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py
+++ b/tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py
@@ -8,28 +8,26 @@ ssh-keygen -f id_rsa.pub -e -m PKCS8 | openssl pkey -pubin -outform DER | openss
 (but without needing the OpenSSL CLI)
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-__metaclass__ = type
 
 import hashlib
 import sys
 
-from Crypto.PublicKey import RSA
+from cryptography.hazmat.primitives import serialization
 
 if len(sys.argv) == 0:
     ssh_public_key = "id_rsa.pub"
 else:
     ssh_public_key = sys.argv[1]
 
-with open(ssh_public_key, "r") as key_fh:
-    data = key_fh.read()
-
-# Convert from SSH format to DER format
-public_key = RSA.importKey(data).exportKey("DER")
-md5digest = hashlib.md5(public_key).hexdigest()
+with open(ssh_public_key, "rb") as key_file:
+    public_key = serialization.load_ssh_public_key(
+        key_file.read(),
+    )
+pub_der = public_key.public_bytes(
+    encoding=serialization.Encoding.DER,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+md5digest = hashlib.md5(pub_der).hexdigest()
 # Format the md5sum into the normal format
 pairs = zip(md5digest[::2], md5digest[1::2])
 md5string = ":".join(["".join(pair) for pair in pairs])


### PR DESCRIPTION
##### SUMMARY

Adjust ec2-fingerprint.py so it use cryptography instead of the deprecated Crypto library.

(originally written by Gonéri)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py

##### ADDITIONAL INFORMATION

Original PR (amazon.aws)
https://github.com/ansible-collections/amazon.aws/pull/799