### PR TITLE
elb_network_lb - add support for AlpnPolicy for TLS listeners

### DIFF
--- a/changelogs/fragments/20231127-elb_network_lb-update-tls-listeners.yaml
+++ b/changelogs/fragments/20231127-elb_network_lb-update-tls-listeners.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - elb_network_lb - add the possibly to update ``SslPolicy`` and ``Certificates`` for TLS listeners ().
+  - elb_network_lb - add support for Application-Layer Protocol Negotiation (ALPN) policy ``AlpnPolicy`` for TLS listeners (https://github.com/ansible-collections/community.aws/issues/1566).

--- a/plugins/modules/elb_network_lb.py
+++ b/plugins/modules/elb_network_lb.py
@@ -69,6 +69,17 @@ options:
                     description:
                       - The name of the target group.
                       - Mutually exclusive with I(TargetGroupArn).
+        AlpnPolicy:
+            description:
+              - The name of the Application-Layer Protocol Negotiation (ALPN) policy.
+            type: str
+            choices:
+              - HTTP1Only
+              - HTTP2Only
+              - HTTP2Optional
+              - HTTP2Preferred
+              - None
+            version_added: 7.1.0
   name:
     description:
       - The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric
@@ -283,6 +294,13 @@ load_balancer:
                             returned: when state is present
                             type: str
                             sample: ""
+                alpn_policy:
+                    description: The name of the Application-Layer Protocol Negotiation (ALPN) policy.
+                    returned: when state is present
+                    type: list
+                    elements: str
+                    version_added: 7.1.0
+                    sample: ["HTTP1Only", "HTTP2Only"]
         load_balancer_arn:
             description: The Amazon Resource Name (ARN) of the load balancer.
             returned: when state is present
@@ -449,6 +467,10 @@ def main():
                 SslPolicy=dict(type="str"),
                 Certificates=dict(type="list", elements="dict"),
                 DefaultActions=dict(type="list", required=True, elements="dict"),
+                AlpnPolicy=dict(
+                    type="str",
+                    choices=["HTTP1Only", "HTTP2Only", "HTTP2Optional", "HTTP2Preferred", "None"],
+                ),
             ),
         ),
         name=dict(required=True, type="str"),

--- a/tests/integration/targets/elb_network_lb/tasks/test_modifying_nlb_listeners.yml
+++ b/tests/integration/targets/elb_network_lb/tasks/test_modifying_nlb_listeners.yml
@@ -73,3 +73,83 @@
       that:
         - nlb.changed
         - not nlb.listeners
+
+# TLS listeners
+- name: Add a TLS listener
+  elb_network_lb:
+    name: "{{ nlb_name }}"
+    subnets: "{{ nlb_subnets }}"
+    state: present
+    listeners:
+      - Protocol: TLS
+        Port: 443
+        Certificates:
+          - CertificateArn: "{{ cert.arn }}"
+        DefaultActions:
+          - Type: forward
+            TargetGroupName: "{{ tg_name }}"
+        SslPolicy: ELBSecurityPolicy-TLS-1-0-2015-04
+        AlpnPolicy: HTTP2Optional
+  register: _add
+
+- assert:
+    that:
+      - _add.listeners[0].alpn_policy == ["HTTP2Optional"]
+      - _add.listeners[0].ssl_policy == "ELBSecurityPolicy-TLS-1-0-2015-04"
+
+- name: Add a TLS listener (idempotency)
+  elb_network_lb:
+    name: "{{ nlb_name }}"
+    subnets: "{{ nlb_subnets }}"
+    listeners:
+      - Protocol: TLS
+        Port: 443
+        Certificates:
+          - CertificateArn: "{{ cert.arn }}"
+        DefaultActions:
+          - Type: forward
+            TargetGroupName: "{{ tg_name }}"
+        SslPolicy: ELBSecurityPolicy-TLS-1-0-2015-04
+        AlpnPolicy: HTTP2Optional
+  register: _idempotency
+
+- assert:
+    that:
+      - _idempotency is not changed
+      - _idempotency.listeners[0].alpn_policy == ["HTTP2Optional"]
+      - _idempotency.listeners[0].ssl_policy == "ELBSecurityPolicy-TLS-1-0-2015-04"
+
+- name: Update TLS listener of NLB
+  elb_network_lb:
+    name: "{{ nlb_name }}"
+    subnets: "{{ nlb_subnets }}"
+    listeners:
+      - Protocol: TLS
+        Port: 443
+        Certificates:
+          - CertificateArn: "{{ cert.arn }}"
+        DefaultActions:
+          - Type: forward
+            TargetGroupName: "{{ tg_name }}"
+        SslPolicy: ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04
+        AlpnPolicy: HTTP1Only
+  register: _update
+
+- assert:
+    that:
+      - _update is changed
+      - _update.listeners[0].alpn_policy == ["HTTP1Only"]
+      - _update.listeners[0].ssl_policy == "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+
+- name: remove listener from NLB
+  elb_network_lb:
+    name: "{{ nlb_name }}"
+    subnets: "{{ nlb_subnets }}"
+    state: present
+    listeners: []
+  register: nlb
+
+- assert:
+    that:
+      - nlb.changed
+      - not nlb.listeners


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1884
closes #1566 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`elb_network_lb`
