### PR TITLE
stable-6:  add upper limit for amazon.aws dependency

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ description: A variety of Ansible content to help automate the management of AWS
 license_file: COPYING
 tags: [community, aws, cloud, amazon]
 dependencies:
-  amazon.aws: '>=6.2.0'
+  amazon.aws: '>=6.2.0, <7.0.0'
 repository: https://github.com/ansible-collections/community.aws
 documentation: https://ansible-collections.github.io/community.aws/branch/stable-6/collections/community/aws/index.html
 homepage: https://github.com/ansible-collections/community.aws

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ description: A variety of Ansible content to help automate the management of AWS
 license_file: COPYING
 tags: [community, aws, cloud, amazon]
 dependencies:
-  amazon.aws: '>=6.2.0, <7.0.0'
+  amazon.aws: '>=6.2.0,<7.0.0'
 repository: https://github.com/ansible-collections/community.aws
 documentation: https://ansible-collections.github.io/community.aws/branch/stable-6/collections/community/aws/index.html
 homepage: https://github.com/ansible-collections/community.aws


### PR DESCRIPTION
##### SUMMARY

Parts of community.aws breaks when amazon.aws version is to high  
ref: https://github.com/ansible-collections/community.aws/issues/1915