### PR TITLE
Fix example of eks_nodegroup

### DIFF
--- a/plugins/modules/eks_nodegroup.py
+++ b/plugins/modules/eks_nodegroup.py
@@ -184,19 +184,19 @@ EXAMPLES = r"""
       - subnet-qwerty123
       - subnet-asdfg456
     scaling_config:
-      - min_size: 1
-      - max_size: 2
-      - desired_size: 1
+      min_size: 1
+      max_size: 2
+      desired_size: 1
     disk_size: 20
     instance_types: 't3.micro'
     ami_type: 'AL2_x86_64'
     labels:
-      - 'teste': 'test'
+      'teste': 'test'
     taints:
       - key: 'test'
         value: 'test'
         effect: 'NO_SCHEDULE'
-    capacity_type: 'on_demand'
+    capacity_type: 'ON_DEMAND'
 
 - name: Remove an EKS Nodegrop
   community.aws.eks_nodegroup:


### PR DESCRIPTION
##### SUMMARY

When using the example as a reference, ansible-playbook command outputs the following errors:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "argument 'scaling_config' is of type <class 'list'> and we were unable to convert to dict: <class 'list'> cannot be converted to a dict"}

fatal: [localhost]: FAILED! => {"changed": false, "msg": "argument 'labels' is of type <class 'list'> and we were unable to convert to dict: <class 'list'> cannot be converted to a dict"}

fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of capacity_type must be one of: ON_DEMAND, SPOT, got: on_demand"}
```

This fixes those issues.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
eks_nodegroup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
