### PR TITLE
add support for G.4X and G.8X in glue_job.py

### DIFF
--- a/changelogs/fragments/2048-add-new-instance-types-in-gluejob.yaml
+++ b/changelogs/fragments/2048-add-new-instance-types-in-gluejob.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - glue_job - add support for 2 new instance types which are G.4X and G.8X
+  - glue_job - add support for 2 new instance types which are G.4X and G.8X (https://github.com/ansible-collections/community.aws/pull/2048).

--- a/changelogs/fragments/2048-add-new-instance-types-in-gluejob.yaml
+++ b/changelogs/fragments/2048-add-new-instance-types-in-gluejob.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443).

--- a/changelogs/fragments/2048-add-new-instance-types-in-gluejob.yaml
+++ b/changelogs/fragments/2048-add-new-instance-types-in-gluejob.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443).
+  - glue_job - add support for 2 new instance types which are G.4X and G.8X

--- a/plugins/modules/glue_job.py
+++ b/plugins/modules/glue_job.py
@@ -95,7 +95,7 @@ options:
   worker_type:
     description:
       - The type of predefined worker that is allocated when a job runs.
-      - new instance types G.4X and G.8X [https://aws.amazon.com/about-aws/whats-new/2023/05/aws-glue-large-instance-types-generally-available/]
+      - Support for instance types C(G.4X( and C(G.8X) was added in community.aws release 7.2.0.
     choices: [ 'Standard', 'G.1X', 'G.2X', 'G.4X', 'G.8X' ]
     type: str
     version_added: 1.5.0

--- a/plugins/modules/glue_job.py
+++ b/plugins/modules/glue_job.py
@@ -95,7 +95,8 @@ options:
   worker_type:
     description:
       - The type of predefined worker that is allocated when a job runs.
-    choices: [ 'Standard', 'G.1X', 'G.2X' ]
+      - new instance types G.4X and G.8X [https://aws.amazon.com/about-aws/whats-new/2023/05/aws-glue-large-instance-types-generally-available/]
+    choices: [ 'Standard', 'G.1X', 'G.2X', 'G.4X', 'G.8X' ]
     type: str
     version_added: 1.5.0
 notes:
@@ -465,7 +466,7 @@ def main():
         state=dict(required=True, choices=["present", "absent"], type="str"),
         tags=dict(type="dict", aliases=["resource_tags"]),
         timeout=dict(type="int"),
-        worker_type=dict(choices=["Standard", "G.1X", "G.2X"], type="str"),
+        worker_type=dict(choices=["Standard", "G.1X", "G.2X", "G.4X", "G.8X"], type="str"),
     )
 
     module = AnsibleAWSModule(


### PR DESCRIPTION
##### SUMMARY
according to https://aws.amazon.com/about-aws/whats-new/2023/05/aws-glue-large-instance-types-generally-available/ I added support for these 2 new instance types

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
glue_job
