### PR TITLE
Remove unparsible sanity error

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,2 +1,0 @@
-plugins/connection/aws_ssm.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353
-plugins/inventory/aws_mq.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible/ansible/pull/82355 has been merged and is now part of milestone, we can remove the ignore

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/sanity/ignore-2.17.txt

##### ADDITIONAL INFORMATION
