### PR TITLE
Update lambda python runtime version in integration tests

### DIFF
--- a/changelogs/fragments/20240402-lambda-test-runtime.yml
+++ b/changelogs/fragments/20240402-lambda-test-runtime.yml
@@ -1,2 +1,2 @@
-bugfixes:
+trivial:
   - integration tests - update lambda ``runtime`` parameter to python3.12 (https://github.com/ansible-collections/community.aws/pull/2065).

--- a/changelogs/fragments/20240402-lambda-test-runtime.yml
+++ b/changelogs/fragments/20240402-lambda-test-runtime.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - integration tests - update lambda ``runtime`` parameter to python3.12 (https://github.com/ansible-collections/community.aws/pull/2065).

--- a/tests/integration/targets/elb_target/tasks/lambda_target.yml
+++ b/tests/integration/targets/elb_target/tasks/lambda_target.yml
@@ -23,7 +23,7 @@
       name: "{{ lambda_name }}"
       state: present
       zip_file: /tmp/lambda.zip
-      runtime: python3.7
+      runtime: python3.12
       role: "{{ ROLE_ARN.arn }}"
       handler: ansible_lambda_target.lambda_handler
       timeout: 30

--- a/tests/integration/targets/s3_bucket_notification/tasks/test_lambda_notifications.yml
+++ b/tests/integration/targets/s3_bucket_notification/tasks/test_lambda_notifications.yml
@@ -41,7 +41,7 @@
         name: '{{ lambda_name }}'
         state: present
         role: "{{ lambda_role_name }}"
-        runtime: python3.7
+        runtime: python3.12
         zip_file: '{{function_res.dest}}'
         handler: lambda_function.lambda_handler
         memory_size: '128'

--- a/tests/integration/targets/secretsmanager_secret/tasks/rotation.yml
+++ b/tests/integration/targets/secretsmanager_secret/tasks/rotation.yml
@@ -55,7 +55,7 @@
       name: "{{ lambda_name }}"
       state: present
       zip_file: "{{ tmp.path }}/hello_world.zip"
-      runtime: 'python3.9'
+      runtime: 'python3.12'
       role: "{{ iam_role_output.arn }}"
       handler: 'hello_world.lambda_handler'
     register: lambda_output
@@ -169,7 +169,7 @@
       name: "{{ lambda_name }}"
       state: absent
       zip_file: "{{ tmp.path }}/hello_world.zip"
-      runtime: 'python3.9'
+      runtime: 'python3.12'
       role: "{{ secret_manager_role }}"
       handler: 'hello_world.lambda_handler'
     ignore_errors: yes

--- a/tests/integration/targets/sns_topic/tasks/main.yml
+++ b/tests/integration/targets/sns_topic/tasks/main.yml
@@ -309,7 +309,7 @@
       name: '{{ sns_topic_lambda_name }}'
       state: present
       zip_file: '{{ tempdir.path }}/{{ sns_topic_lambda_function }}.zip'
-      runtime: python3.9
+      runtime: python3.12
       role: '{{ sns_topic_lambda_role }}'
       handler: '{{ sns_topic_lambda_function }}.handler'
     register: lambda_result


### PR DESCRIPTION
##### SUMMARY
The `elb_target` and `s3_bucket_notification` integration test targets were failing due to the python3.7 runtime no longer being supported. I have updated this to python3.12. While at it I went ahead and updated the `secretsmanager_secret` and `sns_topic` target runtimes from python3.9 to python3.12 too.

##### ISSUE TYPE
- Bugfix Pull Request
