### PR TITLE
amazon.aws 8.0.0 deprecations - test cleanup

### DIFF
--- a/tests/integration/targets/config/tasks/main.yaml
+++ b/tests/integration/targets/config/tasks/main.yaml
@@ -173,7 +173,7 @@
       config_recorder:
         name: '{{ resource_prefix }}-recorder'
         state: present
-        role_arn: "{{ config_iam_role.arn }}"
+        role_arn: "{{ config_iam_role.iam_role.arn }}"
         recording_group:
             all_supported: true
             include_global_types: true
@@ -236,7 +236,7 @@
         account_sources: []
         organization_source:
           all_aws_regions: true
-          role_arn: "{{ config_iam_role.arn }}"
+          role_arn: "{{ config_iam_role.iam_role.arn }}"
       register: output
 
     - name: assert success
@@ -251,7 +251,7 @@
         account_sources: []
         organization_source:
           all_aws_regions: true
-          role_arn: "{{ config_iam_role.arn }}"
+          role_arn: "{{ config_iam_role.iam_role.arn }}"
       register: output
 
     - name: assert not changed
@@ -266,7 +266,7 @@
       config_recorder:
         name: '{{ resource_prefix }}-recorder'
         state: present
-        role_arn: "{{ config_iam_role.arn }}"
+        role_arn: "{{ config_iam_role.iam_role.arn }}"
         recording_group:
             all_supported: false
             include_global_types: false
@@ -348,7 +348,7 @@
           all_aws_regions: false
           aws_regions:
             - '{{ aws_region }}'
-          role_arn: "{{ config_iam_role.arn }}"
+          role_arn: "{{ config_iam_role.iam_role.arn }}"
       register: output
 
     - name: assert success
@@ -365,7 +365,7 @@
           all_aws_regions: false
           aws_regions:
             - '{{ aws_region }}'
-          role_arn: "{{ config_iam_role.arn }}"
+          role_arn: "{{ config_iam_role.iam_role.arn }}"
       register: output
 
     - name: assert success
@@ -380,7 +380,7 @@
       config_recorder:
         name: '{{ resource_prefix }}-recorder'
         state: present
-        role_arn: "{{ config_iam_role.arn }}"
+        role_arn: "{{ config_iam_role.iam_role.arn }}"
         recording_group:
             all_supported: false
             include_global_types: false

--- a/tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
@@ -29,7 +29,7 @@
 
     - assert:
         that:
-          - 'template_with_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.iam_role.arn.replace(":role/", ":instance-profile/")'
 
     - name: Create template again, with no change to instance_role
       ec2_launch_template:
@@ -41,7 +41,7 @@
 
     - assert:
         that:
-          - 'template_with_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.iam_role.arn.replace(":role/", ":instance-profile/")'
           - 'template_with_role is not changed'
 
     - name: Update instance with new instance_role
@@ -54,8 +54,8 @@
 
     - assert:
         that:
-          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
-          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.iam_role.arn.replace(":role/", ":instance-profile/")'
           - 'template_with_role.default_template.version_number < template_with_updated_role.default_template.version_number'
           - 'template_with_updated_role is changed'
           - 'template_with_updated_role is not failed'
@@ -71,7 +71,7 @@
     - assert:
         that:
           - 'template_with_updated_role is not changed'
-          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role_2.iam_role.arn.replace(":role/", ":instance-profile/")'
 
     - name: Update instance with original instance_role (pass profile ARN)
       ec2_launch_template:
@@ -79,13 +79,13 @@
         image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
         # By default an instance profile will be created with the same name as the role
-        iam_instance_profile: '{{ iam_role.arn.replace(":role/", ":instance-profile/") }}'
+        iam_instance_profile: '{{ iam_role.iam_role.arn.replace(":role/", ":instance-profile/") }}'
       register: template_with_updated_role
 
     - assert:
         that:
-          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
-          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.iam_role.arn.replace(":role/", ":instance-profile/")'
           - 'template_with_role.default_template.version_number < template_with_updated_role.default_template.version_number'
           - 'template_with_updated_role is changed'
           - 'template_with_updated_role is not failed'
@@ -95,13 +95,13 @@
         name: "{{ resource_prefix }}-test-instance-role"
         image_id: "{{ ec2_ami_id }}"
         instance_type: t2.micro
-        iam_instance_profile: '{{ iam_role.arn.replace(":role/", ":instance-profile/") }}'
+        iam_instance_profile: '{{ iam_role.iam_role.arn.replace(":role/", ":instance-profile/") }}'
       register: template_with_updated_role
 
     - assert:
         that:
           - 'template_with_updated_role is not changed'
-          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+          - 'template_with_updated_role.default_template.launch_template_data.iam_instance_profile.arn == iam_role.iam_role.arn.replace(":role/", ":instance-profile/")'
 
   always:
     - name: delete launch template

--- a/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
@@ -547,7 +547,7 @@
 
       >> "rolloutStateReason": "ECS deployment ecs-svc/5156684577543126023 in progress.",
       constraints and placement strategies are only changeable if the rollout state is "COMPLETED"
-      
+
       a) ecs_service has currently no waiter function. so this is a DIY waiter
       b) the state reached never "COMPLETED" because something if wrong with the ECS EC2 Instances
          or the network setup. The EC2 instance never arrived as an active instance in the cluster.
@@ -555,9 +555,9 @@
          >> no container instance met all of its requirements. Reason: No Container Instances were found in your cluster.
          >> For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.
          >> ec2_instance networking does not work correctly, no instance available for the cluster
-      
+
       Because all of this, all following tasks, that test the change of a constraint or placement stragegy are
-      using `force_new_deployment: true`. That ignores a) and b).  
+      using `force_new_deployment: true`. That ignores a) and b).
   ignore_errors: true
   ecs_service_info:
     name: "{{ ecs_service_name }}-constraint"
@@ -736,7 +736,7 @@
     launch_type: FARGATE
     cpu: 512
     memory: 1024
-    execution_role_arn: "{{ iam_execution_role.arn }}"
+    execution_role_arn: "{{ iam_execution_role.iam_role.arn }}"
     state: present
   vars:
     ecs_task_host_port: 8080
@@ -750,7 +750,7 @@
     launch_type: EC2
     cpu: 512
     memory: 1024
-    execution_role_arn: "{{ iam_execution_role.arn }}"
+    execution_role_arn: "{{ iam_execution_role.iam_role.arn }}"
     state: present
   vars:
     ecs_task_host_port: 8080
@@ -916,7 +916,7 @@
     launch_type: FARGATE
     cpu: 512
     memory: 1024
-    execution_role_arn: "{{ iam_execution_role.arn }}"
+    execution_role_arn: "{{ iam_execution_role.iam_role.arn }}"
     state: present
     runtime_platform:
       cpuArchitecture: "ARM64"
@@ -938,7 +938,7 @@
     launch_type: FARGATE
     cpu: 512
     memory: 1024
-    execution_role_arn: "{{ iam_execution_role.arn }}"
+    execution_role_arn: "{{ iam_execution_role.iam_role.arn }}"
     state: present
     runtime_platform:
       cpuArchitecture: "ARM64"
@@ -960,7 +960,7 @@
     launch_type: FARGATE
     cpu: 512
     memory: 1024
-    execution_role_arn: "{{ iam_execution_role.arn }}"
+    execution_role_arn: "{{ iam_execution_role.iam_role.arn }}"
     state: present
     runtime_platform:
       cpuArchitecture: "ARM64"

--- a/tests/integration/targets/eks_cluster/tasks/full_test.yml
+++ b/tests/integration/targets/eks_cluster/tasks/full_test.yml
@@ -79,7 +79,7 @@
         name: "{{ eks_cluster_name }}"
         security_groups: "{{ eks_security_groups | map(attribute='name') }}"
         subnets: "{{ setup_subnets.results | map(attribute='subnet.id') }}"
-        role_arn: "{{ iam_role.arn }}"
+        role_arn: "{{ iam_role.iam_role.arn }}"
         tags:
           Name: "{{ resource_prefix }}"
           another: foobar
@@ -97,7 +97,7 @@
         name: "{{ eks_cluster_name }}"
         security_groups: "{{ eks_security_groups | map(attribute='name') }}"
         subnets: "{{ setup_subnets.results | map(attribute='subnet.id') }}"
-        role_arn: "{{ iam_role.arn }}"
+        role_arn: "{{ iam_role.iam_role.arn }}"
         wait: yes
       register: eks_create
 
@@ -117,7 +117,7 @@
         name: "{{ eks_cluster_name }}"
         security_groups: "{{ setup_security_groups.results | map(attribute='group_id') }}"
         subnets: "{{ setup_subnets.results | map(attribute='subnet.id') }}"
-        role_arn: "{{ iam_role.arn }}"
+        role_arn: "{{ iam_role.iam_role.arn }}"
       register: eks_create
 
     - name: check that EKS cluster did not change
@@ -143,7 +143,7 @@
         name: "{{ eks_cluster_name }}"
         security_groups: "{{ eks_security_groups | map(attribute='name') }}"
         subnets: "{{ setup_subnets.results | map(attribute='subnet.id') }}"
-        role_arn: "{{ iam_role.arn }}"
+        role_arn: "{{ iam_role.iam_role.arn }}"
         wait: yes
       register: eks_create
 
@@ -169,7 +169,7 @@
         name: "{{ eks_cluster_short_name }}"
         security_groups: "{{ eks_security_groups | map(attribute='name') }}"
         subnets: "{{ setup_subnets.results | map(attribute='subnet.id') }}"
-        role_arn: "{{ iam_role.arn }}"
+        role_arn: "{{ iam_role.iam_role.arn }}"
       register: eks_create
 
     - name: check that EKS cluster was created with short name

--- a/tests/integration/targets/eks_fargate_profile/tasks/create_eks_cluster.yml
+++ b/tests/integration/targets/eks_fargate_profile/tasks/create_eks_cluster.yml
@@ -87,7 +87,7 @@
     name: '{{ eks_cluster_name }}'
     security_groups: '{{ eks_security_groups | map(attribute=''name'') }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
-    role_arn: '{{ iam_role.arn }}'
+    role_arn: '{{ iam_role.iam_role.arn }}'
     wait: true
   register: eks_create
 

--- a/tests/integration/targets/eks_fargate_profile/tasks/full_test.yml
+++ b/tests/integration/targets/eks_fargate_profile/tasks/full_test.yml
@@ -1,5 +1,5 @@
 # Creating dependencies
-- name: create IAM instance role 
+- name: create IAM instance role
   iam_role:
     name: 'ansible-test-aws_eks_fargate_profile'
     assume_role_policy_document: '{{ lookup(''file'',''eks-fargate-profile-trust-policy.json'') }}'
@@ -19,7 +19,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: fake_cluster
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -38,7 +38,7 @@
     name: fake_profile
     cluster_name: '{{ eks_cluster_name }}'
     state: absent
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -57,7 +57,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'public') | map(attribute='subnet.id') }}
@@ -72,13 +72,13 @@
       - not eks_fargate_profile_create.changed
       - eks_fargate_profile_create.msg.endswith("provided in Fargate Profile is not a private subnet")
 
-# Create Fargate_profile with wait 
+# Create Fargate_profile with wait
 - name: create Fargate Profile with wait (check mode)
   eks_fargate_profile:
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -99,7 +99,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -120,7 +120,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -141,7 +141,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -162,7 +162,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -185,7 +185,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -207,7 +207,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -230,7 +230,7 @@
     name: '{{ eks_fargate_profile_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -253,7 +253,7 @@
     name: '{{ eks_fargate_profile_name_b }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -272,7 +272,7 @@
     name: '{{ eks_fargate_profile_name_b }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -291,7 +291,7 @@
     name: '{{ eks_fargate_profile_name_b }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -310,7 +310,7 @@
     name: '{{ eks_fargate_profile_name_b }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    role_arn: '{{ iam_role_fargate.arn }}'
+    role_arn: '{{ iam_role_fargate.iam_role.arn }}'
     subnets: >-
       {{setup_subnets.results|selectattr('subnet.tags.Name', 'contains',
       'private') | map(attribute='subnet.id') }}
@@ -389,7 +389,7 @@
     that:
       - eks_fargate_profile_b_delete.changed
 
-- name: delete a fargate profile b 
+- name: delete a fargate profile b
   eks_fargate_profile:
     name: '{{ eks_fargate_profile_name_b }}'
     cluster_name: '{{ eks_cluster_name }}'

--- a/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
@@ -67,7 +67,7 @@
     name: '{{ eks_cluster_name }}'
     security_groups: '{{ eks_security_groups | map(attribute=''name'') }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
-    role_arn: '{{ iam_role.arn }}'
+    role_arn: '{{ iam_role.iam_role.arn }}'
     wait: true
   register: eks_create
 

--- a/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
@@ -4,7 +4,7 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: fake_cluster
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
@@ -38,10 +38,10 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     wait: True
-    launch_template: 
+    launch_template:
       id: 'lt-0824c69cafa69ac81'
     disk_size: 30
   register: eks_nodegroup_result
@@ -60,18 +60,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 3
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'test'
     taints:
       - key: 'env'
@@ -98,18 +98,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 3
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'test'
     taints:
       - key: 'env'
@@ -135,18 +135,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 3
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'test'
     taints:
       - key: 'env'
@@ -173,18 +173,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 3
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'test'
     taints:
       - key: 'env'
@@ -214,7 +214,7 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     wait: True
     disk_size: 40
@@ -231,7 +231,7 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     wait: True
     instance_types: ['t3.small']
@@ -251,18 +251,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 4
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'changeit'
     taints:
       - key: 'env'
@@ -289,18 +289,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 4
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'changeit'
     taints:
       - key: 'env'
@@ -326,18 +326,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 4
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'changeit'
     taints:
       - key: 'env'
@@ -364,18 +364,18 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     scaling_config:
       min_size: 1
       max_size: 4
       desired_size: 2
-    disk_size: 30    
+    disk_size: 30
     instance_types: ['t3.small']
     ami_type: 'AL2_x86_64'
     update_config:
       max_unavailable_percentage: 50
-    labels: 
+    labels:
       'env': 'changeit'
     taints:
       - key: 'env'
@@ -405,7 +405,7 @@
     name: '{{ eks_nodegroup_name_a }}'
     state: absent
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
   register: eks_nodegroup_result
   check_mode: True
 
@@ -459,7 +459,7 @@
     name: '{{ eks_nodegroup_name_lt }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     launch_template:
       name: '{{ lt.template.launch_template_name }}'
@@ -477,7 +477,7 @@
     name: '{{ eks_nodegroup_name_lt }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     launch_template:
       name: '{{ lt.template.launch_template_name }}'
@@ -494,7 +494,7 @@
     name: '{{ eks_nodegroup_name_lt }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     launch_template:
       name: '{{ lt.template.launch_template_name }}'
@@ -512,7 +512,7 @@
     name: '{{ eks_nodegroup_name_lt }}'
     state: present
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     launch_template:
       name: '{{ lt.template.launch_template_name }}'
@@ -533,7 +533,7 @@
     name: '{{ eks_nodegroup_name_lt }}'
     state: absent
     cluster_name: '{{ eks_cluster_name }}'
-    node_role: '{{ iam_role_eks_nodegroup.arn }}'
+    node_role: '{{ iam_role_eks_nodegroup.iam_role.arn }}'
     wait: True
   register: eks_nodegroup_result
   check_mode: True


### PR DESCRIPTION
##### SUMMARY

iam_role moved all of the return values under <output>.iam_role, rather than returning a tangled mess at the top level

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration/targets/config/tasks/main.yaml
tests/integration/targets/ec2_launch_template/tasks/iam_instance_role.yml
tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
tests/integration/targets/eks_cluster/tasks/full_test.yml
tests/integration/targets/eks_fargate_profile/tasks/create_eks_cluster.yml
tests/integration/targets/eks_fargate_profile/tasks/full_test.yml
tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
tests/integration/targets/eks_nodegroup/tasks/full_test.yml

##### ADDITIONAL INFORMATION