### PR TITLE
Remove use of ignored boto3 parameter

### DIFF
--- a/changelogs/fragments/boto3_equals.yml
+++ b/changelogs/fragments/boto3_equals.yml
@@ -1,0 +1,3 @@
+trivial:
+- glue_connection - stop passing ``boto3`` into ``get_ec2_security_group_ids_from_names()`` it is no longer used.
+- autoscaling_launch_config - stop passing ``boto3`` into ``get_ec2_security_group_ids_from_names()`` it is no longer used.

--- a/plugins/modules/autoscaling_launch_config.py
+++ b/plugins/modules/autoscaling_launch_config.py
@@ -533,7 +533,7 @@ def create_launch_config(connection, module):
         module.fail_json_aws(e, msg="Failed to connect to AWS")
     try:
         security_groups = get_ec2_security_group_ids_from_names(
-            module.params.get("security_groups"), ec2_connection, vpc_id=vpc_id, boto3=True
+            module.params.get("security_groups"), ec2_connection, vpc_id=vpc_id
         )
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to get Security Group IDs")

--- a/plugins/modules/glue_connection.py
+++ b/plugins/modules/glue_connection.py
@@ -299,7 +299,7 @@ def create_or_update_glue_connection(connection, connection_ec2, module, glue_co
     if module.params.get("security_groups") is not None:
         # Get security group IDs from names
         security_group_ids = get_ec2_security_group_ids_from_names(
-            module.params.get("security_groups"), connection_ec2, boto3=True
+            module.params.get("security_groups"), connection_ec2
         )
         params["ConnectionInput"]["PhysicalConnectionRequirements"]["SecurityGroupIdList"] = security_group_ids
     if module.params.get("subnet_id") is not None:


### PR DESCRIPTION
##### SUMMARY

get_ec2_security_group_ids_from_names() has ignored the boto3 parameter since release 4.0.0, drop the use.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/glue_connection.py
plugins/modules/autoscaling_launch_config.py

##### ADDITIONAL INFORMATION