### PR TITLE
Add tag support to ec2_placement_group

### DIFF
--- a/changelogs/fragments/20240613_ec2_placement_group_tags.yml
+++ b/changelogs/fragments/20240613_ec2_placement_group_tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_placement_group - Added support for creating with ``tags`` (https://github.com/ansible-collections/community.aws/pull/2081).

--- a/plugins/modules/ec2_placement_group_info.py
+++ b/plugins/modules/ec2_placement_group_info.py
@@ -67,6 +67,14 @@ placement_groups:
       description: PG strategy
       type: str
       sample: "cluster"
+    tags:
+      description: Tags associated with the placement group
+      type: dict
+      version_added: 8.1.0
+      sample:
+        tags:
+          some: value1
+          other: value2
 """
 
 try:
@@ -74,6 +82,8 @@ try:
     from botocore.exceptions import ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 
@@ -102,6 +112,7 @@ def get_placement_groups_details(connection, module):
                 "name": placement_group["GroupName"],
                 "state": placement_group["State"],
                 "strategy": placement_group["Strategy"],
+                "tags": boto3_tag_list_to_ansible_dict(placement_group.get("Tags")),
             }
         )
     return results

--- a/tests/integration/targets/ec2_placement_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_placement_group/tasks/main.yml
@@ -241,6 +241,105 @@
           - pg_3_create_check_mode_idem.placement_group.state == "available"
           - '"ec2:CreatePlacementGroup" not in pg_3_create_check_mode_idem.resource_actions'
 
+    - name: Create a placement group 4 with tags - check_mode
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: present
+        strategy: cluster
+        tags:
+          foo: test1
+          bar: test2
+      check_mode: true
+      register: pg_4_create_check_mode
+
+    - assert:
+        that:
+          - pg_4_create_check_mode is changed
+          - pg_4_create_check_mode.placement_group.name == resource_prefix ~ '-pg4'
+          - pg_4_create_check_mode.placement_group.state == "DryRun"
+          - pg_4_create_check_mode.placement_group.tags.foo == "test1"
+          - pg_4_create_check_mode.placement_group.tags.bar == "test2"
+          - '"ec2:CreatePlacementGroup" in pg_4_create_check_mode.resource_actions'
+
+    - name: Create a placement group 4 with tags
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: present
+        strategy: cluster
+        tags:
+          foo: test1
+          bar: test2
+      register: pg_4_create
+
+    - assert:
+        that:
+          - pg_4_create is changed
+          - pg_4_create.placement_group.name == resource_prefix ~ '-pg4'
+          - pg_4_create.placement_group.state == "available"
+          - pg_4_create.placement_group.tags.foo == "test1"
+          - pg_4_create.placement_group.tags.bar == "test2"
+          - '"ec2:CreatePlacementGroup" in pg_4_create.resource_actions'
+
+    - set_fact:
+        placement_group_names: "{{ placement_group_names + [pg_4_create.placement_group.name] }}"
+
+    - name: Gather information about placement group 4
+      community.aws.ec2_placement_group_info:
+        names:
+          - '{{ resource_prefix }}-pg4'
+      register: pg_4_info_result
+
+    - assert:
+        that:
+          - pg_4_info_result is not changed
+          - pg_4_info_result.placement_groups[0].name == resource_prefix ~ '-pg4'
+          - pg_4_info_result.placement_groups[0].state == "available"
+          - pg_4_info_result.placement_groups[0].strategy == "cluster"
+          - pg_4_info_result.placement_groups[0].tags.foo == "test1"
+          - pg_4_info_result.placement_groups[0].tags.bar == "test2"
+          - '"ec2:DescribePlacementGroups" in pg_4_info_result.resource_actions'
+
+    - name: Create a placement group 4 with tags - Idempotency
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: present
+        strategy: cluster
+        tags:
+          foo: test1
+          bar: test2
+      register: pg_4_create
+
+    - assert:
+        that:
+          - pg_4_create is not changed
+          - pg_4_create.placement_group.name == resource_prefix ~ '-pg4'
+          - pg_4_create.placement_group.state == "available"
+          - pg_4_create.placement_group.strategy == "cluster"
+          - pg_4_create.placement_group.tags.foo == "test1"
+          - pg_4_create.placement_group.tags.bar == "test2"
+          - '"ec2:CreatePlacementGroup" not in pg_4_create.resource_actions'
+
+    - name: Create a placement group 4 with tags - check_mode Idempotency
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: present
+        strategy: cluster
+        tags:
+          foo: test1
+          bar: test2
+      check_mode: true
+      register: pg_4_create_check_mode_idem
+
+    - assert:
+        that:
+          - pg_4_create_check_mode_idem is not changed
+          - pg_4_create_check_mode_idem.placement_group.name == resource_prefix ~ '-pg4'
+          - pg_4_create_check_mode_idem.placement_group.state == "available"
+          - pg_4_create_check_mode_idem.placement_group.strategy == "cluster"
+          - pg_4_create_check_mode_idem.placement_group.tags.foo == "test1"
+          - pg_4_create_check_mode_idem.placement_group.tags.bar == "test2"
+          - '"ec2:CreatePlacementGroup" not in pg_4_create_check_mode_idem.resource_actions'
+
     - name: List all placement groups.
       community.aws.ec2_placement_group_info:
       register: all_ec2_placement_groups
@@ -396,6 +495,56 @@
         that:
           - pg_3_delete_check_mode_idem is not changed
           - '"ec2:DeletePlacementGroup" not in pg_3_delete_check_mode_idem.resource_actions'
+
+    - name: Delete a placement group 4 - check_mode
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: absent
+      check_mode: true
+      register: pg_4_delete_check_mode
+      ignore_errors: true
+
+    - assert:
+        that:
+          - pg_4_delete_check_mode is not changed
+          - pg_4_delete_check_mode.error.code == 'DryRunOperation'
+          - '"ec2:DeletePlacementGroup" in pg_4_delete_check_mode.resource_actions'
+
+
+    - name: Delete a placement group 4
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: absent
+      register: pg_4_delete
+
+    - assert:
+        that:
+          - pg_4_delete is changed
+          - '"ec2:DeletePlacementGroup" in pg_4_delete.resource_actions'
+
+    - name: Delete a placement group 4 - Idempotency
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: absent
+      register: pg_4_delete
+
+    - assert:
+        that:
+          - pg_4_delete is not changed
+          - '"ec2:DeletePlacementGroup" not in pg_4_delete.resource_actions'
+
+    - name: Delete a placement group 4 - check_mode Idempotency
+      community.aws.ec2_placement_group:
+        name: '{{ resource_prefix }}-pg4'
+        state: absent
+      check_mode: true
+      register: pg_4_delete_check_mode_idem
+      ignore_errors: true
+
+    - assert:
+        that:
+          - pg_4_delete_check_mode_idem is not changed
+          - '"ec2:DeletePlacementGroup" not in pg_4_delete_check_mode_idem.resource_actions'
 
   always:
 


### PR DESCRIPTION
##### SUMMARY
Allows users to optionally create EC2 placement groups with tags. Extend integration suite with additional test cases.

##### ISSUE TYPE
- Feature Pull Request
