### PR TITLE
acm_certificate_info: Document IAM actions required

### DIFF
--- a/plugins/modules/acm_certificate_info.py
+++ b/plugins/modules/acm_certificate_info.py
@@ -13,6 +13,7 @@ description:
   - Note that this will not return information about uploaded keys of size 4096 bits, due to a limitation of the ACM API.
   - Prior to release 5.0.0 this module was called C(community.aws.aws_acm_info).
     The usage did not change.
+  - Requires the IAM permissions 'acm:ListCertificates', 'acm:DescribeCertificate', 'acm:GetCertificate', 'acm:ListTagsForCertificate'
 options:
   certificate_arn:
     description:


### PR DESCRIPTION
##### SUMMARY

This change documents the IAM actions required in order to use the `community.aws.acm_certificate_info` module

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

community.aws.acm_certificate_info

##### ADDITIONAL INFORMATION

I've not done much with documentation in the past, is this the best place to add this?