### PR TITLE
Fix access_key, token missing issue

### DIFF
--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -804,13 +804,14 @@ class Connection(ConnectionBase):
         aws_session_token = self.get_option("session_token")
 
         session_args = dict(
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token,
             region_name=region_name,
         )
         if profile_name:
             session_args["profile_name"] = profile_name
+        else:
+            session_args["aws_access_key_id"] = aws_access_key_id,
+            session_args["aws_secret_access_key"] = aws_secret_access_key,
+            session_args["aws_session_token"] = aws_session_token,
         session = boto3.session.Session(**session_args)
 
         client = session.client(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix #2088 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible_collections.community.aws.plugins.connection.aws_ssm.Connection._get_boto_client

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If you set the `access_key` first and then set the `profile,` the `acces_key` and token will be overwritten by the profile value instead of being applied. Therefore, only set the `acces_key` and `token` if you are not using the `profile.`
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
aws_access_key_id = self.get_option("access_key_id")
        aws_secret_access_key = self.get_option("secret_access_key")
        aws_session_token = self.get_option("session_token")

        session_args = dict(
            aws_access_key_id=aws_access_key_id,
            aws_secret_access_key=aws_secret_access_key,
            aws_session_token=aws_session_token,
            region_name=region_name,
        )
        if profile_name:
            session_args["profile_name"] = profile_name
        session = boto3.session.Session(**session_args)
============================================
aws_access_key_id = self.get_option("access_key_id")
        aws_secret_access_key = self.get_option("secret_access_key")
        aws_session_token = self.get_option("session_token")

        session_args = dict(
            region_name=region_name,
        )
        if profile_name:
            session_args["profile_name"] = profile_name
        else:
            session_args["aws_access_key_id"]=aws_access_key_id,
            session_args["aws_secret_access_key"]=aws_secret_access_key,
            session_args["aws_session_token"]=aws_session_token,
```
