### PR TITLE
fix error in module iam_server_certificate for _compare_cert

### DIFF
--- a/plugins/modules/iam_server_certificate.py
+++ b/plugins/modules/iam_server_certificate.py
@@ -137,12 +137,8 @@ def _compare_cert(cert_a, cert_b):
     # Trim out the whitespace before comparing the certs.  While this could mean
     # an invalid cert 'matches' a valid cert, that's better than some stray
     # whitespace breaking things
-    cert_a.replace("\r", "")
-    cert_a.replace("\n", "")
-    cert_a.replace(" ", "")
-    cert_b.replace("\r", "")
-    cert_b.replace("\n", "")
-    cert_b.replace(" ", "")
+    cert_a = cert_a.replace("\r", "").replace("\n", "").replace(" ", "")
+    cert_b = cert_b.replace("\r", "").replace("\n", "").replace(" ", "")
 
     return cert_a == cert_b
 


### PR DESCRIPTION
##### SUMMARY
While using the module `iam_server_certificate`, I discovered that the module does not properly compare an existing certificate with the passed value.  This happens because the `str.replace` method does not replace the variable in-place, but returns the string after replacement.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iam_server_certificate

##### ADDITIONAL INFORMATION
To reproduce the error, run the module or include it in a playbook.  Assuming the module's arguments remain the same, the first run of the playbook will succeed.  The second run will fail with the message "Modifying the certificate body is not supported by AWS".  The expected result should be a success, not changed.