### PR TITLE
Add Support for Updating in iam_server_certificate by Deleting and Creating

### DIFF
--- a/plugins/modules/iam_server_certificate.py
+++ b/plugins/modules/iam_server_certificate.py
@@ -11,6 +11,9 @@ version_added: 1.0.0
 short_description: Manage IAM server certificates for use on ELBs and CloudFront
 description:
   - Allows for the management of IAM server certificates.
+  - If a certificate already exists matching the name, but the certificate or chain is different,
+    the certificate will be deleted and recreated.  This will result in the same
+    I(ServerCertificateName) and I(Arn), but the I(ServerCertificateId) may be different.
 options:
   name:
     description:
@@ -144,23 +147,23 @@ def _compare_cert(cert_a, cert_b):
 
 
 def update_server_certificate(current_cert):
-    changed = False
+    need_update = False
     cert = module.params.get("cert")
     cert_chain = module.params.get("cert_chain")
 
     if not _compare_cert(cert, current_cert.get("certificate_body", None)):
-        module.fail_json(msg="Modifying the certificate body is not supported by AWS")
+        need_update = True
     if not _compare_cert(cert_chain, current_cert.get("certificate_chain", None)):
-        module.fail_json(msg="Modifying the chaining certificate is not supported by AWS")
-    # We can't compare keys.
+        need_update = True
 
     if module.check_mode:
-        return changed
+        return need_update
 
-    # For now we can't make any changes.  Updates to tagging would go here and
-    # update 'changed'
+    if need_update:
+        return delete_server_certificate(current_cert) and \
+            create_server_certificate()
 
-    return changed
+    return False
 
 
 def create_server_certificate():

--- a/plugins/modules/iam_server_certificate.py
+++ b/plugins/modules/iam_server_certificate.py
@@ -137,12 +137,8 @@ def _compare_cert(cert_a, cert_b):
     # Trim out the whitespace before comparing the certs.  While this could mean
     # an invalid cert 'matches' a valid cert, that's better than some stray
     # whitespace breaking things
-    cert_a.replace("\r", "")
-    cert_a.replace("\n", "")
-    cert_a.replace(" ", "")
-    cert_b.replace("\r", "")
-    cert_b.replace("\n", "")
-    cert_b.replace(" ", "")
+    cert_a = cert_a.replace("\r", "").replace("\n", "").replace(" ", "")
+    cert_b = cert_b.replace("\r", "").replace("\n", "").replace(" ", "")
 
     return cert_a == cert_b
 


### PR DESCRIPTION
##### SUMMARY
_This PR relies on #2104 fixing the certificate comparison. Please merge #2104 first._

Previously, changes to the certificate would fail because the module does not support modifications.  This change allows for updates by deleting the existing certificate before creating it again.  While AWS does not support updating the certificate in-place, it can be supported by delete and replace.

Because this addresses a previously failed scenario, I don't believe this will break any existing usage.  The newly created certificate will have the same name and ARN as the previous certificate, meaning it can continue to be referenced the same.  The AWS-assigned random ID number will change, but this value is returned in the result from the module so that any downstream usage of the ID will necessarily have a different value and will update accordingly.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iam_server_certificate
