### PR TITLE
s3_logging add bucket policy as default access method to target bucket

### DIFF
--- a/changelogs/fragments/2108-s3-logging-access-with-policy-by-default.yml
+++ b/changelogs/fragments/2108-s3-logging-access-with-policy-by-default.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - s3_logging - target bucket access method is changed from ACL to bucket policy. If plays require the old behavior, the action will need to specify ``target_access: acl`` (https://github.com/ansible-collections/community.aws/pull/2108)

--- a/tests/integration/targets/s3_logging/defaults/main.yml
+++ b/tests/integration/targets/s3_logging/defaults/main.yml
@@ -2,3 +2,4 @@
 test_bucket: '{{ tiny_prefix }}-s3-logging'
 log_bucket_1: '{{ tiny_prefix }}-logs-1'
 log_bucket_2: '{{ tiny_prefix }}-logs-2'
+log_bucket_3: '{{ tiny_prefix }}-logs-3'

--- a/tests/integration/targets/s3_logging/tasks/main.yml
+++ b/tests/integration/targets/s3_logging/tasks/main.yml
@@ -46,7 +46,6 @@
     s3_bucket:
       state: present
       name: '{{ log_bucket_1 }}'
-      object_ownership: BucketOwnerPreferred
     register: output
   - assert:
       that:
@@ -57,12 +56,22 @@
     s3_bucket:
       state: present
       name: '{{ log_bucket_2 }}'
-      object_ownership: BucketOwnerPreferred
     register: output
   - assert:
       that:
       - output is changed
       - output.name == log_bucket_2
+
+  - name: Create simple s3_bucket as third target for logs
+    s3_bucket:
+      state: present
+      name: '{{ log_bucket_3 }}'
+      object_ownership: BucketOwnerPreferred
+    register: output
+  - assert:
+      that:
+      - output is changed
+      - output.name == log_bucket_3
 
 # ============================================================
 
@@ -151,6 +160,76 @@
   - assert:
       that:
       - result is not changed
+
+# ============================================================
+
+  - name: ACL logging bucket (check_mode)
+    s3_logging:
+      state: present
+      name: '{{ test_bucket }}'
+      target_bucket: '{{ log_bucket_3 }}'
+      target_access: acl
+    register: result
+    check_mode: True
+  - assert:
+      that:
+      - result is changed
+
+  - name: ACL logging bucket
+    s3_logging:
+      state: present
+      name: '{{ test_bucket }}'
+      target_bucket: '{{ log_bucket_3 }}'
+      target_access: acl
+    register: result
+  - assert:
+      that:
+      - result is changed
+
+  - name: ACL logging bucket idempotency (check_mode)
+    s3_logging:
+      state: present
+      name: '{{ test_bucket }}'
+      target_bucket: '{{ log_bucket_3 }}'
+      target_access: acl
+    register: result
+    check_mode: True
+  - assert:
+      that:
+      - result is not changed
+
+  - name: ACL logging bucket idempotency
+    s3_logging:
+      state: present
+      name: '{{ test_bucket }}'
+      target_bucket: '{{ log_bucket_3 }}'
+      target_access: acl
+    register: result
+  - assert:
+      that:
+      - result is not changed
+
+  - name: ACL logging bucket convert to policy
+    s3_logging:
+      state: present
+      name: '{{ test_bucket }}'
+      target_bucket: '{{ log_bucket_3 }}'
+      target_access: policy
+    register: result
+  - assert:
+      that:
+      - result is changed
+
+  - name: policy logging bucket convert to ACL
+    s3_logging:
+      state: present
+      name: '{{ test_bucket }}'
+      target_bucket: '{{ log_bucket_3 }}'
+      target_access: acl
+    register: result
+  - assert:
+      that:
+      - result is changed
 
 # ============================================================
 


### PR DESCRIPTION
##### SUMMARY

S3 ACL is disabled by default and AWS documentation encourages using policies.
This change adds policy as the default option and allows switching between ACL and policy.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
s3_logging

##### ADDITIONAL INFORMATION
The module modifies target bucket policy.
Reference:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html#object-ownership-setting
> A majority of modern use cases in Amazon S3 no longer require the use of ACLs, and we recommend that you keep ACLs disabled except in unusual circumstances where you must control access for each object individually. With ACLs disabled, you can use policies to more easily control access to every object in your bucket, regardless of who uploaded the objects in your bucket.