### PR TITLE
Update eks_nodegroup test to use t3a.micro

### DIFF
--- a/tests/integration/targets/eks_nodegroup/aliases
+++ b/tests/integration/targets/eks_nodegroup/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+time=55m

--- a/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/dependecies.yml
@@ -97,14 +97,8 @@
 - name: create instance template
   ec2_launch_template:
     name: "{{ resource_prefix }}-simple"
-    instance_type: t3.nano
-  register: lt_default
-
-- name: update simple instance template
-  ec2_launch_template:
-    name: "{{ resource_prefix }}-simple"
     default_version: 1
-    instance_type: t3.micro
+    instance_type: t3a.micro
   register: lt
 
 - name: Create securitygroup for node access

--- a/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
@@ -84,7 +84,7 @@
       ec2_ssh_key: "{{ ec2_key_eks_nodegroup.key.name }}"
       source_sg:
         - "{{ securitygroup_eks_nodegroup.group_id }}"
-    wait: True
+    wait: False
   register: eks_nodegroup_result
   check_mode: True
 
@@ -464,7 +464,7 @@
     subnets: '{{ setup_subnets.results | map(attribute=''subnet.id'') }}'
     launch_template:
       name: '{{ lt.template.launch_template_name }}'
-    wait: True
+    wait: False
   register: eks_nodegroup_result
   check_mode: True
 

--- a/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/full_test.yml
@@ -123,6 +123,7 @@
       source_sg:
         - "{{ securitygroup_eks_nodegroup.group_id }}"
     wait: True
+    wait_timeout: 1500
   register: eks_nodegroup_result
 
 - name: check that eks_nodegroup is created

--- a/tests/integration/targets/eks_nodegroup/tasks/main.yml
+++ b/tests/integration/targets/eks_nodegroup/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: 'eks_nodegroup integration tests'
   collections:
     - amazon.aws
-    - amozon.community
+    - amazon.community
   module_defaults:
     group/aws:
       access_key: '{{ aws_access_key }}'


### PR DESCRIPTION
##### SUMMARY

t3.micro's been having capacity issues, bump the eks_nodegroup integration tests over to t3a.micro which seems to be doing better.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

eks_nodegroup

##### ADDITIONAL INFORMATION
