### PR TITLE
ecs_taskdefinition: use `aws_retry` to avoid throttling exception

### DIFF
--- a/plugins/modules/ecs_taskdefinition.py
+++ b/plugins/modules/ecs_taskdefinition.py
@@ -929,7 +929,7 @@ class EcsTaskManager:
         return list(
             sorted(
                 [
-                    self.ecs.describe_task_definition(taskDefinition=arn)["taskDefinition"]
+                    self.ecs.describe_task_definition(aws_retry=True, taskDefinition=arn)["taskDefinition"]
                     for arn in data["taskDefinitionArns"]
                 ],
                 key=lambda td: td["revision"],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.aws/issues/2123 by adding `aws_retry=True` to the API calls.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_taskdefinition

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
We observed that `ecs_taskdefinition` intermittently causes a `ThrottlingException` when running on a task definition with a large number of revisions. Looking at the code, it appears that `describe_task_definitions` loops over the revisions without using the retry mechanism. This PR attempts to solve the problem by adding `aws_retry=True` to the API calls.

Due to the nature of the problem (intermittent throttling by AWS), I couldn't devise automated tests that validate the fix.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
