### PR TITLE
ec2_vpc_vgw - fix call to parent static method in class VGWRetry

### DIFF
--- a/changelogs/fragments/20240909-ec2_vpc_vgw-fix-super-exception.yaml
+++ b/changelogs/fragments/20240909-ec2_vpc_vgw-fix-super-exception.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_vpc_vgw - Fix call to parent static method in class ``VGWRetry`` (https://github.com/ansible-collections/community.aws/pull/2140).

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -170,7 +170,7 @@ class VGWRetry(AWSRetry):
             response_code = (response_code,)
 
         for code in response_code:
-            if super().found(response_code, catch_extra_error_codes):
+            if super(VGWRetry, VGWRetry).found(response_code, catch_extra_error_codes):
                 return True
 
         return False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When trying to create a VPN virtual gateway with a non-existent VPC id, module fails incorrectly with the following error 

```
\\"/tmp/ansible_community.aws.ec2_vpc_vgw_payload_t4kolii1/ansible_community.aws.ec2_vpc_vgw_payload.zip/ansible_collections/community/aws/plugins/modules/ec2_vpc_vgw.py\\", line 173, in found\\nTypeError: super(type, obj): obj must be an instance or subtype of type
```
The fix consists in adding argument to `super()`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
``ec2_vpc_vgw``
