### PR TITLE
elb_network_lb: Update tests to use valid cert

### DIFF
--- a/changelogs/fragments/2142-elb_network_lb-update-tests-to-use-valid-cert.yml
+++ b/changelogs/fragments/2142-elb_network_lb-update-tests-to-use-valid-cert.yml
@@ -1,2 +1,2 @@
-minor_changes:
+trivial:
   - elb_network_lb - Update tests to use valid cert RSA 3072-bit instead of 4096 (https://github.com/ansible-collections/community.aws/pull/2142).

--- a/changelogs/fragments/2142-elb_network_lb-update-tests-to-use-valid-cert.yml
+++ b/changelogs/fragments/2142-elb_network_lb-update-tests-to-use-valid-cert.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - elb_network_lb - Update tests to use valid cert RSA 3072-bit instead of 4096 (https://github.com/ansible-collections/community.aws/pull/2142).

--- a/tests/integration/targets/elb_network_lb/tasks/generate-certs.yml
+++ b/tests/integration/targets/elb_network_lb/tasks/generate-certs.yml
@@ -4,7 +4,7 @@
 - name: 'Generate SSL Keys'
   community.crypto.openssl_privatekey:
     path: '{{ remote_tmp_dir }}/{{ item }}-key.pem'
-    size: 4096
+    size: 3072
   loop:
   - 'ca'
   - 'cert1'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The tests for network load balancers use an invalid cert: https://github.com/ansible-collections/community.aws/blob/d79e817ea7b6dbfaedd11b809c21df9ef4cdee51/tests/integration/targets/elb_network_lb/tasks/generate-certs.yml#L7. 
As per AWS documentation Network load balancers only support RSA certs with up to 3072 bit keys.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elb_network_lb
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#tls-listener-certificates
```
Supported key algorithms
RSA 1024-bit
RSA 2048-bit
RSA 3072-bit
ECDSA 256-bit
ECDSA 384-bit
ECDSA 521-bit
```
related to https://github.com/mattclay/aws-terminator/issues/309
