### PR TITLE
Rename ec2_vpc_peer module to ec2_vpc_peering

### DIFF
--- a/changelogs/fragments/20240919-ec2_vpc_peer-rename.yml
+++ b/changelogs/fragments/20240919-ec2_vpc_peer-rename.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+ - ec2_vpc_peer - the ``ec2_vpc_peer`` module has been renamed to ``ec2_vpc_peering``.
+   The usage of the module has not changed. The ec2_vpc_peer alias will be removed in version 11.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2058).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -118,6 +118,7 @@ action_groups:
     - ec2_vpc_nacl
     - ec2_vpc_nacl_info
     - ec2_vpc_peer
+    - ec2_vpc_peering
     - ec2_vpc_peering_info
     - ec2_vpc_vgw
     - ec2_vpc_vgw_info
@@ -521,5 +522,12 @@ plugin_routing:
     sts_assume_role:
       redirect: amazon.aws.sts_assume_role
   module_utils:
+    ec2_vpc_peer:
+      redirect: amazon.aws.ec2_vpc_peer
+      deprecation:
+        removal_version: 11.0.0
+        warning_text: >-
+          ec2_vpc_peer has been renamed to ec2_vpc_peering.
+          Please update your tasks.
     route53:
       redirect: amazon.aws.route53

--- a/plugins/modules/ec2_vpc_peering.py
+++ b/plugins/modules/ec2_vpc_peering.py
@@ -5,7 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = r"""
-module: ec2_vpc_peer
+module: ec2_vpc_peering
 short_description: create, delete, accept, and reject VPC peering connections between two VPCs.
 version_added: 1.0.0
 description:
@@ -64,7 +64,7 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # Complete example to create and accept a local peering connection.
 - name: Create local account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-87654321
@@ -76,7 +76,7 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: Accept local VPC peering request
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     peering_id: "{{ vpc_peer.peering_id }}"
     state: accept
@@ -84,7 +84,7 @@ EXAMPLES = r"""
 
 # Complete example to delete a local peering connection.
 - name: Create local account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-87654321
@@ -96,7 +96,7 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: delete a local VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     peering_id: "{{ vpc_peer.peering_id }}"
     state: absent
@@ -104,7 +104,7 @@ EXAMPLES = r"""
 
   # Complete example to create and accept a cross account peering connection.
 - name: Create cross account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-12345678
@@ -117,7 +117,7 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: Accept peering connection from remote account
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     peering_id: "{{ vpc_peer.peering_id }}"
     profile: bot03_profile_for_cross_account
@@ -126,7 +126,7 @@ EXAMPLES = r"""
 
 # Complete example to create and accept an intra-region peering connection.
 - name: Create intra-region VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: us-east-1
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-87654321
@@ -139,7 +139,7 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: Accept peering connection from peer region
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: us-west-2
     peering_id: "{{ vpc_peer.peering_id }}"
     state: accept
@@ -147,7 +147,7 @@ EXAMPLES = r"""
 
 # Complete example to create and reject a local peering connection.
 - name: Create local account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-87654321
@@ -159,14 +159,14 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: Reject a local VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     peering_id: "{{ vpc_peer.peering_id }}"
     state: reject
 
 # Complete example to create and accept a cross account peering connection.
 - name: Create cross account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-12345678
@@ -179,7 +179,7 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: Accept a cross account VPC peering connection request
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     peering_id: "{{ vpc_peer.peering_id }}"
     profile: bot03_profile_for_cross_account
@@ -191,7 +191,7 @@ EXAMPLES = r"""
 
 # Complete example to create and reject a cross account peering connection.
 - name: Create cross account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-12345678
@@ -204,7 +204,7 @@ EXAMPLES = r"""
   register: vpc_peer
 
 - name: Reject a cross account VPC peering Connection
-  community.aws.ec2_vpc_peer:
+  community.aws.ec2_vpc_peering:
     region: ap-southeast-2
     peering_id: "{{ vpc_peer.peering_id }}"
     profile: bot03_profile_for_cross_account

--- a/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_peer/tasks/main.yml
@@ -66,7 +66,7 @@
       connection_name: 'Peering connection for VPC {{ vpc_1 }} to VPC {{ vpc_2 }}'
 
   - name: Create local account VPC peering Connection request
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       vpc_id: '{{ vpc_1 }}'
       peer_vpc_id: '{{ vpc_2 }}'
       state: present
@@ -88,7 +88,7 @@
       peer_id_1: '{{ vpc_peer.peering_id }}'
 
   - name: (re-) Create local account VPC peering Connection request (idempotency)
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       vpc_id: '{{ vpc_1 }}'
       peer_vpc_id: '{{ vpc_2 }}'
       state: present
@@ -104,7 +104,7 @@
         - vpc_peer.peering_id == peer_id_1
 
   - name: (re-) Create local account VPC peering Connection request with accepter/requester reversed (idempotency)
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       vpc_id: '{{ vpc_2 }}'
       peer_vpc_id: '{{ vpc_1 }}'
       state: present
@@ -211,7 +211,7 @@
       requester_details: '{{ peer_details["requester_vpc_info"] }}'
 
   - name: Update tags on the VPC Peering Connection
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       vpc_id: '{{ vpc_1 }}'
       peer_vpc_id: '{{ vpc_2 }}'
       state: present
@@ -227,7 +227,7 @@
         - tag_peer.peering_id == peer_id_1
 
   - name: (re-) Update tags on the VPC Peering Connection (idempotency)
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       vpc_id: '{{ vpc_1 }}'
       peer_vpc_id: '{{ vpc_2 }}'
       state: present
@@ -260,7 +260,7 @@
       peer_details: '{{ peer_info.vpc_peering_connections[0] }}'
 
   - name: Accept local VPC peering request
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer.peering_id }}"
       state: accept
       wait: True
@@ -332,7 +332,7 @@
       requester_details: '{{ peer_details["requester_vpc_info"] }}'
 
   - name: (re-) Accept local VPC peering request (idempotency)
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer.peering_id }}"
       state: accept
     register: action_peer
@@ -345,7 +345,7 @@
         - action_peer.vpc_peering_connection.vpc_peering_connection_id == peer_id_1
 
   - name: delete a local VPC peering Connection
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer.peering_id }}"
       state: absent
     register: delete_peer
@@ -406,7 +406,7 @@
       requester_details: '{{ peer_details["requester_vpc_info"] }}'
 
   - name: (re-) delete a local VPC peering Connection (idempotency)
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer.peering_id }}"
       state: absent
     register: delete_peer
@@ -417,7 +417,7 @@
         - delete_peer is successful
 
   - name: Create local account VPC peering Connection
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       vpc_id: '{{ vpc_1 }}'
       peer_vpc_id: '{{ vpc_2 }}'
       state: present
@@ -437,7 +437,7 @@
       peer_id_2: '{{ vpc_peer2.peering_id }}'
 
   - name: reject a local VPC peering Connection
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer2.peering_id }}"
       state: reject
       wait: True
@@ -450,7 +450,7 @@
         - reject_peer.peering_id == peer_id_2
 
   - name: (re-) reject a local VPC peering Connection
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer2.peering_id }}"
       state: reject
     register: reject_peer
@@ -463,7 +463,7 @@
         - reject_peer.vpc_peering_connection.vpc_peering_connection_id == peer_id_2
 
   - name: delete a local VPC peering Connection
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ vpc_peer2.peering_id }}"
       state: absent
     register: delete_peer
@@ -493,7 +493,7 @@
     # ============================================================
 
   - name: Delete remaining Peering connections
-    ec2_vpc_peer:
+    ec2_vpc_peering:
       peering_id: "{{ item }}"
       state: absent
     ignore_errors: True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rename ec2_vpc_peer module to ec2_vpc_peering to be consistent with the ec2_vpc_peering_info module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_peer

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
