### PR TITLE
Fix sanity errors happening with the ansible devel branch

### DIFF
--- a/changelogs/fragments/20240919-fix_sanity.yml
+++ b/changelogs/fragments/20240919-fix_sanity.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Fix sanity errors happening with the ansible devel branch (e.g., unreachable code, using variable before assignment)."

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -420,6 +420,7 @@ def ensure_vgw_absent(client, module):
     changed = False
     params = dict()
     result = dict()
+    deleted_vgw = None
     params["Name"] = module.params.get("name")
     params["VpcId"] = module.params.get("vpc_id")
     params["Type"] = module.params.get("type")

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -339,7 +339,7 @@ def main():
     elif module.params["state"] == "has_instances":
         if not existing:
             module.fail_json(msg="Cluster '" + module.params["name"] + " not found.")
-            return
+
         # it exists, so we should delete it and mark changed.
         # return info about the cluster deleted
         delay = module.params["delay"]
@@ -361,7 +361,6 @@ def main():
                 + str(delay)
                 + " seconds each."
             )
-            return
 
     module.exit_json(**results)
 

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -1248,7 +1248,7 @@ def main():
     elif module.params["state"] == "deleting":
         if not existing:
             module.fail_json(msg="Service '" + module.params["name"] + " not found.")
-            return
+
         # it exists, so we should delete it and mark changed.
         # return info about the cluster deleted
         delay = module.params["delay"]
@@ -1263,7 +1263,6 @@ def main():
             time.sleep(delay)
         if i is repeat - 1:
             module.fail_json(msg=f"Service still not deleted after {repeat} tries of {delay} seconds each.")
-            return
 
     module.exit_json(**results)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix sanity errors happening with the ansible devel branch
```
ERROR: Found 5 pylint issue(s) which need to be resolved:
ERROR: plugins/modules/ec2_vpc_vgw.py:504:13: used-before-assignment: Using variable 'deleted_vgw' before assignment
ERROR: plugins/modules/ecs_cluster.py:342:12: unreachable: Unreachable code
ERROR: plugins/modules/ecs_cluster.py:364:12: unreachable: Unreachable code
ERROR: plugins/modules/ecs_service.py:1251:12: unreachable: Unreachable code
ERROR: plugins/modules/ecs_service.py:1266:12: unreachable: Unreachable code
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
