### PR TITLE
opensearch - Remove CurrentState attribute

### DIFF
--- a/plugins/module_utils/opensearch.py
+++ b/plugins/module_utils/opensearch.py
@@ -63,6 +63,10 @@ def get_domain_config(client, module, domain_name):
         for k in response["DomainConfig"]:
             if "Options" in response["DomainConfig"][k]:
                 domain_config[k] = response["DomainConfig"][k]["Options"]
+                # describe_domain_config method returns both CurrentState and DesiredState
+                # while update_domain_config only expects DesiredState
+                if k == "AIMLOptions" and "CurrentState" in domain_config[k]:
+                    del domain_config[k]["AIMLOptions"]["CurrentState"]
         domain_config["DomainName"] = domain_name
         # If ES cluster is attached to the Internet, the "VPCOptions" property is not present.
         if "VPCOptions" in domain_config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is necessary because [`describe_domain_config`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/opensearch/client/describe_domain_config.html) method returns both `CurrentState` and `DesiredState` while [`update_domain_config`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/opensearch/client/update_domain_config.html) method only expects `DesiredState`.

Fixes #2161.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
opensearch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
