### PR TITLE
DNM - Migrate ec2_vpc_egress_igw* modules and tests

### DIFF
--- a/changelogs/fragments/migrate_ec2_vpc_egress_igw.yml
+++ b/changelogs/fragments/migrate_ec2_vpc_egress_igw.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - ec2_vpc_egress_igw - The module has been migrated from the ``community.aws`` collection.
+    Playbooks using the Fully Qualified Collection Name for this module should be
+    updated to use ``amazon.aws.ec2_vpc_egress_igw`` (https://api.github.com/repos/ansible-collections/community.aws/pulls/2168).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -114,7 +114,6 @@ action_groups:
     - ec2_transit_gateway_info
     - ec2_transit_gateway_vpc_attachment
     - ec2_transit_gateway_vpc_attachment_info
-    - ec2_vpc_egress_igw
     - ec2_vpc_nacl
     - ec2_vpc_nacl_info
     - ec2_vpc_peer
@@ -520,6 +519,8 @@ plugin_routing:
       redirect: amazon.aws.s3_bucket_info
     sts_assume_role:
       redirect: amazon.aws.sts_assume_role
+    ec2_vpc_egress_igw:
+      redirect: amazon.aws.ec2_vpc_egress_igw
   module_utils:
     route53:
       redirect: amazon.aws.route53


### PR DESCRIPTION
- Remove modules ec2_vpc_egress_igw modules and tests
  These modules have been migrated to `amazon.aws`
- Update runtime.yml with redirects to that collection
- Update ignore files
