### PR TITLE
Add Github workflow that adds backport_failed label when automatic backports fail.

### DIFF
--- a/.github/workflows/backports-check.yml
+++ b/.github/workflows/backports-check.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   check_patchback_comment:
-    if: >
-      ${{ github.event.pull_request.merged }} == true &&
-      github.event.comment.user.login == 'patchback' &&
+    if: ${{
+      github.event.issue.pull_request.merged_at &&
+      github.event.comment.user.login == 'patchback[bot]' &&
       contains(github.event.comment.body, '💔 cherry-picking failed')
+      }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/backports-check.yml
+++ b/.github/workflows/backports-check.yml
@@ -1,0 +1,22 @@
+---
+name: Check Patchback Comment on Edit
+
+on:
+  issue_comment:
+    types:
+      - edited
+
+jobs:
+  check_patchback_comment:
+    if: >
+      ${{ github.event.pull_request.merged }} == true &&
+      github.event.comment.user.login == 'patchback' &&
+      contains(github.event.comment.body, '💔 cherry-picking failed')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add Label for Backport Failure
+        run: |
+          gh pr edit ${{ github.event.issue.number }} -R ${{ github.repository }} --add-label 'backport_failed'
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add Github workflow that adds backport_failed label when automatic backports fail.
This will help keep track of any failed backported PRs that require manual actions to be taken.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
