### PR TITLE
Integration tests Connection SSM

### DIFF
--- a/tests/integration/targets/connection/test_connection.yml
+++ b/tests/integration/targets/connection/test_connection.yml
@@ -13,6 +13,7 @@
 
   - wait_for_connection:
       timeout: '{{ wait_for_timeout | default(100) }}'
+      sleep: 10
 
   ### Try to gather the default facts from the host
 

--- a/tests/integration/targets/connection_aws_ssm_amazon/aliases
+++ b/tests/integration/targets/connection_aws_ssm_amazon/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=20m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_amazon/aws_ssm_integration_test_setup.yml
+++ b/tests/integration/targets/connection_aws_ssm_amazon/aws_ssm_integration_test_setup.yml
@@ -3,3 +3,4 @@
     - role: ../setup_connection_aws_ssm
       vars:
         target_os: amazon
+        os_python_path: "/usr/local/bin/python3.11"

--- a/tests/integration/targets/connection_aws_ssm_amazon/runme.sh
+++ b/tests/integration/targets/connection_aws_ssm_amazon/runme.sh
@@ -28,4 +28,5 @@ cd ../connection
 # Execute Integration tests
 INVENTORY="${PLAYBOOK_DIR}/ssm_inventory" ./test.sh \
     -e target_hosts=aws_ssm \
+    -e wait_for_timeout=1200 \
     "$@"

--- a/tests/integration/targets/connection_aws_ssm_centos/aliases
+++ b/tests/integration/targets/connection_aws_ssm_centos/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_cross_region/aliases
+++ b/tests/integration/targets/connection_aws_ssm_cross_region/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_encrypted_s3/aliases
+++ b/tests/integration/targets/connection_aws_ssm_encrypted_s3/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_endpoint/aliases
+++ b/tests/integration/targets/connection_aws_ssm_endpoint/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_profile/aliases
+++ b/tests/integration/targets/connection_aws_ssm_profile/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_ssm_document/aliases
+++ b/tests/integration/targets/connection_aws_ssm_ssm_document/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_ubuntu/aliases
+++ b/tests/integration/targets/connection_aws_ssm_ubuntu/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_vars/aliases
+++ b/tests/integration/targets/connection_aws_ssm_vars/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/connection_aws_ssm_windows/aliases
+++ b/tests/integration/targets/connection_aws_ssm_windows/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=12m
 
 cloud/aws
 connection_aws_ssm

--- a/tests/integration/targets/setup_connection_aws_ssm/defaults/main.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/defaults/main.yml
@@ -15,7 +15,7 @@ ami_details:
         name: 'CentOS Stream 9 x86_64*'
         user_data: |
             #!/bin/sh
-            sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+            sudo dnf install -y python3 https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
             sudo systemctl start amazon-ssm-agent
         os_type: linux
     amazon:
@@ -24,8 +24,17 @@ ami_details:
         # name: amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2
         user_data: |
             #!/bin/sh
+            # Install Python3.11
+            yum -y groupinstall "Development Tools"
+            yum -y install gcc devel libffi-devel openssl11-1.1.1g openssl11-libs-1.1.1g openssl11-devel-1.1.1g wget
+            wget https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz
+            tar zxvf Python-3.11.9.tgz
+            cd Python-3.11.9/
+            ./configure --enable-optimizations
+            make -j4
+            make altinstall -j4
             # Pre-Installed just needs started
-            sudo systemctl start amazon-ssm-agent
+            systemctl start amazon-ssm-agent
         os_type: linux
     ubuntu:
         ssm_parameter: /aws/service/canonical/ubuntu/server-minimal/jammy/stable/current/amd64/hvm/ebs-gp2/ami-id
@@ -53,3 +62,8 @@ ami_details:
 s3_bucket_name: "{{ tiny_prefix }}-connection-ssm-{{ test_suffix | default(target_os) }}"
 kms_key_name: "{{ resource_prefix }}-connection-ssm"
 ssm_document_name: "{{ resource_prefix }}-connection-ssm"
+ec2_infra_vpc_name: "{{ resource_prefix }}-vpc"
+ec2_infra_vpc_cidr_block: '172.10.0.0/16'
+ec2_infra_public_subnet_cidr_block: '172.10.1.0/24'
+ec2_infra_private_subnet_cidr_block: '172.10.3.0/24'
+ec2_infra_security_group_name: "{{ resource_prefix }}-sg"

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/cleanup.yml
@@ -54,22 +54,25 @@
         instance_ids: "{{ created_instance_ids }}"
         state: absent
         wait: True
-      ignore_errors: yes
+      ignore_errors: true
       when: ec2_vars_file.stat.exists == true
+
+    - name: Delete EC2 infrastructure
+      include_tasks: 'ec2_infra_teardown.yml'
 
     - name: Delete S3 bucket
       include_tasks: 'delete_bucket.yml'
       loop:
         - "{{ bucket_name }}"
       when: s3_vars_file.stat.exists == true
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Delete IAM role
       iam_role:
         name: "{{ iam_role_name }}"
         state: absent
         delete_instance_profile: True
-      ignore_errors: yes
+      ignore_errors: true
       when: iam_role_vars_file.stat.exists == true
 
     - name: Delete the KMS key
@@ -80,10 +83,10 @@
     - name: Delete SSM document
       command: "aws ssm delete-document --name {{ ssm_document_name }}"
       environment: "{{ connection_env }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Delete AWS keys environement
       file:
         path: "{{ playbook_dir }}/aws-env-vars.sh"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/debian.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/debian.yml
@@ -1,6 +1,12 @@
+- name: Display architecture
+  ansible.builtin.debug:
+    var: ansible_architecture
+- name: Set download link
+  ansible.builtin.set_fact:
+    ssm_plugin_url: "{{ (ansible_architecture in ['aarch64', 'arm64']) | ternary('ubuntu_arm64', 'ubuntu_64bit') }}"
 - name: Download SSM plugin
   get_url:
-    url: https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb
+    url: 'https://s3.amazonaws.com/session-manager-downloads/plugin/latest/{{ ssm_plugin_url }}/session-manager-plugin.deb'
     dest: /tmp/session-manager-plugin.deb
     mode: '0440'
   tags: setup_infra

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/ec2_infra_setup.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/ec2_infra_setup.yml
@@ -1,0 +1,94 @@
+---
+- name: Create a VPC to work in
+  amazon.aws.ec2_vpc_net:
+    cidr_block: "{{ ec2_infra_vpc_cidr_block }}"
+    name: "{{ ec2_infra_vpc_name }}"
+    dns_support: true
+    dns_hostnames: true
+  register: vpc
+
+- name: Create internet gateway attached to the VPC
+  amazon.aws.ec2_vpc_igw:
+    vpc_id: "{{ vpc.vpc.id }}"
+    state: present
+  register: internet_gw
+
+- name: Create public subnet
+  amazon.aws.ec2_vpc_subnet:
+    vpc_id: "{{ vpc.vpc.id }}"
+    cidr: "{{ ec2_infra_public_subnet_cidr_block }}"
+    map_public: true
+    az: "{{ aws_region }}a"
+  register: public_subnet
+
+- name: Create private subnet
+  amazon.aws.ec2_vpc_subnet:
+    vpc_id: "{{ vpc.vpc.id }}"
+    cidr: "{{ ec2_infra_private_subnet_cidr_block }}"
+    map_public: true
+    az: "{{ aws_region }}a"
+  register: private_subnet
+
+- name: Set fact for private subnet
+  ansible.builtin.set_fact:
+    private_subnet_id: "{{ private_subnet.subnet.id }}"
+
+- name: Allocate Elastic IP
+  amazon.aws.ec2_eip:
+    state: present
+    release_on_disassociation: true
+  register: allocate_eip
+
+- name: Create NAT gateway on public subnet
+  amazon.aws.ec2_vpc_nat_gateway:
+    state: present
+    subnet_id: "{{ public_subnet.subnet.id }}"
+    allocation_id: "{{ allocate_eip.allocation_id }}"
+    if_exist_do_not_create: true
+    wait: true
+    wait_timeout: 600
+  register: natgateway
+
+- name: Create Route table for public subnet
+  amazon.aws.ec2_vpc_route_table:
+    vpc_id: "{{ vpc.vpc.id }}"
+    subnets:
+      - "{{ public_subnet.subnet.id }}"
+    routes:
+      - dest: 0.0.0.0/0
+        gateway_id: "{{ internet_gw.gateway_id }}"
+    lookup: tag
+    resource_tags:
+      subnet: public
+      route: internet
+    state: present
+
+- name: Create Route table for private subnet
+  amazon.aws.ec2_vpc_route_table:
+    vpc_id: "{{ vpc.vpc.id }}"
+    subnets:
+      - "{{ private_subnet.subnet.id }}"
+    routes:
+      - dest: 0.0.0.0/0
+        gateway_id: "{{ natgateway.nat_gateway_id }}"
+    lookup: tag
+    resource_tags:
+      subnet: private
+      route: gateway
+    state: present
+
+- name: Create security group
+  amazon.aws.ec2_security_group:
+    name: "{{ ec2_infra_security_group_name }}"
+    vpc_id: "{{ vpc.vpc.id }}"
+    description: VPC security group
+    rules:
+      - cidr_ip: 0.0.0.0/0
+        proto: tcp
+        from_port: 22
+        to_port: 22
+    rules_egress:
+      - cidr_ip: 0.0.0.0/0
+        proto: -1
+    state: present
+  register: secgroup

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/ec2_infra_teardown.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/ec2_infra_teardown.yml
@@ -1,0 +1,86 @@
+---
+- name: Get VPC information
+  amazon.aws.ec2_vpc_net_info:
+    filters:
+      cidr: "{{ ec2_infra_vpc_cidr_block }}"
+      "tag:Name": "{{ ec2_infra_vpc_name }}"
+  register: vpc_info
+
+- name: Delete VPC resources
+  when: vpc_info.vpcs | length == 1
+  block:
+    - name: Set variable for vpc id
+      ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_info.vpcs.0.vpc_id }}"
+    
+    - name: Delete resource group attached to the VPC
+      amazon.aws.ec2_security_group:
+        name: "{{ ec2_infra_security_group_name }}"
+        vpc_id: "{{ vpc_id }}"
+        state: absent
+    
+    - name: List subnets attached to the VPC
+      amazon.aws.ec2_vpc_subnet_info:
+        filters:
+          vpc-id: "{{ vpc_id }}"
+      register: vpc_subnets
+
+    - name: List route tables attached to the VPC
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          vpc-id: "{{ vpc_id }}"
+      register: route_tables
+
+    - name: Delete route tables
+      amazon.aws.ec2_vpc_route_table:
+        route_table_id: "{{ item.id }}"
+        lookup: id
+        state: absent
+      ignore_errors: true
+      with_items: "{{ route_tables.route_tables }}"
+
+    - name: List NAT gateway
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          vpc-id: "{{ vpc_id }}"
+          state: ['available', 'pending']
+      register: nat_gateways
+
+    - name: Delete nat gateway
+      amazon.aws.ec2_vpc_nat_gateway:
+        state: absent
+        nat_gateway_id: "{{ item.nat_gateway_id }}"
+        wait: true
+        wait_timeout: 600
+      ignore_errors: true
+      with_items: "{{ nat_gateways.result }}"
+
+    - name: List Elastic IP
+      amazon.aws.ec2_eip_info:
+        filters:
+          "tag:ResourcePrefix": "{{ resource_prefix }}"
+      register: eips
+
+    - name: Delete Elastic IP
+      amazon.aws.ec2_eip:
+        public_ip: "{{ item.public_ip }}"
+        state: absent
+      with_items: "{{ eips.addresses }}"
+
+    - name: Delete internet gateway
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc_id }}"
+        state: absent
+
+    - name: Delete subnets
+      amazon.aws.ec2_vpc_subnet:
+        state: absent
+        wait: true
+        vpc_id: "{{ vpc_id }}"
+        cidr: "{{ item.cidr_block }}"
+      with_items: "{{ vpc_subnets.subnets }}"
+
+    - name: Delete VPC
+      amazon.aws.ec2_vpc_net:
+        state: absent
+        vpc_id: "{{ vpc_id }}"

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/macos.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/macos.yml
@@ -1,0 +1,30 @@
+---
+- name: Display architecture
+  ansible.builtin.debug:
+    var: ansible_architecture
+
+- name: Set download link
+  ansible.builtin.set_fact:
+    ssm_plugin_url: "{{ (ansible_architecture in ['aarch64', 'arm64']) | ternary('mac_arm64', 'mac') }}"
+
+- name: Download SSM plugin (x86_64 architecture)
+  get_url:
+    url: https://s3.amazonaws.com/session-manager-downloads/plugin/latest/{{ ssm_plugin_url }}/sessionmanager-bundle.zip
+    dest: /tmp/sessionmanager-bundle.zip
+    mode: '0440'
+  tags: setup_infra
+
+- name: Unzip the package
+  ansible.builtin.unarchive:
+    dest: /tmp/
+    src: /tmp/sessionmanager-bundle.zip
+  tags: setup_infra
+
+- name: Run the install command
+  become: true
+  ansible.builtin.shell: >-
+    /tmp/sessionmanager-bundle/install -i /usr/local/sessionmanagerplugin -b /usr/local/bin/session-manager-plugin
+
+- name: Check the SSM Plugin
+  ansible.builtin.shell: /usr/local/sessionmanagerplugin/bin/session-manager-plugin --version
+  tags: setup_infra

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/main.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/main.yml
@@ -12,14 +12,14 @@
   block:
 
     - name: get ARN of calling user
-      aws_caller_info:
+      amazon.aws.aws_caller_info:
       register: aws_caller_info
 
     - name: setup connection argments fact
-      include_tasks: 'connection_args.yml'
+      ansible.builtin.include_tasks: 'connection_args.yml'
 
     - name: Ensure IAM instance role exists
-      iam_role:
+      amazon.aws.iam_role:
         name: "ansible-test-{{tiny_prefix}}-aws-ssm-role"
         assume_role_policy_document: "{{ lookup('file','ec2-trust-policy.json') }}"
         state: present
@@ -30,11 +30,11 @@
       register: role_output
 
     - name: Lookup AMI configuration
-      set_fact:
+      ansible.builtin.set_fact:
         ami_configuration: '{{ ami_details[(target_os | default("fedora"))] }}'
 
     - name: AMI Lookup (ami_info)
-      ec2_ami_info:
+      amazon.aws.ec2_ami_info:
         owners: '{{ ami_configuration.owner | default("amazon") }}'
         filters:
           name: '{{ ami_configuration.name }}'
@@ -46,110 +46,121 @@
       when:
         - ami_configuration.ssm_parameter | default(False)
       block:
-        - set_fact:
-            ssm_amis: "{{ lookup('aws_ssm', ami_configuration.ssm_parameter, **connection_args) }}"
+        - ansible.builtin.set_fact:
+            ssm_amis: "{{ lookup('amazon.aws.ssm_parameter', ami_configuration.ssm_parameter, **connection_args) }}"
 
     - name: Set facts with latest AMIs
       vars:
         latest_ami: '{{ ec2_amis.images | default([]) | sort(attribute="creation_date") | last }}'
-      set_fact:
+      ansible.builtin.set_fact:
         latest_ami_id: '{{ ssm_amis | default(latest_ami.image_id) }}'
 
     # (Local installation of the SSM **client** which is then used by the plugin)
     - name: Install Session Manager Client for Debian/Ubuntu
-      include_tasks: debian.yml
+      ansible.builtin.include_tasks: debian.yml
       when: ansible_distribution in ["Ubuntu", "Debian"]
       register: install_plugin_debian
 
     - name: Install Session Manager Client for RedHat/Amazon
-      include_tasks: redhat.yml
+      ansible.builtin.include_tasks: redhat.yml
       when: ansible_distribution in ["CentOS", "RedHat", "Amazon", "Fedora"]
       register: install_plugin_redhat
 
+    - name: Install Session Manager Client for MacOS
+      ansible.builtin.include_tasks: macos.yml
+      when: ansible_distribution in ["MacOSX"]
+      register: install_plugin_macos
+
     - block:
         - name: Fail if the plugin was not installed
-          fail:
+          ansible.builtin.fail:
             msg: The distribution does not contain the required Session Manager Plugin
           when:
             - install_plugin_debian is skipped
             - install_plugin_redhat is skipped
+            - install_plugin_macos is skipped
       always:
         - debug:
             var: ansible_distribution
 
+    # Setup EC2 infrastructure
+    - name: Create EC2 infrastructure
+      ansible.builtin.include_tasks: 'ec2_infra_setup.yml'
+
     - name: Create EC2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         instance_type: "{{ instance_type }}"
         ebs_optimized: True
         image_id: "{{ latest_ami_id }}"
-        wait: "yes"
+        wait: true
         instance_role: "{{ role_output.iam_role.role_name }}"
         name: "{{ resource_prefix }}-connection-aws-ssm"
         user_data: "{{ ami_configuration.user_data }}"
-        state: running
+        state: started
+        subnet_id: "{{ private_subnet_id }}"
         tags:
           TestPrefix: '{{ resource_prefix }}'
       register: instance_output
 
     - name: setup SSM document
-      include_tasks: 'ssm_document.yml'
+      ansible.builtin.include_tasks: 'ssm_document.yml'
       when:
         - use_ssm_document | default(False)
 
     - name: Create S3 bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ s3_bucket_name }}"
         region: "{{ s3_bucket_region | default(omit)}}"
       register: s3_output
 
     - name: setup encryption
-      include_tasks: 'encryption.yml'
+      ansible.builtin.include_tasks: 'encryption.yml'
       when:
         - encrypted_bucket | default(False)
 
     - name: Create Inventory file
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/ssm_inventory"
         src: inventory-combined.aws_ssm.j2
 
     - name: Create AWS Keys Environement
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/aws-env-vars.sh"
         src: aws-env-vars.j2
-      no_log: yes
+      no_log: true
 
     - name: Create out boto3 config file'
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/boto3_config"
         src: "boto_config.j2"
 
   always:
     - name: Create EC2 Linux vars_to_delete.yml
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/instance_vars_to_delete.yml"
         src: ec2_instance_vars_to_delete.yml.j2
-      ignore_errors: yes
+      ignore_errors: true
       when:
         - instance_output is successful
 
     - name: Create IAM Role vars_to_delete.yml
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/iam_role_vars_to_delete.yml"
         src: iam_role_vars_to_delete.yml.j2
       when:
         - role_output is successful
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Create S3.yml
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/s3_vars_to_delete.yml"
         src: s3_vars_to_delete.yml.j2
       when:
         - s3_output is successful
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Create SSM vars_to_delete.yml
-      template:
+      ansible.builtin.template:
         dest: "{{ playbook_dir }}/ssm_vars_to_delete.yml"
         src: ssm_vars_to_delete.yml.j2
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/redhat.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/redhat.yml
@@ -1,6 +1,12 @@
+- name: Display architecture
+  ansible.builtin.debug:
+    var: ansible_architecture
+- name: Set download link
+  ansible.builtin.set_fact:
+    ssm_plugin_url: "{{ (ansible_architecture in ['aarch64', 'arm64']) | ternary('linux_arm64', 'linux_64bit') }}"
 - name: Download SSM plugin
   get_url:
-    url: https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm
+    url: https://s3.amazonaws.com/session-manager-downloads/plugin/latest/{{ ssm_plugin_url }}/session-manager-plugin.rpm
     dest: /tmp/session-manager-plugin.rpm
     mode: '0440'
   tags: setup_infra

--- a/tests/integration/targets/setup_connection_aws_ssm/tasks/ssm_document.yml
+++ b/tests/integration/targets/setup_connection_aws_ssm/tasks/ssm_document.yml
@@ -8,4 +8,4 @@
       template:
         dest: "{{ playbook_dir }}/ssm_vars_to_delete.yml"
         src: ssm_vars_to_delete.yml.j2
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/setup_connection_aws_ssm/templates/inventory-combined.aws_ssm.j2
+++ b/tests/integration/targets/setup_connection_aws_ssm/templates/inventory-combined.aws_ssm.j2
@@ -29,7 +29,7 @@ aws_ssm_windows
 [aws_ssm:vars]
 ansible_connection=community.aws.aws_ssm
 ansible_aws_ssm_plugin=/usr/local/sessionmanagerplugin/bin/session-manager-plugin
-ansible_python_interpreter=/usr/bin/env python3
+ansible_python_interpreter={{ os_python_path | default('/usr/bin/python3') }}
 local_tmp=/tmp/ansible-local-{{ tiny_prefix }}
 ansible_aws_ssm_bucket_name={{ s3_bucket_name }}
 {% if s3_addressing_style | default(False) %}

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -10,16 +10,6 @@ from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.six import string_types
 
-# Magic...  Incorrectly identified by pylint as unused
-# isort: off
-# pylint: disable=unused-import
-
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import fixture_maybe_sleep
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import fixture_placeboify
-
-# pylint: enable=unused-import
-# isort: on
-
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -10,6 +10,16 @@ from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.six import string_types
 
+# Magic...  Incorrectly identified by pylint as unused
+# isort: off
+# pylint: disable=unused-import
+
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import fixture_maybe_sleep
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import fixture_placeboify
+
+# pylint: enable=unused-import
+# isort: on
+
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue with connection_ssm* integration tests
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- The ec2 instance was deployed into the default subnet which does not always allow the SSM plugin to reach target. We now deploy a specific infrastructure with the required network configuration for the instance to be visible by the SSM plugin
- The latest AMI used for Amazon Linux has `python3.7` leading to the error `"ansible-core requires a minimum of Python version 3.8. Current version: 3.7.16 (default, Oct 30 2024, 20:44:12) [GCC 7.3.1 20180712 (Red Hat 7.3.1-17)]"`. The Python version has been upgraded with a compiled version on the host, this is a time-consuming operation, therefore the wait timeout has been increased for the `wait_for_connection` module.
- Update installation process on the ansible controller host depending on the architecture
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`CI`