### PR TITLE
Add generate_mark() function and corresponding unit test.

### DIFF
--- a/changelogs/fragments/2096-refactor-random-helper-function.yml
+++ b/changelogs/fragments/2096-refactor-random-helper-function.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssm - add function to generate random strings for SSM CLI delimitation (https://github.com/ansible-collections/community.aws/pull/2235).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -377,7 +377,7 @@ def chunks(lst, n):
     for i in range(0, len(lst), n):
         yield lst[i:i + n]  # fmt: skip
 
-    
+ 
 def filter_ansi(line: str, is_windows: bool) -> str:
     """Remove any ANSI terminal control codes.
 

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -704,7 +704,7 @@ class Connection(ConnectionBase):
         # see https://github.com/pylint-dev/pylint/issues/8909)
         return (returncode, stdout, self._flush_stderr(self._session))  # pylint: disable=unreachable
 
-    def generate_mark() -> str:
+    def generate_mark(self) -> str:
         """Generates a random string of characters to delimit SSM CLI commands"""
         mark = "".join([random.choice(string.ascii_letters) for i in range(Connection.MARK_LENGTH)])
         return mark

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -377,7 +377,7 @@ def chunks(lst, n):
     for i in range(0, len(lst), n):
         yield lst[i:i + n]  # fmt: skip
 
- 
+
 def filter_ansi(line: str, is_windows: bool) -> str:
     """Remove any ANSI terminal control codes.
 
@@ -704,12 +704,10 @@ class Connection(ConnectionBase):
         # see https://github.com/pylint-dev/pylint/issues/8909)
         return (returncode, stdout, self._flush_stderr(self._session))  # pylint: disable=unreachable
 
-
     def generate_mark() -> str:
         """Generates a random string of characters to delimit SSM CLI commands"""
         mark = "".join([random.choice(string.ascii_letters) for i in range(Connection.MARK_LENGTH)])
-        return(mark)
-
+        return mark
 
     @_ssm_retry
     def exec_command(self, cmd: str, in_data: bool = None, sudoable: bool = True) -> Tuple[int, str, str]:

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -704,7 +704,8 @@ class Connection(ConnectionBase):
         # see https://github.com/pylint-dev/pylint/issues/8909)
         return (returncode, stdout, self._flush_stderr(self._session))  # pylint: disable=unreachable
 
-    def generate_mark(self) -> str:
+    @staticmethod
+    def generate_mark() -> str:
         """Generates a random string of characters to delimit SSM CLI commands"""
         mark = "".join([random.choice(string.ascii_letters) for i in range(Connection.MARK_LENGTH)])
         return mark

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -10,6 +10,7 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+from ansible_collections.community.aws.plugins.connection.aws_ssm import Connection
 
 if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_data_pipeline.py requires the python modules 'boto3' and 'botocore'")
@@ -257,3 +258,12 @@ class TestConnectionBaseClass:
         conn._session_id.return_value = "a"
         conn._client = MagicMock()
         conn.close()
+
+    def test_generate_mark(self):
+        """Testing string generation"""
+        test_a = Connection.generate_mark()
+        test_b = Connection.generate_mark()
+
+        assert test_a != test_b
+        assert len(test_a) == Connection.MARK_LENGTH
+        assert len(test_b) == Connection.MARK_LENGTH

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -10,6 +10,7 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+
 from ansible_collections.community.aws.plugins.connection.aws_ssm import Connection
 
 if not HAS_BOTO3:
@@ -267,4 +268,3 @@ class TestConnectionBaseClass:
         assert test_a != test_b
         assert len(test_a) == Connection.MARK_LENGTH
         assert len(test_b) == Connection.MARK_LENGTH
-        

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -267,3 +267,4 @@ class TestConnectionBaseClass:
         assert test_a != test_b
         assert len(test_a) == Connection.MARK_LENGTH
         assert len(test_b) == Connection.MARK_LENGTH
+        


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I created a function inside of the Connection class to generate a random string to replace existing repetitive code. Since this functionality was only currently used in this particular class and still relies on the MARK_LENGTH variable, I did not pull it out as a separate/common utility.

This function generates a random string of characters based on a globally-defined MARK_LENGTH variable, which seem to be used to bookend SSM CLI input.

This existed in the previous iteration of this code, and I did not change it because I was not able to ascertain why 26 was chosen as the length in the first place, and I did not want to make a prescriptive decision around that. There is an existing unit test that calls "5" as the MARK_LENGTH, so I assume that would have worked as well, but did not want to make breaking changes to the existing unit test. This may be something for a future TODO if the team wants to clarify/standardize a length for this string.

I wrote a unit test for this and confirmed that it passes, though I mainly did that for my own benefit and practice, and don't believe that this function really required any unit testing given what it's doing.

Fixes #ACA-2096 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Function to generate a random string for AWS SSM CLI  delimiting.