### PR TITLE
disable redshift tests

### DIFF
--- a/tests/integration/targets/redshift/aliases
+++ b/tests/integration/targets/redshift/aliases
@@ -1,3 +1,6 @@
+# reason: broken
+# AWS no longer supports unencrypted Redshift clusters - tests need updating
+disabled
 time=35m
 cloud/aws
 redshift_info


### PR DESCRIPTION
##### SUMMARY

See also: https://github.com/ansible-collections/community.aws/issues/2237

Blocking https://github.com/ansible-collections/amazon.aws/pull/2517 because module_utils.botocore is triggering all the tests

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redshift

##### ADDITIONAL INFORMATION

