### PR TITLE
Add S3 lifecycle rule for cleaning up incomplete multipart uploads

### DIFF
--- a/plugins/modules/s3_lifecycle.py
+++ b/plugins/modules/s3_lifecycle.py
@@ -230,6 +230,14 @@ EXAMPLES = r"""
         storage_class: standard_ia
       - transition_days: 90
         storage_class: glacier
+
+- name: Configure cleanup policies to delete incomplete multipart uploads after 30 days
+  community.aws.s3_lifecycle:
+    name: mybucket
+    prefix: largefiles/
+    abort_incomplete_multipart_upload_days: 30
+    expire_object_delete_marker: true
+        
 """
 
 import datetime


### PR DESCRIPTION

##### SUMMARY
- Add lifecycle rule for mybucket/largefiles/ prefix
- Set 30-day cleanup policy for incomplete multipart uploads
- Helps prevent storage costs from abandoned uploads

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
  community.aws.s3_lifecycle:

