### PR TITLE
connection/aws_ssm - support environment variable for aws_ssm_plugin variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 # Created by https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 # Edit at https://www.gitignore.io/?templates=git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 tests/integration/inventory
+tests/integration/targets/connection_aws_ssm_*/boto3_config
+tests/integration/targets/connection_aws_ssm_*/iam_role_vars_to_delete.yml
+tests/integration/targets/connection_aws_ssm_*/instance_vars_to_delete.yml
+tests/integration/targets/connection_aws_ssm_*/s3_vars_to_delete.yml
+tests/integration/targets/connection_aws_ssm_*/ssm_inventory
+tests/integration/targets/connection_aws_ssm_*/ssm_vars_to_delete.yml
+
 ### dotenv ###
 .env
 

--- a/changelogs/fragments/20250217-connection-aws_ssm-add-env-variable-for-aws_ssm_plugin.yaml
+++ b/changelogs/fragments/20250217-connection-aws_ssm-add-env-variable-for-aws_ssm_plugin.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - connection/aws_ssm - Add the possibility to define ``aws_ssm_plugin`` variable via environment variable and by default use the version found on the $PATH
+    rather than require that you provide an absolute path (https://github.com/ansible-collections/community.aws/issues/1990).

--- a/tests/unit/plugins/connection/aws_ssm/test_get_executable.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_get_executable.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# While it may seem appropriate to import our custom fixtures here, the pytest_ansible pytest plugin
+# isn't as agressive as the ansible_test._util.target.pytest.plugins.ansible_pytest_collections plugin
+# when it comes to rewriting the import paths and as such we can't import fixtures via their
+# absolute import path or across collections.
+
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible.errors import AnsibleError
+
+
+@pytest.mark.parametrize("executable_path_exists", [True, False])
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.os")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.to_bytes")
+def test_get_executable_user_provided(m_to_bytes, m_os, connection_aws_ssm, executable_path_exists):
+    ssm_plugin = MagicMock()
+    connection_aws_ssm.get_option.return_value = ssm_plugin
+    b_ssm_plugin = MagicMock()
+    m_to_bytes.return_value = b_ssm_plugin
+    m_os.path = MagicMock()
+    m_os.path.exists = MagicMock()
+    m_os.path.exists.return_value = executable_path_exists
+
+    if executable_path_exists:
+        assert ssm_plugin == connection_aws_ssm.get_executable()
+    else:
+        with pytest.raises(AnsibleError) as exc_info:
+            connection_aws_ssm.get_executable()
+        assert str(exc_info.value) == f"failed to find the executable specified {ssm_plugin}."
+
+    connection_aws_ssm.get_option.assert_called_once_with("plugin")
+    m_to_bytes.assert_called_once_with(ssm_plugin, errors="surrogate_or_strict")
+    m_os.path.exists.assert_called_once_with(b_ssm_plugin)
+
+
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.get_bin_path")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.os")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.to_bytes")
+def test_get_executable_default_value_exists(m_to_bytes, m_os, m_get_bin_path, connection_aws_ssm):
+    connection_aws_ssm.get_option.return_value = None
+    b_ssm_plugin = MagicMock()
+    m_to_bytes.return_value = b_ssm_plugin
+    m_os.path = MagicMock()
+    m_os.path.exists = MagicMock()
+    m_os.path.exists.return_value = True
+
+    ssm_plugin_default = "/usr/local/bin/session-manager-plugin"
+
+    assert ssm_plugin_default == connection_aws_ssm.get_executable()
+
+    connection_aws_ssm.get_option.assert_called_once_with("plugin")
+    m_to_bytes.assert_called_once_with(ssm_plugin_default, errors="surrogate_or_strict")
+    m_os.path.exists.assert_called_once_with(b_ssm_plugin)
+    m_get_bin_path.assert_not_called()
+
+
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.get_bin_path")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.os")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.to_bytes")
+def test_get_executable_default_from_path(m_to_bytes, m_os, m_get_bin_path, connection_aws_ssm):
+    connection_aws_ssm.get_option.return_value = None
+    b_ssm_plugin = MagicMock()
+    m_to_bytes.return_value = b_ssm_plugin
+    m_os.path = MagicMock()
+    m_os.path.exists = MagicMock()
+    m_os.path.exists.return_value = False
+    ssm_plugin = MagicMock()
+    m_get_bin_path.return_value = ssm_plugin
+
+    ssm_plugin_default = "/usr/local/bin/session-manager-plugin"
+
+    assert ssm_plugin == connection_aws_ssm.get_executable()
+
+    connection_aws_ssm.get_option.assert_called_once_with("plugin")
+    m_to_bytes.assert_called_once_with(ssm_plugin_default, errors="surrogate_or_strict")
+    m_os.path.exists.assert_called_once_with(b_ssm_plugin)
+    m_get_bin_path.assert_called_once_with("session-manager-plugin")
+
+
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.get_bin_path")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.os")
+@patch("ansible_collections.community.aws.plugins.connection.aws_ssm.to_bytes")
+def test_get_executable_default_missing_from_path(m_to_bytes, m_os, m_get_bin_path, connection_aws_ssm):
+    connection_aws_ssm.get_option.return_value = None
+    b_ssm_plugin = MagicMock()
+    m_to_bytes.return_value = b_ssm_plugin
+    m_os.path = MagicMock()
+    m_os.path.exists = MagicMock()
+    m_os.path.exists.return_value = False
+    m_get_bin_path.side_effect = ValueError("executable missing from PATH")
+
+    ssm_plugin_default = "/usr/local/bin/session-manager-plugin"
+    with pytest.raises(AnsibleError) as exc_info:
+        connection_aws_ssm.get_executable()
+    assert str(exc_info.value) == "executable missing from PATH"
+
+    connection_aws_ssm.get_option.assert_called_once_with("plugin")
+    m_to_bytes.assert_called_once_with(ssm_plugin_default, errors="surrogate_or_strict")
+    m_os.path.exists.assert_called_once_with(b_ssm_plugin)
+    m_get_bin_path.assert_called_once_with("session-manager-plugin")

--- a/tests/unit/plugins/connection/aws_ssm/test_get_executable.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_get_executable.py
@@ -3,10 +3,6 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# While it may seem appropriate to import our custom fixtures here, the pytest_ansible pytest plugin
-# isn't as agressive as the ansible_test._util.target.pytest.plugins.ansible_pytest_collections plugin
-# when it comes to rewriting the import paths and as such we can't import fixtures via their
-# absolute import path or across collections.
 
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #1990 
- Add the possibility to define the `aws_ssm_plugin` variable using environment variable `AWS_SESSION_MANAGER_PLUGIN`
- To avoid breaking change, the default value of the `aws_ssm_plugin` will remains ``/usr/local/bin/session-manager-plugin``, in case the path is not found, the plugin will try to find the executable from the PATH
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
``connection/aws_ssm``