### PR TITLE
Refactor Some Command-Related Methods in `aws_ssm.py`

### DIFF
--- a/changelogs/fragments/2248-aws_ssm-refactor-command-related-methods.yml
+++ b/changelogs/fragments/2248-aws_ssm-refactor-command-related-methods.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_ssm - Refactor ``_exec_transport_commands``, ``_generate_commands``, and ``_exec_transport_commands`` methods for improved clarity (https://github.com/ansible-collections/community.aws/pull/2248).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -445,7 +445,7 @@ def filter_ansi(line: str, is_windows: bool) -> str:
 @dataclass
 class Command:
     """
-    Custom command dataclass for the generated command dictionaries.
+    Custom dataclass for the generated command dictionaries.
     """
 
     command: str

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -332,12 +332,12 @@ import select
 import string
 import subprocess
 import time
-from dataclasses import dataclass
 from typing import Dict
 from typing import List
 from typing import NoReturn
 from typing import Optional
 from typing import Tuple
+from typing import TypedDict
 
 try:
     import boto3
@@ -442,10 +442,9 @@ def filter_ansi(line: str, is_windows: bool) -> str:
     return line
 
 
-@dataclass
-class CommandResult:
+class CommandResult(TypedDict):
     """
-    Custom dataclass for the executed command results.
+    A dictionary that contains the executed command results.
     """
 
     returncode: int

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -444,6 +444,10 @@ def filter_ansi(line: str, is_windows: bool) -> str:
 
 @dataclass
 class Command:
+    """
+    Custom command dataclass for the generated command dictionaries.
+    """
+
     command: str
     method: str  # 'get' or 'put'
     headers: Dict[str, str]
@@ -451,6 +455,10 @@ class Command:
 
 @dataclass
 class CommandResult:
+    """
+    Custom dataclass for the executed command results.
+    """
+
     returncode: int
     stdout_combined: str
     stderr_combined: str

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -1017,6 +1017,7 @@ class Connection(ConnectionBase):
 
         :returns: List of Command dictionaries containing the command string and metadata.
         """
+
         put_args, put_headers = self._generate_encryption_settings()
         commands = []
 
@@ -1100,6 +1101,7 @@ class Connection(ConnectionBase):
 
         :returns: A CommandResult object containing the return code, stdout, and stderr in a tuple.
         """
+
         stdout_combined, stderr_combined = "", ""
         for command in commands:
             (returncode, stdout, stderr) = self.exec_command(command["command"], in_data=None, sudoable=False)

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -1082,10 +1082,19 @@ class Connection(ConnectionBase):
 
         return commands, put_args
 
-    def _exec_transport_commands(self, in_path, out_path, commands):
+    def _exec_transport_commands(self, in_path: str, out_path: str, commands: List[Command]) -> CommandResult:
+        """
+        Execute the provided transport commands.
+
+        :param in_path: The input path.
+        :param out_path: The output path.
+        :param commands: A list of command dictionaries containing the command string and metadata.
+
+        :returns: A CommandResult object containing the return code, stdout, and stderr in a tuple.
+        """
         stdout_combined, stderr_combined = "", ""
         for command in commands:
-            (returncode, stdout, stderr) = self.exec_command(command, in_data=None, sudoable=False)
+            (returncode, stdout, stderr) = self.exec_command(command["command"], in_data=None, sudoable=False)
 
             # Check the return code
             if returncode != 0:
@@ -1094,7 +1103,7 @@ class Connection(ConnectionBase):
             stdout_combined += stdout
             stderr_combined += stderr
 
-        return (returncode, stdout_combined, stderr_combined)
+        return CommandResult(returncode, stdout_combined, stderr_combined)
 
     @_ssm_retry
     def _file_transport_command(self, in_path, out_path, ssm_action):

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -1129,7 +1129,7 @@ class Connection(ConnectionBase):
 
         try:
             if ssm_action == "get":
-                put_commands, _ = self._generate_commands(
+                put_commands, put_args = self._generate_commands(
                     bucket_name,
                     s3_path,
                     in_path,

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -332,6 +332,8 @@ import select
 import string
 import subprocess
 import time
+from dataclasses import dataclass
+from typing import Dict
 from typing import NoReturn
 from typing import Optional
 from typing import Tuple
@@ -437,6 +439,20 @@ def filter_ansi(line: str, is_windows: bool) -> str:
             line = line[:-1]
 
     return line
+
+
+@dataclass
+class Command:
+    command: str
+    method: str  # 'get' or 'put'
+    headers: Dict[str, str]
+
+
+@dataclass
+class CommandResult:
+    returncode: int
+    stdout_combined: str
+    stderr_combined: str
 
 
 class Connection(ConnectionBase):

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -1,6 +1,5 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import sys
 from io import StringIO
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -285,11 +284,11 @@ class TestConnectionBaseClass:
         conn._s3_client = mock_s3_client
 
         test_command_generation = conn._generate_commands(
-                "test_bucket",
-                "test/s3/path",
-                "test/in/path",
-                "test/out/path",
-            )
+            "test_bucket",
+            "test/s3/path",
+            "test/in/path",
+            "test/out/path",
+        )
 
         # Check contents of generated command dictionaries
         if is_windows:

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -270,71 +270,45 @@ class TestConnectionBaseClass:
         assert len(test_a) == Connection.MARK_LENGTH
         assert len(test_b) == Connection.MARK_LENGTH
 
-    @pytest.mark.skipif(sys.platform == "win", reason="This test is only for non-Windows systems")
-    def test_generate_commands_non_windows(self):
-        """Testing command generation on non-Windows systems"""
+    @pytest.mark.parametrize("is_windows", [False, True])
+    def test_generate_commands(self, is_windows):
+        """Testing command generation on Windows systems"""
         pc = PlayContext()
         new_stdin = StringIO()
         conn = connection_loader.get("community.aws.aws_ssm", pc, new_stdin)
         conn.get_option = MagicMock()
 
-        mock_s3_client = MagicMock()
-        mock_s3_client.generate_presigned_url.return_value = "https://test-url"
-        conn._s3_client = mock_s3_client
-
-        test_command_generation = conn._generate_commands(
-            "test_bucket",
-            "test/s3/path",
-            "test/in/path",
-            "test/out/path",
-        )
-
-        # Ensure data types of command object are as expected
-        assert isinstance(test_command_generation, tuple)
-        assert isinstance(test_command_generation[0], list)
-        assert isinstance(test_command_generation[0][0], dict)
-
-        # Three command dictionaries are generated for non-Windows systems
-        assert len(test_command_generation[0]) == 3
-
-        # Check contents of command dictionaries
-        assert "command" in test_command_generation[0][0]
-        assert "method" in test_command_generation[0][2]
-        assert "headers" in test_command_generation[0][2]
-        assert "curl --request PUT -H" in test_command_generation[0][2]["command"]
-        assert test_command_generation[0][2]["method"] == "put"
-
-    @patch("ansible_collections.community.aws.plugins.connection.aws_ssm.Connection.is_windows")
-    def test_generate_commands_windows(self, mock_is_windows):
-        """Testing command generation on Windows systems"""
-        pc = PlayContext()
-        new_stdin = StringIO()
-        conn = connection_loader.get("community.aws.aws_ssm", pc, new_stdin)
-
-        mock_is_windows.return_value = True
+        conn.is_windows = is_windows
 
         mock_s3_client = MagicMock()
         mock_s3_client.generate_presigned_url.return_value = "https://test-url"
         conn._s3_client = mock_s3_client
 
         test_command_generation = conn._generate_commands(
-            "test_bucket",
-            "test/s3/path",
-            "test/in/path",
-            "test/out/path",
-        )
+                "test_bucket",
+                "test/s3/path",
+                "test/in/path",
+                "test/out/path",
+            )
+
+        # Check contents of generated command dictionaries
+        if is_windows:
+            assert "command" in test_command_generation[0][0]
+            assert "method" in test_command_generation[0][1]
+            assert "headers" in test_command_generation[0][1]
+            assert "Invoke-WebRequest" in test_command_generation[0][1]["command"]
+            assert test_command_generation[0][1]["method"] == "put"
+            # Two command dictionaries are generated for Windows
+            assert len(test_command_generation[0]) == 2
+        else:
+            assert "method" in test_command_generation[0][2]
+            assert "headers" in test_command_generation[0][2]
+            assert "curl --request PUT -H" in test_command_generation[0][2]["command"]
+            assert test_command_generation[0][2]["method"] == "put"
+            # Three command dictionaries are generated on non-Windows systems
+            assert len(test_command_generation[0]) == 3
 
         # Ensure data types of command object are as expected
         assert isinstance(test_command_generation, tuple)
         assert isinstance(test_command_generation[0], list)
         assert isinstance(test_command_generation[0][0], dict)
-
-        # Two command dictionaries are generated for Windows
-        assert len(test_command_generation[0]) == 2
-
-        # Check contents of command dictionaries
-        assert "command" in test_command_generation[0][0]
-        assert "method" in test_command_generation[0][1]
-        assert "headers" in test_command_generation[0][1]
-        assert "Invoke-WebRequest" in test_command_generation[0][1]["command"]
-        assert test_command_generation[0][1]["method"] == "put"

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -291,17 +291,16 @@ class TestConnectionBaseClass:
         )
 
         # Check contents of generated command dictionaries
+        assert "command" in test_command_generation[0][0]
+        assert "method" in test_command_generation[0][0]
+        assert "headers" in test_command_generation[0][0]
+
         if is_windows:
-            assert "command" in test_command_generation[0][0]
-            assert "method" in test_command_generation[0][1]
-            assert "headers" in test_command_generation[0][1]
             assert "Invoke-WebRequest" in test_command_generation[0][1]["command"]
             assert test_command_generation[0][1]["method"] == "put"
             # Two command dictionaries are generated for Windows
             assert len(test_command_generation[0]) == 2
         else:
-            assert "method" in test_command_generation[0][2]
-            assert "headers" in test_command_generation[0][2]
             assert "curl --request PUT -H" in test_command_generation[0][2]["command"]
             assert test_command_generation[0][2]["method"] == "put"
             # Three command dictionaries are generated on non-Windows systems


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This work is part of the currently ongoing [AWS SSM Connection Refactoring & Plugin Promotion](https://forum.ansible.com/t/aws-ssm-connection-refactoring-plugin-promotion/39930) effort and related to https://github.com/ansible-collections/amazon.aws/issues/2394.

Fixes [ACA-2095](https://issues.redhat.com/browse/ACA-2095)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### TASK LIST
<!--- Write the short name of the module, plugin, task or feature below -->

- [x] The [`_exec_transport_commands`](https://github.com/ansible-collections/community.aws/blob/f2bd35b1e5d9c333ae7f1d63f52ad97b6ad12466/plugins/connection/aws_ssm.py#L1011) method is refactored to accept a single structured object (a tuple containing lists of command dictionaries) that contains the necessary command data.
- [ ] ~~Create a custom dataclass to hold command output.~~
- [x] Create a ~~custom dataclass~~ `TypedDict` to hold command results.
- [x] The [`_generate_commands`](https://github.com/ansible-collections/community.aws/blob/7f0f9e0ebaf6a068fcad320bc41f3e45e952a84f/plugins/connection/aws_ssm.py#L956) function returns a list of typed dictionaries with clear metadata (command strings, method, headers).
- [x] [`_exec_transport_commands`](https://github.com/ansible-collections/community.aws/blob/7f0f9e0ebaf6a068fcad320bc41f3e45e952a84f/plugins/connection/aws_ssm.py#L1010) accepts a list of typed dictionaries as an argument and returns the custom `CommandResults` object.
- [x] Python type hints are added to the method signature and the structured object to improve readability, facilitate static analysis, and clearly define the expected structure and data types.
- [x] Docstrings should be added to any refactored methods and the structured object (if custom), clarifying the purpose, structure, inputs, outputs, and any edge cases or special handling (if applicable).
- [x] Unit tests have been created to ensure that the refactored [`_generate_commands`](https://github.com/ansible-collections/community.aws/blob/7f0f9e0ebaf6a068fcad320bc41f3e45e952a84f/plugins/connection/aws_ssm.py#L956) method outputs the expected structured command object.
- [x] Add a changelog file.
