### PR TITLE
support for redis7 group family for parameter groups

### DIFF
--- a/plugins/modules/elasticache_parameter_group.py
+++ b/plugins/modules/elasticache_parameter_group.py
@@ -20,7 +20,7 @@ options:
     description:
       - The name of the cache parameter group family that the cache parameter group can be used with.
         Required when creating a cache parameter group.
-    choices: ['memcached1.4', 'memcached1.5', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0', 'redis5.0', 'redis6.x']
+    choices: ['memcached1.4', 'memcached1.5', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0', 'redis5.0', 'redis6.x', 'redis7']
     type: str
   name:
     description:
@@ -301,6 +301,7 @@ def main():
                 "redis4.0",
                 "redis5.0",
                 "redis6.x",
+                "redis7"
             ],
         ),
         name=dict(required=True, type="str"),


### PR DESCRIPTION
SUMMARY
AWS cache parameters groups can now be of type redis7. This PR adds to the module elasticache_parameter_group support to pass this new family group.

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
Impacted component: elasticache_parameter_group module.