### PR TITLE
redshift_info: removes jijna delimiters from example using failed_when

### DIFF
--- a/plugins/modules/redshift_info.py
+++ b/plugins/modules/redshift_info.py
@@ -61,7 +61,7 @@ EXAMPLES = r"""
       env: stg
       stack: db
   register: redshift_user
-  failed_when: "{{ redshift_user.results | length == 0 }}"
+  failed_when: redshift_user.results | length == 0
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY

The current example includes extra jinja delimiters which
result in double-interpretation of the statement.

Fixes: #2297

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request

