### PR TITLE
Add `matrix_exclude` to skip `ansible-core` 2.16 and specific Python versions for sanity and unit tests

### DIFF
--- a/.github/workflows/all_green_ckeck.yml
+++ b/.github/workflows/all_green_ckeck.yml
@@ -22,33 +22,6 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   changelog-and-linters:
     uses: ./.github/workflows/changelog_and_linters.yml  # use the callable changelog_and_linters job to run tests
-    with:
-      matrix_exclude: >-
-          [
-            {
-              "ansible-version": "devel",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "milestone",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.19",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.18",
-              "python-version": "3.10"
-            },
-            {
-              "ansible-version": "stable-2.17",
-              "python-version": "3.13"
-            },
-            {
-              "ansible-version": "stable-2.16"
-            }
-          ]
   sanity:
     uses: ./.github/workflows/sanity.yml  # use the callable sanity job to run tests
   units:

--- a/.github/workflows/all_green_ckeck.yml
+++ b/.github/workflows/all_green_ckeck.yml
@@ -22,6 +22,33 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   changelog-and-linters:
     uses: ./.github/workflows/changelog_and_linters.yml  # use the callable changelog_and_linters job to run tests
+    with:
+      matrix_exclude: >-
+          [
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.16"
+            }
+          ]
   sanity:
     uses: ./.github/workflows/sanity.yml  # use the callable sanity job to run tests
   units:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -33,6 +33,6 @@ jobs:
               "ansible-version": "stable-2.16"
             }
           ]
-    with:
+    
       matrix_include: "[]"
       collection_pre_install: '-r source/tests/sanity/requirements.yml'

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -33,6 +33,5 @@ jobs:
               "ansible-version": "stable-2.16"
             }
           ]
-    
       matrix_include: "[]"
       collection_pre_install: '-r source/tests/sanity/requirements.yml'

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -7,5 +7,32 @@ jobs:
   sanity:
     uses: ansible-network/github_actions/.github/workflows/sanity.yml@main
     with:
+      matrix_exclude: >-
+          [
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.16"
+            }
+          ]
+    with:
       matrix_include: "[]"
       collection_pre_install: '-r source/tests/sanity/requirements.yml'

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -7,4 +7,30 @@ jobs:
   unit-source:
     uses: ansible-network/github_actions/.github/workflows/unit_source.yml@main
     with:
+      matrix_exclude: >-
+          [
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.19",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.16"
+            }
+          ]
       collection_pre_install: '-r source/tests/unit/requirements.yml'

--- a/changelogs/fragments/20250505-skip_ansible-core_2.16.yml
+++ b/changelogs/fragments/20250505-skip_ansible-core_2.16.yml
@@ -1,3 +1,3 @@
 ---
 trivial:
-  - exclude ansible-core 2.16 for sanity tests
+  - Exclude ansible-core 2.16 for sanity tests (https://github.com/ansible-collections/community.aws/pull/2304).

--- a/changelogs/fragments/20250505-skip_ansible-core_2.16.yml
+++ b/changelogs/fragments/20250505-skip_ansible-core_2.16.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - exclude ansible-core 2.16 for sanity tests


### PR DESCRIPTION
Excluding testing on `ansible-core` 2.16 as well as specified Python versions.