### PR TITLE
Update backport label versions to account for new `10.0.0` major release

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -18,5 +18,5 @@ jobs:
   changelog-labeller:
     uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@main
     with:
-      label_minor_release: backport-9
-      label_bugfix_release: backport-8
+      label_minor_release: backport-10
+      label_bugfix_release: backport-9


### PR DESCRIPTION
Since we have a new `stable-10` branch, the backport label workflow needs to be updated accordingly.