### PR TITLE
Remove unnecessary changelog fragment from main

### DIFF
--- a/changelogs/fragments/20250513-python_support.yml
+++ b/changelogs/fragments/20250513-python_support.yml
@@ -1,5 +1,0 @@
-breaking_changes:
-- community.aws collection - Due to the AWS SDKs announcing the end of support
-  for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
-  support for Python less than 3.8 by this collection has been deprecated and will be removed in release 10.0.0.
-  (https://github.com/ansible-collections/community.aws/pull/2304).


### PR DESCRIPTION
This changelog fragment has already been accounted for via the recent `10.0.0` release; see "Deprecated Features" section of the [release changelog](https://github.com/ansible-collections/community.aws/releases/tag/10.0.0).