### PR TITLE
Add rebalancing switch to ECS service creation and modification.

### DIFF
--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -817,6 +817,7 @@ class EcsServiceManager:
         tags,
         propagate_tags,
         enable_execute_command,
+        availability_zone_rebalancing,
     ):
         params = dict(
             cluster=cluster_name,
@@ -840,6 +841,8 @@ class EcsServiceManager:
             params["healthCheckGracePeriodSeconds"] = health_check_grace_period_seconds
         if service_registries:
             params["serviceRegistries"] = service_registries
+        if availability_zone_rebalancing:
+            params["availabilityZoneRebalancing"] = availability_zone_rebalancing
 
         # filter placement_constraint and left only those where value is not None
         # use-case: `distinctInstance` type should never contain `expression`, but None will fail `str` type validation
@@ -887,6 +890,7 @@ class EcsServiceManager:
         purge_placement_constraints,
         purge_placement_strategy,
         enable_execute_command,
+        availability_zone_rebalancing,
     ):
         params = dict(
             cluster=cluster_name,
@@ -922,6 +926,8 @@ class EcsServiceManager:
         # desired count is not required if scheduling strategy is daemon
         if desired_count is not None:
             params["desiredCount"] = desired_count
+        if availability_zone_rebalancing:
+            params["availabilityZoneRebalancing"] = availability_zone_rebalancing
         if enable_execute_command is not None:
             params["enableExecuteCommand"] = enable_execute_command
 

--- a/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
+++ b/tests/integration/targets/ecs_cluster/tasks/20_ecs_service.yml
@@ -61,6 +61,42 @@
       - ecs_service.service.deploymentConfiguration.deploymentCircuitBreaker.enable
       - ecs_service.service.deploymentConfiguration.deploymentCircuitBreaker.rollback
 
+- name: create ECS service definition with rebalancing disabled
+  ecs_service:
+    state: present
+    name: "{{ ecs_service_name }}"
+    cluster: "{{ ecs_cluster_name }}"
+    task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+    desired_count: 1
+    availability_zone_rebalancing: DISABLED
+    deployment_configuration: "{{ ecs_service_deployment_configuration }}"
+    placement_strategy: "{{ ecs_service_placement_strategy }}"
+    placement_constraints:
+      - type: distinctInstance
+    health_check_grace_period_seconds: "{{ ecs_service_health_check_grace_period }}"
+    load_balancers:
+      - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+        containerName: "{{ ecs_task_name }}"
+        containerPort: "{{ ecs_task_container_port }}"
+    role: "{{ ecs_service_role_name }}"
+  register: ecs_service
+
+- name: check that ECS service creation changed
+  assert:
+    that:
+      - ecs_service.changed
+
+- name: check that placement constraint has been applied
+  assert:
+    that:
+      - "ecs_service.service.availabilityZoneRebalancing == 'DISABLED'"
+
+- name: check that ECS service was created with deployment_circuit_breaker
+  assert:
+    that:
+      - ecs_service.service.deploymentConfiguration.deploymentCircuitBreaker.enable
+      - ecs_service.service.deploymentConfiguration.deploymentCircuitBreaker.rollback
+
 - name: create same ECS service definition (should not change)
   ecs_service:
     state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for the ECS Service availabilityZoneRebalancing switch, as described in [AWS Service Rebalancing](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-rebalancing.html)

This simply adds a new value to the JSON, so it was implemented identically to the existing parameters, and there was no design decision, as such.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_service_rebalancing

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is a trivial change, adding support for a new feature flag.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
