### PR TITLE
[WIP] Add the identitystore_user module

### DIFF
--- a/plugins/modules/identitystore_user.py
+++ b/plugins/modules/identitystore_user.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: identitystore_user
+version_added: 0.0.0
+short_description: Manage users in Identity Store (IAM Identity Center)
+description:
+  - Manage users in the Identity Store service.
+  - The Identity Store service is used by IAM Identity Center.
+author:
+  - Christian von Schultz (@vonschultz)
+options:
+  identity_store_id:
+    description:
+      - The ID of the identity store.
+      - Found on the Settings page in IAM Identity Center.
+    type: str
+    required: true
+  display_name:
+    description:
+      - A string containing the name of the user.
+      - https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_CreateUser.html
+    type: str
+  user_name:
+    description:
+      - A string containing the user name of the user.
+    required: true
+    type: str
+  name:
+    description:
+      - A dictionary containing the full name of the user.
+      - https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Name.html
+    type: dict
+    suboptions:
+      family_name:
+        description:
+          - The family name of the user
+        type: str
+      given_name:
+        description:
+          - The given name of the user
+        type: str
+  emails:
+    description:
+      - A list of email dictionaries containing email addresses for the user.
+      - https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Email.html
+    type: list
+    elements: dict
+    suboptions:
+      value:
+        description:
+          - The e-mail address
+        required: true
+        type: str
+      type:
+        description:
+          - The type of e-mail address (e.g., "work")
+        required: true
+        type: str
+      primary:
+        description:
+          - Whether this e-mail address is the user's primary address
+        required: true
+        type: bool
+  state:
+    description:
+      - Create/Update or Delete a user
+    choices: [ 'present', 'absent' ]
+    required: True
+    type: str
+extends_documentation_fragment:
+  - amazon.aws.boto3
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+"""
+
+EXAMPLES = r"""
+- name: Create/update user
+  community.aws.identitystore_user:
+    identity_store_id: d-cba0987654
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: John Doe
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+
+- name: Remove user
+  community.aws.identitystore_user:
+    identity_store_id: d-c36714741a
+    state: absent
+    user_name: john.doe@example.com
+"""
+
+RETURN = r"""
+identity_store_id:
+  description:
+    - just echos the identity_store_id
+  type: str
+  returned: success
+user_id:
+  description:
+    - the identifier for a user in the identity store
+    - only present if the user exists when we return
+  type: str
+  returned: success
+"""
+
+from ansible.module_utils.common.dict_transformations import (
+    snake_dict_to_camel_dict,
+)
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import (
+    is_boto3_error_code,
+)
+from ansible_collections.amazon.aws.plugins.module_utils.exceptions import (
+    AnsibleAWSError,
+)
+from ansible_collections.amazon.aws.plugins.module_utils.modules import (
+    AnsibleAWSModule,
+)
+
+
+def flatten_dict(nested_dict):
+    flat = {}
+    for key, value in nested_dict.items():
+        if isinstance(value, dict):
+            for inner_key, inner_value in flatten_dict(value).items():
+                flat[f'{key}.{inner_key}'] = inner_value
+        else:
+            flat[key] = value
+    return flat
+
+
+def create_user(connection, module, user_attributes):
+    args = {
+        'identity_store_id': module.params.get("identity_store_id"),
+        **user_attributes,
+    }
+    response = connection.create_user(
+        **snake_dict_to_camel_dict(args, capitalize_first=True)
+    )
+    module.exit_json(
+        changed=True,
+        user_id=response['UserId'],
+        identity_store_id=response['IdentityStoreId'],
+    )
+
+
+def update_user(connection, module, user_id, user_attributes):
+    response = connection.describe_user(
+        IdentityStoreId=module.params.get("identity_store_id"), UserId=user_id
+    )
+    if all(
+        value == response[key]
+        for key, value in snake_dict_to_camel_dict(
+            user_attributes, capitalize_first=True
+        ).items()
+    ):
+        module.exit_json(
+            changed=False,
+            user_id=user_id,
+            identity_store_id=response['IdentityStoreId'],
+        )
+    elif module.check_mode:
+        module.exit_json(
+            changed=True,
+            user_id=user_id,
+            identity_store_id=response['IdentityStoreId'],
+        )
+    else:
+        args = {
+            'identity_store_id': module.params.get("identity_store_id"),
+            'user_id': user_id,
+            'operations': [
+                {'attribute_path': key, 'attribute_value': value}
+                for key, value in snake_dict_to_camel_dict(
+                    flatten_dict(user_attributes)
+                ).items()
+            ],
+        }
+
+        connection.update_user(
+            **snake_dict_to_camel_dict(args, capitalize_first=True)
+        )
+        module.exit_json(
+            changed=True,
+            user_id=args['user_id'],
+            identity_store_id=args['identity_store_id'],
+        )
+
+
+def create_or_update_user(connection, module):
+    identity_store_id = module.params.get("identity_store_id")
+    user_name = module.params.get("user_name")
+
+    user_attributes = {
+        path: module.params.get(path)
+        for path in ('user_name', 'display_name', 'emails', 'name')
+    }
+    user_attributes = {
+        key: value
+        for key, value in user_attributes.items()
+        if value is not None
+    }
+
+    try:
+        user_id = connection.get_user_id(
+            IdentityStoreId=identity_store_id,
+            AlternateIdentifier={
+                'UniqueAttribute': {
+                    'AttributePath': 'userName',
+                    'AttributeValue': user_name,
+                }
+            },
+        )
+        update_user(
+            connection=connection,
+            module=module,
+            user_id=user_id['UserId'],
+            user_attributes=user_attributes,
+        )
+    except is_boto3_error_code("ResourceNotFoundException"):
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                identity_store_id=identity_store_id,
+                msg="Would have created user if not in check mode.",
+            )
+        else:
+            create_user(
+                connection=connection,
+                module=module,
+                user_attributes=user_attributes,
+            )
+
+
+def destroy_user(connection, module):
+    identity_store_id = module.params.get("identity_store_id")
+    user_name = module.params.get("user_name")
+
+    try:
+        user_id = connection.get_user_id(
+            IdentityStoreId=identity_store_id,
+            AlternateIdentifier={
+                'UniqueAttribute': {
+                    'AttributePath': 'userName',
+                    'AttributeValue': user_name,
+                }
+            },
+        )
+        if not module.check_mode:
+            connection.delete_user(
+                IdentityStoreId=identity_store_id,
+                UserId=user_id['UserId'],
+            )
+        module.exit_json(changed=True, identity_store_id=identity_store_id)
+    except is_boto3_error_code("ResourceNotFoundException"):
+        module.exit_json(changed=False, identity_store_id=identity_store_id)
+
+
+def main():
+    argument_spec = dict(
+        user_name=dict(required=True, type="str"),
+        display_name=dict(required=False, type="str"),
+        name=dict(
+            required=False,
+            type="dict",
+            options=dict(
+                family_name=dict(required=False, type="str"),
+                given_name=dict(required=False, type="str"),
+            ),
+        ),
+        emails=dict(
+            required=False,
+            type="list",
+            elements="dict",
+            options=dict(
+                value=dict(required=True, type="str"),
+                type=dict(required=True, type="str"),
+                primary=dict(required=True, type="bool"),
+            ),
+        ),
+        identity_store_id=dict(required=True, type="str"),
+        state=dict(choices=["present", "absent"], required=True),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    connection = module.client("identitystore")
+
+    state = module.params.get("state")
+
+    try:
+        if state == "present":
+            create_or_update_user(connection, module)
+        else:
+            destroy_user(connection, module)
+    except AnsibleAWSError as e:
+        module.fail_json_aws_error(e)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/identitystore/aliases
+++ b/tests/integration/targets/identitystore/aliases
@@ -1,0 +1,6 @@
+# reason: Requires having set up an identity_store_id first
+disabled
+
+cloud/aws
+
+identitystore_user

--- a/tests/integration/targets/identitystore/tasks/identitystore_user.yml
+++ b/tests/integration/targets/identitystore/tasks/identitystore_user.yml
@@ -1,0 +1,285 @@
+- name: User creation under check mode
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: John Doe
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  check_mode: true
+  register: new_user_creation_check_mode
+
+- name: Assert that we looked for the user without actually creating it
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:DescribeUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - new_user_creation_check_mode is changed
+  vars:
+    resource_actions: "{{ new_user_creation_check_mode.resource_actions }}"
+
+- name: User creation
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: John Doe
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  register: new_user_creation
+
+- name: Assert that we looked for and created the user
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:CreateUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:DescribeUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - new_user_creation is changed
+  vars:
+    resource_actions: "{{ new_user_creation.resource_actions }}"
+
+- name: User creation again (idempotency) under check mode
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: John Doe
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  check_mode: true
+  register: old_user_creation_check_mode
+
+- name: Assert that we looked for the user without creating or changing it
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DescribeUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - old_user_creation_check_mode is not changed
+  vars:
+    resource_actions: "{{ old_user_creation_check_mode.resource_actions }}"
+
+- name: User creation again (idempotency)
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: John Doe
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  register: old_user_creation
+
+- name: Assert that we looked for the user without creating or changing it
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DescribeUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - old_user_creation is not changed
+  vars:
+    resource_actions: "{{ old_user_creation.resource_actions }}"
+
+- name: User modification under check mode
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: Johnny
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  check_mode: true
+  register: new_modify_check_mode
+
+- name: Assert that we would have changed some attribute
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DescribeUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - new_modify_check_mode is changed
+  vars:
+    resource_actions: "{{ new_modify_check_mode.resource_actions }}"
+
+- name: User modification
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: Johnny
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  register: new_modify
+
+- name: Assert that we have changed some attribute
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DescribeUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:UpdateUser" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - new_modify is changed
+  vars:
+    resource_actions: "{{ new_modify.resource_actions }}"
+
+- name: User modification again (idempotency) under check mode
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: Johnny
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  check_mode: true
+  register: old_modify_check_mode
+
+- name: Assert that we would not have changed any attribute
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DescribeUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - old_modify_check_mode is not changed
+  vars:
+    resource_actions: "{{ old_modify_check_mode.resource_actions }}"
+
+- name: User modification again (idempotency)
+  community.aws.identitystore_user:
+    state: present
+    user_name: john.doe@example.com
+    name:
+      family_name: Doe
+      given_name: John
+    display_name: Johnny
+    emails:
+      - value: john.doe@example.com
+        type: work
+        primary: true
+  register: old_modify
+
+- name: Assert that we have not changed any attribute
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DescribeUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - old_modify is not changed
+  vars:
+    resource_actions: "{{ old_modify.resource_actions }}"
+
+- name: User deletion under check mode
+  community.aws.identitystore_user:
+    state: absent
+    user_name: john.doe@example.com
+  check_mode: true
+  register: new_delete_check_mode
+
+- name: Assert that we would have deleted the user
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:DescribeUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - new_delete_check_mode is changed
+  vars:
+    resource_actions: "{{ new_delete_check_mode.resource_actions }}"
+
+- name: User deletion
+  community.aws.identitystore_user:
+    state: absent
+    user_name: john.doe@example.com
+  register: new_delete
+
+- name: Assert that we have deleted the user
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:DeleteUser" in resource_actions'
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DescribeUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - new_delete is changed
+  vars:
+    resource_actions: "{{ new_delete.resource_actions }}"
+
+- name: User deletion (non-existent resource) under check mode
+  community.aws.identitystore_user:
+    state: absent
+    user_name: john.doe@example.com
+  check_mode: true
+  register: old_delete_check_mode
+
+- name: Assert that we have deleted the user
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:DescribeUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - old_delete_check_mode is not changed
+  vars:
+    resource_actions: "{{ old_delete_check_mode.resource_actions }}"
+
+- name: User deletion (non-existent resource)
+  community.aws.identitystore_user:
+    state: absent
+    user_name: john.doe@example.com
+  register: old_delete
+
+- name: Assert that we have deleted the user
+  ansible.builtin.assert:
+    that:
+      - '"identitystore:GetUserId" in resource_actions'
+      - '"identitystore:CreateUser" not in resource_actions'
+      - '"identitystore:DeleteUser" not in resource_actions'
+      - '"identitystore:DescribeUser" not in resource_actions'
+      - '"identitystore:UpdateUser" not in resource_actions'
+      - old_delete is not changed
+  vars:
+    resource_actions: "{{ old_delete.resource_actions }}"

--- a/tests/integration/targets/identitystore/tasks/main.yml
+++ b/tests/integration/targets/identitystore/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Run identitystore tests
+  module_defaults:
+    community.aws.identitystore_user:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+      identity_store_id: |-
+        {{
+          aws_identity_store_id |
+          mandatory("This test requires that you set up an identity_store_id.")
+        }}
+
+  block:
+    - name: Test the identitystore_user module
+      include_tasks: identitystore_user.yml


### PR DESCRIPTION
Add the community.aws.identitystore_user module, for managing users in an identity store (used by the IAM Identity Center).

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible is currently lacking a way to interact with the AWS IdentityStore API, https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/identitystore.html. This change adds support for adding and removing users, and setting the most important attributes on those users. This could potentially be extended in the future to include things like group creation, group membership and more user attributes.

There is currently no way to create an identity store in Ansible, so I made the integration tests "disabled", since they rely on that external resource. You can create it in the IAM Identity Center, and maybe the `AWS::SSO::Instance` CloudFormation resource also produces identity stores that could be used for this (at most one per account, according to the docs).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
identitystore_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

