### PR TITLE
Add EC2 LGW Route Table Association for Outposts

### DIFF
--- a/plugins/modules/ec2_lgw_route_table_association.py
+++ b/plugins/modules/ec2_lgw_route_table_association.py
@@ -1,0 +1,260 @@
+#!/usr/bin/python
+
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: ec2_lgw_route_table_association
+version_added: 1.0.0
+short_description: Associate a VPC to a Local Gateway Route Table
+description:
+  - Associate a VPC to a Local Gateway Route Table
+author:
+  - Joel Bento Valenca (@joe1368)
+options:
+  lgw_route_table_id:
+    description:
+      - The ID of the local gateway route table to associate.
+      - Required when O(state=present).
+    type: str
+  vpc_id:
+    description:
+      - VPC ID of the VPC in which to associate.
+      - Required when O(state=present).
+    type: str
+  lgw_route_table_vpc_association_id:
+    description:
+      - The ID of the association between the VPC and the Local Gateway Route Table.
+      - Required when O(state=absent).
+    type: str
+  state:
+    description: Create or destroy the Local Gateway Route Table association with the VPC.
+    default: present
+    choices: [ 'present', 'absent' ]
+    type: str
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.tags
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Creation example:
+- name: Create local gateway route table association
+  community.aws.ec2_lgw_route_table_association:
+    vpc_id: vpc-xxxxxxxxx
+    lgw_route_table_id: lgw-rtb-xxxxxxxxxxxxxxxxx
+    tags:
+      Name: LGW-RT-vpc-1245678
+  register: lgw_route_table_association
+
+# Deletion example:
+- name: Delete local gateway route table association
+  community.aws.ec2_lgw_route_table_association:
+    lgw_route_table_vpc_association_id: lgw-vpc-assoc-xxxxxxxxxxx
+    state: absent
+
+- name: Delete local gateway route table association
+  community.aws.ec2_lgw_route_table_association:
+    vpc_id: vpc-xxxxxxxxx
+    lgw_route_table_id: lgw-rtb-xxxxxxxxxxxxxxxxx
+    state: absent
+"""
+
+RETURN = r"""
+result:
+  description: Returns an array of complex objects as described below.
+  returned: success
+  type: complex
+  contains:
+    LocalGatewayRouteTableVpcAssociationId:
+      description: The ID of the association.
+      returned: always
+      type: str
+      sample: lgw-vpc-assoc-xxxxxxxxxxx
+    LocalGatewayRouteTableId :
+      description: The ID of the local gateway route table.
+      returned: always
+      type: str
+      sample: lgw-rtb-xxxxxxxxxxxxxxxxx
+    LocalGatewayRouteTableArn:
+      description: The ARN of the local gateway route table.
+      returned: always
+      type: str
+      sample: arn:aws:ec2:us-east-1:123456789012:local-gateway-route-table/lgw-rtb-xxxxxxxxxxxxxxxxx
+    LocalGatewayId:
+      description: The ID of the local gateway.
+      returned: always
+      type: str
+      sample: lgw-xxxxxxxxxxxxxxxxx
+    vpc_id:
+      description: ID for the VPC in which the route lives.
+      returned: always
+      type: str
+      sample: vpc-6e2d2407
+    owner_id:
+        description: AWS account owning resource.
+        type: str
+        sample: 123456789012
+    state:
+      description: The state of the local gateway route table association.
+      returned: always
+      type: str
+      sample: associated
+    tags:
+      description: Tags applied to the route table.
+      returned: always
+      type: dict
+      sample:
+        Name: LGW-RT-vpc-1245678
+"""
+
+
+from time import sleep
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
+from typing import Optional
+
+
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
+
+from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+
+
+@AWSRetry.jittered_backoff()
+def describe_lgw_route_table_associations(
+    client, **params: Dict[str, Union[List[str], bool, List[Dict[str, Union[str, List[str]]]]]]
+) -> List[Dict[str, Any]]:
+    paginator = client.get_paginator("describe_local_gateway_route_table_vpc_associations")
+    return paginator.paginate(**params).build_full_result()["LocalGatewayRouteTableVpcAssociations"]
+
+@AWSRetry.jittered_backoff()
+def create_lgw_route_table_association(client, lgw_route_table_id: str, vpc_id: str, tags: Optional[Dict[str, str]]) -> Dict[str, Any]:
+    params = {"LocalGatewayRouteTableId": lgw_route_table_id,
+              "VpcId": vpc_id}
+    if tags:
+        params["TagSpecifications"] = boto3_tag_specifications(tags, types="local-gateway-route-table-vpc-association")
+    return client.create_local_gateway_route_table_vpc_association(**params)["LocalGatewayRouteTableVpcAssociation"]
+
+@AWSRetry.jittered_backoff()
+def delete_lgw_route_table_association(client, lgw_route_table_vpc_association_id: str) -> bool:
+    client.delete_local_gateway_route_table_vpc_association(LocalGatewayRouteTableVpcAssociationId=lgw_route_table_vpc_association_id)
+    return True
+
+
+def ensure_lgw_route_table_vpc_association_present(connection, module: AnsibleAWSModule) -> Dict[str, Any]:
+    lgw_route_table_id = module.params.get("lgw_route_table_id")
+    tags = module.params.get("tags")
+    vpc_id = module.params.get("vpc_id")
+
+    changed = False
+
+    filters = ansible_dict_to_boto3_filter_list({"vpc-id": vpc_id, "local-gateway-route-table-id": lgw_route_table_id})
+    lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+
+    #If not Local Gateway Route Table Association found, create new association
+    if lgw_route_table_associations in ([], None):
+        changed = True
+        if module.check_mode:
+            lgw_route_table_associations = {"LocalGatewayRouteTableVpcAssociationId": "lgw-vpc-assoc-xxxxxxxxxxx", 
+                                           "LocalGatewayRouteTableId": lgw_route_table_id, 
+                                           "LocalGatewayRouteTableArn": f"arn:aws:ec2:us-east-2:xxxxxxxxxxxx:local-gateway-route-table/{lgw_route_table_id}",
+                                           "LocalGatewayId": "lgw-xxxxxxxxxxxxxx",
+                                           "VpcId": vpc_id,
+                                           "OwnerId": "xxxxxxxxxxx",
+                                           "State": "associated",
+                                           "Tags": tags}
+            return dict(changed=changed, result=lgw_route_table_associations)
+
+        create_lgw_route_table_association(connection, lgw_route_table_id, vpc_id, tags)
+
+    if changed:
+        #Wait for the local gateway route table association to be created
+        lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+        while lgw_route_table_associations[0]["State"] != "associated":
+            sleep(5)
+            lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+
+    lgw_route_table_associations[0]["Tags"] = boto3_tag_list_to_ansible_dict(lgw_route_table_associations[0]["Tags"])
+
+    return dict(changed=changed, result=lgw_route_table_associations[0])
+
+def ensure_lgw_route_table_vpc_association_absent(connection, module: AnsibleAWSModule) -> Dict[str, bool]:
+    lgw_route_table_vpc_association_id = module.params.get("lgw_route_table_vpc_association_id")
+    vpc_id = module.params.get("vpc_id")
+    lgw_route_table_id = module.params.get("lgw_route_table_id")
+
+    changed = False
+
+    if lgw_route_table_vpc_association_id:
+        filters = ansible_dict_to_boto3_filter_list({"local-gateway-route-table-vpc-association-id": lgw_route_table_vpc_association_id})
+    elif vpc_id and lgw_route_table_id:
+        filters = ansible_dict_to_boto3_filter_list({"vpc-id": vpc_id, "local-gateway-route-table-id": lgw_route_table_id})
+
+    lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+
+    if lgw_route_table_associations in ([], None):
+        return {"changed": changed}
+
+    if module.check_mode:
+        changed = True
+        return {"changed": changed}
+    else:
+        lgw_route_table_vpc_association_id = lgw_route_table_associations[0]["LocalGatewayRouteTableVpcAssociationId"]
+        changed = delete_lgw_route_table_association(connection, lgw_route_table_vpc_association_id)
+
+    if changed:
+        # Wait for the local gateway route table association to be deleted
+        lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+        while lgw_route_table_associations not in ([], None):
+            sleep(5)
+            lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+
+    return {"changed": changed}
+
+
+def main() -> None:
+    argument_spec = dict(
+        lgw_route_table_id=dict(type="str"),
+        vpc_id=dict(),
+        tags=dict(type="dict", aliases=["resource_tags"]),
+        lgw_route_table_vpc_association_id=dict(type="str"),
+        state=dict(default="present", choices=["present", "absent"]),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ["state", "absent", ["lgw_route_table_vpc_association_id","vpc_id"],True],
+        ],
+        required_together=[
+            ["lgw_route_table_id", "vpc_id"],
+        ],
+        supports_check_mode=True,
+    )
+
+    connection = module.client("ec2")
+    method_operation = (
+        ensure_lgw_route_table_vpc_association_present if module.params.get("state") == "present" else ensure_lgw_route_table_vpc_association_absent
+    )
+
+    try:
+        result = method_operation(connection, module)
+    except AnsibleEC2Error as e:
+        module.fail_json_aws_error(e)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ec2_lgw_route_table_association_info.py
+++ b/plugins/modules/ec2_lgw_route_table_association_info.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -30,7 +31,6 @@ options:
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
-  - amazon.aws.tags
   - amazon.aws.boto3
 """
 
@@ -100,34 +100,16 @@ result:
       returned: always
       type: str
       sample: associated
-    tags:
-      description: Tags applied to the route table.
-      returned: always
-      type: dict
-      sample:
-        Name: LGW-RT-vpc-1245678
 """
 
 
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Union
-
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+from ansible_collections.community.aws.plugins.module_utils.ec2 import describe_lgw_route_table_associations
 
-
-@AWSRetry.jittered_backoff()
-def describe_lgw_route_table_associations(
-    client, **params: Dict[str, Union[List[str], bool, List[Dict[str, Union[str, List[str]]]]]]
-) -> List[Dict[str, Any]]:
-    paginator = client.get_paginator("describe_local_gateway_route_table_vpc_associations")
-    return paginator.paginate(**params).build_full_result()["LocalGatewayRouteTableVpcAssociations"]
 
 def list_ec2_lgw_route_tables_associations(connection, module: AnsibleAWSModule) -> None:
     lgw_route_table_id = module.params.get("lgw_route_table_id")
@@ -141,7 +123,7 @@ def list_ec2_lgw_route_tables_associations(connection, module: AnsibleAWSModule)
     elif vpc_id:
         filters = ansible_dict_to_boto3_filter_list({"vpc-id": vpc_id})
     elif lgw_route_table_id:
-      filters = ansible_dict_to_boto3_filter_list({"local-gateway-route-table-id": lgw_route_table_id})
+        filters = ansible_dict_to_boto3_filter_list({"local-gateway-route-table-id": lgw_route_table_id})
 
     try:
         lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)

--- a/plugins/modules/ec2_lgw_route_table_association_info.py
+++ b/plugins/modules/ec2_lgw_route_table_association_info.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: ec2_lgw_route_table_association_info
+version_added: 1.0.0
+short_description: Get information about a Local Gateway Route Table association
+description:
+  - Get information about a Local Gateway Route Table association
+author:
+  - Joel Bento Valenca (@joe1368)
+options:
+  lgw_route_table_id:
+    description:
+      - The ID of the local gateway route table.
+      - Required when no other options are specified.
+    type: str
+  vpc_id:
+    description:
+      - VPC ID of the VPC.
+      - Required when no other options are specified.
+    type: str
+  lgw_route_table_vpc_association_id:
+    description:
+      - The ID of the association between the VPC and the Local Gateway Route Table.
+      - Required when no other options are specified.
+    type: str
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.tags
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Getting example:
+- name: Get local gateway route table associations by ID
+  community.aws.ec2_lgw_route_table_association_info:
+    lgw_route_table_vpc_association_id: lgw-vpc-assoc-xxxxxxxxxxx
+  register: lgw_route_table_associations
+
+- name: Get local gateway route table associations by VPC ID
+  community.aws.ec2_lgw_route_table_association_info:
+    vpc_id: vpc-xxxxxxxxxxx
+  register: lgw_route_table_associations
+
+- name: Get local gateway route table associations by Local Gateway Route Table ID
+  community.aws.ec2_lgw_route_table_association_info:
+    lgw_route_table_id: lgw-rtb-xxxxxxxxxxxxxxxxx
+  register: lgw_route_table_associations
+
+- name: Get local gateway route table associations by Local Gateway Route Table ID and VPC ID
+  community.aws.ec2_lgw_route_table_association_info:
+    lgw_route_table_id: lgw-rtb-xxxxxxxxxxxxxxxxx
+    vpc_id: vpc-xxxxxxxxxxx
+  register: lgw_route_table_associations
+"""
+
+RETURN = r"""
+result:
+  description: Returns an array of complex objects as described below.
+  returned: success
+  type: complex
+  contains:
+    LocalGatewayRouteTableVpcAssociationId:
+      description: The ID of the association.
+      returned: always
+      type: str
+      sample: lgw-vpc-assoc-xxxxxxxxxxx
+    LocalGatewayRouteTableId :
+      description: The ID of the local gateway route table.
+      returned: always
+      type: str
+      sample: lgw-rtb-xxxxxxxxxxxxxxxxx
+    LocalGatewayRouteTableArn:
+      description: The ARN of the local gateway route table.
+      returned: always
+      type: str
+      sample: arn:aws:ec2:us-east-1:123456789012:local-gateway-route-table/lgw-rtb-xxxxxxxxxxxxxxxxx
+    LocalGatewayId:
+      description: The ID of the local gateway.
+      returned: always
+      type: str
+      sample: lgw-xxxxxxxxxxxxxxxxx
+    vpc_id:
+      description: ID for the VPC in which the route lives.
+      returned: always
+      type: str
+      sample: vpc-6e2d2407
+    owner_id:
+        description: AWS account owning resource.
+        type: str
+        sample: 123456789012
+    state:
+      description: The state of the local gateway route table association.
+      returned: always
+      type: str
+      sample: associated
+    tags:
+      description: Tags applied to the route table.
+      returned: always
+      type: dict
+      sample:
+        Name: LGW-RT-vpc-1245678
+"""
+
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
+
+from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+
+
+@AWSRetry.jittered_backoff()
+def describe_lgw_route_table_associations(
+    client, **params: Dict[str, Union[List[str], bool, List[Dict[str, Union[str, List[str]]]]]]
+) -> List[Dict[str, Any]]:
+    paginator = client.get_paginator("describe_local_gateway_route_table_vpc_associations")
+    return paginator.paginate(**params).build_full_result()["LocalGatewayRouteTableVpcAssociations"]
+
+def list_ec2_lgw_route_tables_associations(connection, module: AnsibleAWSModule) -> None:
+    lgw_route_table_id = module.params.get("lgw_route_table_id")
+    vpc_id = module.params.get("vpc_id")
+    lgw_route_table_vpc_association_id = module.params.get("lgw_route_table_vpc_association_id")
+
+    if lgw_route_table_vpc_association_id:
+        filters = ansible_dict_to_boto3_filter_list({"local-gateway-route-table-vpc-association-id": lgw_route_table_vpc_association_id})
+    elif vpc_id and lgw_route_table_id:
+        filters = ansible_dict_to_boto3_filter_list({"vpc-id": vpc_id, "local-gateway-route-table-id": lgw_route_table_id})
+    elif vpc_id:
+        filters = ansible_dict_to_boto3_filter_list({"vpc-id": vpc_id})
+    elif lgw_route_table_id:
+      filters = ansible_dict_to_boto3_filter_list({"local-gateway-route-table-id": lgw_route_table_id})
+
+    try:
+        lgw_route_table_associations = describe_lgw_route_table_associations(connection, Filters=filters)
+    except AnsibleEC2Error as e:
+        module.fail_json_aws_error(e)
+
+    for i in range(len(lgw_route_table_associations)):
+        lgw_route_table_associations[i]["Tags"] = boto3_tag_list_to_ansible_dict(lgw_route_table_associations[i]["Tags"])
+
+    module.exit_json(changed=False, result=lgw_route_table_associations)
+
+
+def main() -> None:
+    argument_spec = dict(
+        vpc_id=dict(),
+        lgw_route_table_vpc_association_id=dict(type="str"),
+        lgw_route_table_id=dict(type="str"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_one_of=[
+            ["vpc_id", "lgw_route_table_vpc_association_id", "lgw_route_table_id"],
+        ],
+        supports_check_mode=True,
+    )
+
+    connection = module.client("ec2")
+
+    list_ec2_lgw_route_tables_associations(connection, module)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ec2_lgw_route_table_association/aliases
+++ b/tests/integration/targets/ec2_lgw_route_table_association/aliases
@@ -1,0 +1,4 @@
+cloud/aws
+
+ec2_lgw_route_table_association
+ec2_lgw_route_table_association_info

--- a/tests/integration/targets/ec2_lgw_route_table_association/defaults/main.yml
+++ b/tests/integration/targets/ec2_lgw_route_table_association/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+vpc_name: "vpc-{{ resource_prefix }}"
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+lgw_route_table_id: "lgw-rtb-xxxxxxxx"  # replace with your Local Gateway Route Table ID

--- a/tests/integration/targets/ec2_lgw_route_table_association/meta/main.yml
+++ b/tests/integration/targets/ec2_lgw_route_table_association/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ec2_lgw_route_table_association/tasks/main.yml
+++ b/tests/integration/targets/ec2_lgw_route_table_association/tasks/main.yml
@@ -1,0 +1,184 @@
+---
+- name: ec2_lgw_route_table_association integration tests
+  module_defaults:
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    # ==================================================================
+    - name: Create Local Gateway Route Table VPC Association - check_mode
+      ec2_lgw_route_table_association:
+        state: present
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+        tags:
+          Description: Created by ansible-test
+      register: lgw_rt_asso_check_mode
+      check_mode: true
+
+    - name: Assert check_mode result - no lgw_rt_association creation
+      ansible.builtin.assert:
+        that:
+          - lgw_rt_asso_check_mode.changed
+          - not lgw_rt_asso_check_mode.failed
+
+    - name: Create Local Gateway Route Table VPC Association
+      ec2_lgw_route_table_association:
+        state: present
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+        tags:
+          Description: Created by ansible-test
+      register: lgw_rt_asso
+
+    - name: Use set fact for lgw_rt_asso id
+      ansible.builtin.set_fact:
+        lgw_rt_asso_id: "{{ lgw_rt_asso.result.LocalGatewayRouteTableVpcAssociationId }}"
+
+    - name: Assert result - lgw_rt_association creation
+      ansible.builtin.assert:
+        that:
+          - lgw_rt_asso.changed
+          - lgw_rt_asso.result.VpcId == vpc_id
+
+    - name: Test idempotence
+      ec2_lgw_route_table_association:
+        state: present
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+        tags:
+          Description: Created by ansible-test
+      register: lgw_rt_asso
+
+    - name: Assert idempotence result - no change
+      ansible.builtin.assert:
+        that:
+          - not lgw_rt_asso.changed
+          - lgw_rt_asso.result.LocalGatewayRouteTableVpcAssociationId == lgw_rt_asso_id
+
+    # ============================================================
+    - name: Get local gateway route table associations by ID
+      ec2_lgw_route_table_association_info:
+        lgw_route_table_vpc_association_id: "{{ lgw_rt_asso_id }}"
+      register: lgw_rt_asso_info
+      check_mode: true
+
+    - name: Verify expected facts by ID
+      vars:
+        lgw_rt_asso_details: "{{ lgw_rt_asso_info.result[0] }}"
+      ansible.builtin.assert:
+        that:
+          - '"LocalGatewayId" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableArn" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableId" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableVpcAssociationId" in lgw_rt_asso_details'
+          - '"OwnerId" in lgw_rt_asso_details'
+          - '"Tags" in lgw_rt_asso_details'
+          - '"VpcId" in lgw_rt_asso_details'
+          - '"State" in lgw_rt_asso_details'
+          - lgw_rt_asso_details.LocalGatewayRouteTableVpcAssociationId == lgw_rt_asso_id
+          - lgw_rt_asso_details.VpcId == vpc_id
+          - lgw_rt_asso_details.LocalGatewayRouteTableId == lgw_route_table_id
+
+    - name: Get local gateway route table associations by VPC ID
+      ec2_lgw_route_table_association_info:
+        vpc_id: "{{ vpc_id }}"
+      register: lgw_rt_asso_info
+      check_mode: true
+
+    - name: Verify expected facts by VPC ID
+      vars:
+        lgw_rt_asso_details: "{{ lgw_rt_asso_info.result[0] }}"
+      ansible.builtin.assert:
+        that:
+          - '"LocalGatewayId" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableArn" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableId" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableVpcAssociationId" in lgw_rt_asso_details'
+          - '"OwnerId" in lgw_rt_asso_details'
+          - '"Tags" in lgw_rt_asso_details'
+          - '"VpcId" in lgw_rt_asso_details'
+          - '"State" in lgw_rt_asso_details'
+          - lgw_rt_asso_details.LocalGatewayRouteTableVpcAssociationId == lgw_rt_asso_id
+          - lgw_rt_asso_details.VpcId == vpc_id
+          - lgw_rt_asso_details.LocalGatewayRouteTableId == lgw_route_table_id
+
+    - name: Get local gateway route table associations by Local Gateway Route Table ID and VPC ID
+      ec2_lgw_route_table_association_info:
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+      register: lgw_rt_asso_info
+      check_mode: true
+
+    - name: Verify expected facts by Local Gateway Route Table ID and VPC ID
+      vars:
+        lgw_rt_asso_details: "{{ lgw_rt_asso_info.result[0] }}"
+      ansible.builtin.assert:
+        that:
+          - '"LocalGatewayId" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableArn" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableId" in lgw_rt_asso_details'
+          - '"LocalGatewayRouteTableVpcAssociationId" in lgw_rt_asso_details'
+          - '"OwnerId" in lgw_rt_asso_details'
+          - '"Tags" in lgw_rt_asso_details'
+          - '"VpcId" in lgw_rt_asso_details'
+          - '"State" in lgw_rt_asso_details'
+          - lgw_rt_asso_details.LocalGatewayRouteTableVpcAssociationId == lgw_rt_asso_id
+          - lgw_rt_asso_details.VpcId == vpc_id
+          - lgw_rt_asso_details.LocalGatewayRouteTableId == lgw_route_table_id
+
+    # ============================================================
+    - name: Delete Local Gateway Route Table VPC Association - check_mode
+      ec2_lgw_route_table_association:
+        state: absent
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+      register: lgw_rt_asso_check_mode
+      check_mode: true
+
+    - name: Assert check_mode result - no lgw_rt_association deletion
+      ansible.builtin.assert:
+        that:
+          - lgw_rt_asso_check_mode.changed
+          - not lgw_rt_asso_check_mode.failed
+
+    - name: Delete Local Gateway Route Table VPC Association
+      ec2_lgw_route_table_association:
+        state: absent
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+      register: lgw_rt_asso
+
+    - name: Assert result - lgw_rt_association deletion
+      ansible.builtin.assert:
+        that:
+          - lgw_rt_asso.changed
+
+    - name: Test idempotence deletion
+      ec2_lgw_route_table_association:
+        state: absent
+        lgw_route_table_id: "{{ lgw_route_table_id }}"
+        vpc_id: "{{ vpc_id }}"
+      register: lgw_rt_asso
+
+    - name: Assert idempotence result - no change on deletion
+      ansible.builtin.assert:
+        that:
+          - not lgw_rt_asso.changed
+
+# ============================================================
+  always:
+    - ansible.builtin.debug:
+        msg: "Removing test dependencies"
+
+    - name: Delete vpc
+      amazon.aws.ec2_vpc_net:
+        vpc_id: "{{ vpc_id }}"
+        state: absent
+      register: result
+      retries: 10
+      delay: 5
+      until: result is not failed
+      ignore_errors: true

--- a/tests/integration/targets/ec2_lgw_route_table_association/tasks/main.yml
+++ b/tests/integration/targets/ec2_lgw_route_table_association/tasks/main.yml
@@ -7,6 +7,19 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
+    # ============================================================
+    - name: Create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Description: Created by ansible-test
+      register: vpc_result
+
+    - name: Use set fact for vpc ids
+      ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_result.results.0.vpc.id }}"
     # ==================================================================
     - name: Create Local Gateway Route Table VPC Association - check_mode
       community.aws.ec2_lgw_route_table_association:

--- a/tests/integration/targets/ec2_lgw_route_table_association/tasks/main.yml
+++ b/tests/integration/targets/ec2_lgw_route_table_association/tasks/main.yml
@@ -9,7 +9,7 @@
   block:
     # ==================================================================
     - name: Create Local Gateway Route Table VPC Association - check_mode
-      ec2_lgw_route_table_association:
+      community.aws.ec2_lgw_route_table_association:
         state: present
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"
@@ -25,7 +25,7 @@
           - not lgw_rt_asso_check_mode.failed
 
     - name: Create Local Gateway Route Table VPC Association
-      ec2_lgw_route_table_association:
+      community.aws.ec2_lgw_route_table_association:
         state: present
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"
@@ -44,7 +44,7 @@
           - lgw_rt_asso.result.VpcId == vpc_id
 
     - name: Test idempotence
-      ec2_lgw_route_table_association:
+      community.aws.ec2_lgw_route_table_association:
         state: present
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"
@@ -60,7 +60,7 @@
 
     # ============================================================
     - name: Get local gateway route table associations by ID
-      ec2_lgw_route_table_association_info:
+      community.aws.ec2_lgw_route_table_association_info:
         lgw_route_table_vpc_association_id: "{{ lgw_rt_asso_id }}"
       register: lgw_rt_asso_info
       check_mode: true
@@ -83,7 +83,7 @@
           - lgw_rt_asso_details.LocalGatewayRouteTableId == lgw_route_table_id
 
     - name: Get local gateway route table associations by VPC ID
-      ec2_lgw_route_table_association_info:
+      community.aws.ec2_lgw_route_table_association_info:
         vpc_id: "{{ vpc_id }}"
       register: lgw_rt_asso_info
       check_mode: true
@@ -106,7 +106,7 @@
           - lgw_rt_asso_details.LocalGatewayRouteTableId == lgw_route_table_id
 
     - name: Get local gateway route table associations by Local Gateway Route Table ID and VPC ID
-      ec2_lgw_route_table_association_info:
+      community.aws.ec2_lgw_route_table_association_info:
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"
       register: lgw_rt_asso_info
@@ -131,7 +131,7 @@
 
     # ============================================================
     - name: Delete Local Gateway Route Table VPC Association - check_mode
-      ec2_lgw_route_table_association:
+      community.aws.ec2_lgw_route_table_association:
         state: absent
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"
@@ -145,7 +145,7 @@
           - not lgw_rt_asso_check_mode.failed
 
     - name: Delete Local Gateway Route Table VPC Association
-      ec2_lgw_route_table_association:
+      community.aws.ec2_lgw_route_table_association:
         state: absent
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"
@@ -157,7 +157,7 @@
           - lgw_rt_asso.changed
 
     - name: Test idempotence deletion
-      ec2_lgw_route_table_association:
+      community.aws.ec2_lgw_route_table_association:
         state: absent
         lgw_route_table_id: "{{ lgw_route_table_id }}"
         vpc_id: "{{ vpc_id }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the community.aws.ec2_lgw_route_table_association module, for managing VPC association on LGW route table. Good for Outposts.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Local Gateway Route Table
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
