### PR TITLE
Increase gp3 throughput limits

### DIFF
--- a/plugins/modules/autoscaling_launch_config.py
+++ b/plugins/modules/autoscaling_launch_config.py
@@ -110,7 +110,7 @@ options:
         type: int
         description:
           - The throughput to provision for a gp3 volume.
-          - Valid Range is a minimum value of 125 and a maximum value of 1000.
+          - Valid Range is a minimum value of 125 and a maximum value of 2000.
         version_added: 3.1.0
       encrypted:
         type: bool


### PR DESCRIPTION
##### SUMMARY

aws inreased **gp3** **IO** and **throughput** limits
[https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-ebs-size-provisioned-performance-gp3-volumes/](https://github.com/ansible-collections/amazon.aws/pull/url)
