### PR TITLE
ec2_describe_instance_types: New Module

### DIFF
--- a/plugins/modules/ec2_describe_instance_types.py
+++ b/plugins/modules/ec2_describe_instance_types.py
@@ -1,0 +1,476 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# ruff: noqa: E402
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: ec2_describe_instance_types
+version_added: 10.1.0
+short_description: Retrieve information about EC2 instance types
+description:
+  - Retrieves detailed information about EC2 instance types.
+  - By default, all instance types for the current region are described.
+  - Can filter results using instance type names or filters.
+  - Does not implement DryRun feature.
+author:
+  - "Jonathan Springer <jps@s390x.com>"
+options:
+    instance_types:
+        description:
+          - List of instance types to describe.
+          - Must be exact instance type names (e.g., C(t3.micro), C(m5.large)).
+          - For wildcard matching, use the I(filters) option with C(instance-type) filter instead.
+          - Maximum of 100 instance types.
+          - If not provided, all instance types are returned.
+        required: false
+        type: list
+        elements: str
+        default: []
+    filters:
+        description:
+          - A list of filters to apply.
+          - Each filter is a dict with I(name) and I(values) keys.
+          - Filter values support wildcards (e.g., C(t3.*) to match all t3 instance types).
+          - See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html)
+            for possible filters.
+          - Filter names and values are case sensitive.
+        required: false
+        type: list
+        elements: dict
+        default: []
+        suboptions:
+            name:
+                description: The name of the filter.
+                type: str
+                required: true
+            values:
+                description: The filter values. Can be a single value or list of values.
+                type: list
+                elements: str
+                required: true
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+# Get information about all instance types
+- ec2_describe_instance_types:
+  register: all_instance_types
+
+# Get information about specific instance types
+- ec2_describe_instance_types:
+    instance_types:
+      - t3.micro
+      - t3.small
+      - t3.medium
+  register: t3_types
+
+# Get all c5 instance types using wildcard filter
+- ec2_describe_instance_types:
+    filters:
+      - name: instance-type
+        values:
+          - "c5.*"
+  register: c5_types
+
+# Filter for current generation instance types with GPU
+- ec2_describe_instance_types:
+    filters:
+      - name: current-generation
+        values:
+          - "true"
+      - name: instance-type
+        values:
+          - "p3.*"
+  register: gpu_types
+
+# Filter for bare metal instance types
+- ec2_describe_instance_types:
+    filters:
+      - name: bare-metal
+        values:
+          - "true"
+  register: bare_metal_types
+
+# Filter by processor architecture
+- ec2_describe_instance_types:
+    filters:
+      - name: processor-info.supported-architecture
+        values:
+          - arm64
+  register: arm_types
+
+# Filter for free tier eligible instances
+- ec2_describe_instance_types:
+    filters:
+      - name: free-tier-eligible
+        values:
+          - "true"
+  register: free_tier_types
+
+# Combine multiple filters (m5 family with 4 vCPUs)
+- ec2_describe_instance_types:
+    filters:
+      - name: instance-type
+        values:
+          - "m5.*"
+      - name: vcpu-info.default-vcpus
+        values:
+          - "4"
+  register: m5_4vcpu_types
+
+# Filter with multiple values
+- ec2_describe_instance_types:
+    filters:
+      - name: processor-info.supported-architecture
+        values:
+          - arm64
+          - x86_64
+  register: multi_arch_types
+
+# Combine specific instance types with filters
+- ec2_describe_instance_types:
+    instance_types:
+      - t3.micro
+      - t3.small
+      - t3.medium
+    filters:
+      - name: processor-info.supported-architecture
+        values:
+          - x86_64
+  register: filtered_t3_types
+"""
+
+RETURN = r"""
+instance_types:
+    description: List of instance type information objects.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        instance_type:
+            description: The instance type identifier.
+            returned: always
+            type: str
+            sample: "t3.micro"
+        current_generation:
+            description: Whether the instance type is current generation.
+            returned: always
+            type: bool
+        free_tier_eligible:
+            description: Whether the instance type is eligible for the free tier.
+            returned: always
+            type: bool
+        supported_usage_classes:
+            description: Usage classes supported (on-demand, spot, capacity-block).
+            returned: always
+            type: list
+            elements: str
+        supported_root_device_types:
+            description: Supported root device types (ebs, instance-store).
+            returned: always
+            type: list
+            elements: str
+        supported_virtualization_types:
+            description: Supported virtualization types (hvm, paravirtual).
+            returned: always
+            type: list
+            elements: str
+        bare_metal:
+            description: Whether this is a bare metal instance type.
+            returned: always
+            type: bool
+        hypervisor:
+            description: The hypervisor type (nitro, xen).
+            returned: when available
+            type: str
+        processor_info:
+            description: Processor information.
+            returned: always
+            type: dict
+            contains:
+                supported_architectures:
+                    description: Supported CPU architectures.
+                    type: list
+                    elements: str
+                sustained_clock_speed_in_ghz:
+                    description: Sustained clock speed in GHz.
+                    type: float
+        v_cpu_info:
+            description: vCPU information.
+            returned: always
+            type: dict
+            contains:
+                default_v_cpus:
+                    description: Default number of vCPUs.
+                    type: int
+                default_cores:
+                    description: Default number of cores.
+                    type: int
+                default_threads_per_core:
+                    description: Default threads per core.
+                    type: int
+                valid_cores:
+                    description: List of valid core counts.
+                    type: list
+                    elements: int
+                valid_threads_per_core:
+                    description: List of valid thread per core counts.
+                    type: list
+                    elements: int
+        memory_info:
+            description: Memory information.
+            returned: always
+            type: dict
+            contains:
+                size_in_mi_b:
+                    description: Memory size in MiB.
+                    type: int
+        instance_storage_supported:
+            description: Whether instance storage is supported.
+            returned: always
+            type: bool
+        instance_storage_info:
+            description: Instance storage information.
+            returned: when instance_storage_supported is true
+            type: dict
+            contains:
+                total_size_in_g_b:
+                    description: Total instance storage size in GB.
+                    type: int
+                disks:
+                    description: List of instance storage disks.
+                    type: list
+                    elements: dict
+                nvme_support:
+                    description: NVMe support status.
+                    type: str
+                encryption_support:
+                    description: Encryption support status.
+                    type: str
+        ebs_info:
+            description: EBS information.
+            returned: always
+            type: dict
+            contains:
+                ebs_optimized_support:
+                    description: EBS optimized support status.
+                    type: str
+                encryption_support:
+                    description: EBS encryption support status.
+                    type: str
+                ebs_optimized_info:
+                    description: EBS optimized performance info.
+                    type: dict
+                nvme_support:
+                    description: NVMe support status.
+                    type: str
+        network_info:
+            description: Network information.
+            returned: always
+            type: dict
+            contains:
+                network_performance:
+                    description: Network performance description.
+                    type: str
+                maximum_network_interfaces:
+                    description: Maximum number of network interfaces.
+                    type: int
+                maximum_network_cards:
+                    description: Maximum number of network cards.
+                    type: int
+                ipv4_addresses_per_interface:
+                    description: Maximum IPv4 addresses per interface.
+                    type: int
+                ipv6_addresses_per_interface:
+                    description: Maximum IPv6 addresses per interface.
+                    type: int
+                ipv6_supported:
+                    description: Whether IPv6 is supported.
+                    type: bool
+                ena_support:
+                    description: ENA support status.
+                    type: str
+                efa_supported:
+                    description: Whether EFA is supported.
+                    type: bool
+                encryption_in_transit_supported:
+                    description: Whether encryption in transit is supported.
+                    type: bool
+        gpu_info:
+            description: GPU information.
+            returned: when GPU is available
+            type: dict
+            contains:
+                gpus:
+                    description: List of GPU devices.
+                    type: list
+                    elements: dict
+                total_gpu_memory_in_mi_b:
+                    description: Total GPU memory in MiB.
+                    type: int
+        fpga_info:
+            description: FPGA information.
+            returned: when FPGA is available
+            type: dict
+        inference_accelerator_info:
+            description: Inference accelerator information.
+            returned: when inference accelerators are available
+            type: dict
+        placement_group_info:
+            description: Placement group information.
+            returned: always
+            type: dict
+            contains:
+                supported_strategies:
+                    description: Supported placement strategies.
+                    type: list
+                    elements: str
+        hibernation_supported:
+            description: Whether hibernation is supported.
+            returned: always
+            type: bool
+        burstable_performance_supported:
+            description: Whether burstable performance is supported.
+            returned: always
+            type: bool
+        dedicated_hosts_supported:
+            description: Whether dedicated hosts are supported.
+            returned: always
+            type: bool
+        auto_recovery_supported:
+            description: Whether auto recovery is supported.
+            returned: always
+            type: bool
+        supported_boot_modes:
+            description: Supported boot modes (legacy-bios, uefi).
+            returned: always
+            type: list
+            elements: str
+        nitro_enclaves_support:
+            description: Nitro Enclaves support status.
+            returned: when available
+            type: str
+        nitro_tpm_support:
+            description: NitroTPM support status.
+            returned: when available
+            type: str
+        nitro_tpm_info:
+            description: NitroTPM information.
+            returned: when NitroTPM is supported
+            type: dict
+"""
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.community.aws.plugins.module_utils.modules import (
+    AnsibleCommunityAWSModule as AnsibleAWSModule,
+)
+
+
+def ansible_filters_to_boto3_filters(filters_list):
+    """Convert an Ansible filter list to boto3 filter format.
+
+    Args:
+        filters_list: List of dicts with 'name' and 'values' keys.
+
+    Returns:
+        List of dicts in boto3 filter format: [{'Name': name, 'Values': [values]}]
+    """
+    if not filters_list:
+        return None
+    return [{"Name": f["name"], "Values": f["values"]} for f in filters_list]
+
+
+class EC2InstanceTypesManager:
+    """Handles EC2 instance types information retrieval"""
+
+    def __init__(self, module):
+        self.module = module
+        self.ec2 = module.client("ec2")
+
+    def describe_instance_types(self, instance_types=None, filters=None):
+        """Describe EC2 instance types with optional filtering.
+
+        Args:
+            instance_types: Optional list of instance type names
+            filters: Optional list of boto3 filters
+
+        Returns:
+            List of instance type info dictionaries
+        """
+        params = {}
+
+        if instance_types:
+            params["InstanceTypes"] = instance_types
+
+        if filters:
+            params["Filters"] = filters
+
+        try:
+            results = []
+            paginator = self.ec2.get_paginator("describe_instance_types")
+            for page in paginator.paginate(**params):
+                results.extend(page.get("InstanceTypes", []))
+            return results
+        except botocore.exceptions.ClientError as e:
+            self.module.fail_json_aws(e, msg="Failed to describe instance types")
+        except botocore.exceptions.BotoCoreError as e:
+            self.module.fail_json_aws(e, msg="Failed to describe instance types")
+
+
+def main():
+    argument_spec = dict(
+        instance_types=dict(required=False, type="list", elements="str", default=[]),
+        filters=dict(
+            required=False,
+            type="list",
+            elements="dict",
+            default=[],
+            options=dict(
+                name=dict(required=True, type="str"),
+                values=dict(required=True, type="list", elements="str"),
+            ),
+        ),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    instance_types = module.params["instance_types"]
+    filters_list = module.params["filters"]
+
+    # Convert filters list to boto3 format
+    filters = ansible_filters_to_boto3_filters(filters_list)
+
+    manager = EC2InstanceTypesManager(module)
+
+    # Get instance type information
+    raw_results = manager.describe_instance_types(
+        instance_types=instance_types if instance_types else None,
+        filters=filters,
+    )
+
+    # Convert keys to snake_case for Ansible convention
+    instance_type_list = [camel_dict_to_snake_dict(item) for item in raw_results]
+
+    module.exit_json(
+        changed=False,
+        instance_types=instance_type_list,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ec2_describe_instance_types/aliases
+++ b/tests/integration/targets/ec2_describe_instance_types/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+
+ec2_describe_instance_types

--- a/tests/integration/targets/ec2_describe_instance_types/meta/main.yml
+++ b/tests/integration/targets/ec2_describe_instance_types/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ec2_describe_instance_types/tasks/main.yml
+++ b/tests/integration/targets/ec2_describe_instance_types/tasks/main.yml
@@ -1,0 +1,274 @@
+---
+- name: 'ec2_describe_instance_types integration tests'
+  collections:
+    - amazon.aws
+    - community.aws
+  module_defaults:
+    group/aws:
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
+    community.aws.ec2_describe_instance_types:
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
+
+  block:
+    # ============================================================
+    # Basic functionality tests
+    # ============================================================
+
+    - name: Get information about a specific instance type
+      ec2_describe_instance_types:
+        instance_types:
+          - t3.micro
+      register: specific_result
+
+    - name: Verify specific instance type result
+      assert:
+        that:
+          - specific_result is success
+          - specific_result is not changed
+          - specific_result.instance_types | length == 1
+          - specific_result.instance_types[0].instance_type == 't3.micro'
+          - "'current_generation' in specific_result.instance_types[0]"
+          - "'free_tier_eligible' in specific_result.instance_types[0]"
+          - "'v_cpu_info' in specific_result.instance_types[0]"
+          - "'memory_info' in specific_result.instance_types[0]"
+          - "'processor_info' in specific_result.instance_types[0]"
+          - "'network_info' in specific_result.instance_types[0]"
+
+    - name: Verify t3.micro is current generation
+      assert:
+        that:
+          - specific_result.instance_types[0].current_generation == true
+
+    # ============================================================
+    # Multiple instance types
+    # ============================================================
+
+    - name: Get information about multiple specific instance types
+      ec2_describe_instance_types:
+        instance_types:
+          - t3.micro
+          - t3.small
+          - t3.medium
+      register: multiple_result
+
+    - name: Verify multiple instance types result
+      assert:
+        that:
+          - multiple_result is success
+          - multiple_result is not changed
+          - multiple_result.instance_types | length == 3
+          - "'t3.micro' in (multiple_result.instance_types | map(attribute='instance_type') | list)"
+          - "'t3.small' in (multiple_result.instance_types | map(attribute='instance_type') | list)"
+          - "'t3.medium' in (multiple_result.instance_types | map(attribute='instance_type') | list)"
+
+    # ============================================================
+    # Wildcard pattern tests (using filters)
+    # ============================================================
+
+    - name: Get instance types using wildcard pattern via filter
+      ec2_describe_instance_types:
+        filters:
+          - name: instance-type
+            values:
+              - "t3.*"
+      register: wildcard_result
+
+    - name: Verify wildcard results contain t3 family instances
+      assert:
+        that:
+          - wildcard_result is success
+          - wildcard_result is not changed
+          - wildcard_result.instance_types | length >= 1
+          - wildcard_result.instance_types | map(attribute='instance_type') | select('match', '^t3\\.') | list | length == wildcard_result.instance_types | length
+
+    # ============================================================
+    # Filter tests
+    # ============================================================
+
+    - name: Filter for free tier eligible instances
+      ec2_describe_instance_types:
+        filters:
+          - name: free-tier-eligible
+            values:
+              - "true"
+      register: free_tier_result
+
+    - name: Verify free tier results
+      assert:
+        that:
+          - free_tier_result is success
+          - free_tier_result is not changed
+          - free_tier_result.instance_types | length >= 1
+          - free_tier_result.instance_types | selectattr('free_tier_eligible', 'equalto', true) | list | length == free_tier_result.instance_types | length
+
+    - name: Filter by processor architecture (x86_64)
+      ec2_describe_instance_types:
+        instance_types:
+          - t3.micro
+        filters:
+          - name: processor-info.supported-architecture
+            values:
+              - x86_64
+      register: arch_filter_result
+
+    - name: Verify architecture filter results
+      assert:
+        that:
+          - arch_filter_result is success
+          - arch_filter_result is not changed
+          - arch_filter_result.instance_types | length >= 1
+          - "'x86_64' in arch_filter_result.instance_types[0].processor_info.supported_architectures"
+
+    - name: Filter for current generation instances
+      ec2_describe_instance_types:
+        filters:
+          - name: current-generation
+            values:
+              - "true"
+          - name: instance-type
+            values:
+              - "t3.micro"
+      register: current_gen_result
+
+    - name: Verify current generation filter results
+      assert:
+        that:
+          - current_gen_result is success
+          - current_gen_result is not changed
+          - current_gen_result.instance_types | length == 1
+          - current_gen_result.instance_types[0].current_generation == true
+
+    # ============================================================
+    # Combined filters
+    # ============================================================
+
+    - name: Combine multiple filters
+      ec2_describe_instance_types:
+        filters:
+          - name: instance-type
+            values:
+              - "m5.*"
+          - name: vcpu-info.default-vcpus
+            values:
+              - "4"
+      register: combined_result
+
+    - name: Verify combined results
+      assert:
+        that:
+          - combined_result is success
+          - combined_result is not changed
+          - combined_result.instance_types | length >= 1
+          - combined_result.instance_types | map(attribute='instance_type') | select('match', '^m5\\.') | list | length == combined_result.instance_types | length
+          - combined_result.instance_types | selectattr('v_cpu_info.default_v_cpus', 'equalto', 4) | list | length == combined_result.instance_types | length
+
+    # ============================================================
+    # Check mode tests
+    # ============================================================
+
+    - name: Test check mode - get specific instance type
+      ec2_describe_instance_types:
+        instance_types:
+          - t3.micro
+      register: check_mode_result
+      check_mode: true
+
+    - name: Verify check mode result
+      assert:
+        that:
+          - check_mode_result is success
+          - check_mode_result is not changed
+          - check_mode_result.instance_types | length == 1
+          - check_mode_result.instance_types[0].instance_type == 't3.micro'
+
+    # ============================================================
+    # Return value structure validation
+    # ============================================================
+
+    - name: Validate return structure for a known instance type
+      ec2_describe_instance_types:
+        instance_types:
+          - t3.micro
+      register: structure_result
+
+    - name: Verify return structure contains expected fields
+      vars:
+        instance_info: "{{ structure_result.instance_types[0] }}"
+      assert:
+        that:
+          - "'instance_type' in instance_info"
+          - "'current_generation' in instance_info"
+          - "'free_tier_eligible' in instance_info"
+          - "'supported_usage_classes' in instance_info"
+          - "'supported_root_device_types' in instance_info"
+          - "'supported_virtualization_types' in instance_info"
+          - "'bare_metal' in instance_info"
+          - "'processor_info' in instance_info"
+          - "'v_cpu_info' in instance_info"
+          - "'memory_info' in instance_info"
+          - "'ebs_info' in instance_info"
+          - "'network_info' in instance_info"
+          - "'placement_group_info' in instance_info"
+          - "'hibernation_supported' in instance_info"
+          - "'burstable_performance_supported' in instance_info"
+          - "'dedicated_hosts_supported' in instance_info"
+          - "'auto_recovery_supported' in instance_info"
+          - "'supported_boot_modes' in instance_info"
+
+    - name: Verify nested structure - processor_info
+      vars:
+        proc_info: "{{ structure_result.instance_types[0].processor_info }}"
+      assert:
+        that:
+          - "'supported_architectures' in proc_info"
+          - proc_info.supported_architectures | type_debug == 'list'
+
+    - name: Verify nested structure - v_cpu_info
+      vars:
+        vcpu: "{{ structure_result.instance_types[0].v_cpu_info }}"
+      assert:
+        that:
+          - "'default_v_cpus' in vcpu"
+          - "'default_cores' in vcpu"
+          - "'default_threads_per_core' in vcpu"
+
+    - name: Verify nested structure - memory_info
+      vars:
+        mem: "{{ structure_result.instance_types[0].memory_info }}"
+      assert:
+        that:
+          - "'size_in_mi_b' in mem"
+          - mem.size_in_mi_b | int > 0
+
+    - name: Verify nested structure - network_info
+      vars:
+        net: "{{ structure_result.instance_types[0].network_info }}"
+      assert:
+        that:
+          - "'network_performance' in net"
+          - "'maximum_network_interfaces' in net"
+          - "'ipv4_addresses_per_interface' in net"
+          - "'ipv6_supported' in net"
+
+    # ============================================================
+    # Invalid instance type test
+    # ============================================================
+
+    - name: Test with non-existent instance type (should fail)
+      ec2_describe_instance_types:
+        instance_types:
+          - nonexistent.type.xyz
+      register: invalid_result
+      ignore_errors: true
+
+    - name: Verify error result for non-existent type
+      assert:
+        that:
+          - invalid_result is failed
+          - invalid_result.error.code == 'InvalidInstanceType'


### PR DESCRIPTION
## Summary

- Adds new `ec2_describe_instance_types` module to retrieve detailed information about EC2 instance types
- Supports filtering by specific instance type names or using AWS filters (including wildcards via `instance-type` filter)
- Uses standard `camel_dict_to_snake_dict` for consistent snake_case field naming
- Includes comprehensive integration tests

## Features

- Query specific instance types by exact name (e.g., `t3.micro`, `m5.large`)
- Filter using AWS DescribeInstanceTypes filters (e.g., `free-tier-eligible`, `processor-info.supported-architecture`)
- Wildcard support via filters (e.g., `instance-type: "t3.*"`)
- Returns detailed instance type information including vCPU, memory, network, storage, and GPU info
- Supports check mode

## Test plan

- [x] Integration tests created covering:
  - Basic instance type queries
  - Multiple instance types
  - Wildcard pattern matching via filters
  - Free tier and architecture filters
  - Combined multiple filters
  - Check mode
  - Return value structure validation
  - Invalid instance type error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)