### PR TITLE
Bugfix StackId KeyError in cloudformation_stack_set

### DIFF
--- a/changelogs/fragments/cloudformation_stack_set-stackid-keyerror.yaml
+++ b/changelogs/fragments/cloudformation_stack_set-stackid-keyerror.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cloudformation_stack_set - fix KeyError when StackId field is not present in stack instance responses (https://github.com/ansible-collections/community.aws/pull/2359).

--- a/plugins/modules/cloudformation_stack_set.py
+++ b/plugins/modules/cloudformation_stack_set.py
@@ -459,8 +459,8 @@ def await_stack_instance_completion(module, cfn, stack_set_name, max_wait):
         time.sleep(15)
 
     module.warn(
-        f"Timed out waiting for stack set {stack_set_name} instances {', '.join(s['StackId'] for s in to_await)} to"
-        f" complete after {max_wait} seconds. Returning unfinished operation"
+        f"Timed out waiting for stack set {stack_set_name} instances {', '.join(s.get('StackId', s['StackSetId'].split(':')[1]) for s in to_await)}"
+        f" to complete after {max_wait} seconds. Returning unfinished operation"
     )
 
 


### PR DESCRIPTION
##### SUMMARY
Fixed KeyError in cloudformation_stack_set module when handling suspended AWS accounts. The module attempted to access 'StackId' field which doesn't exist in stack instance responses for suspended accounts. The fix uses 'StackSetId' as a fallback to extract the stack identifier.

Fixes #2358 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudformation_stack_set

##### ADDITIONAL INFORMATION
When a stack set contains instances in suspended AWS accounts, the AWS API returns stack instance data with status "SKIPPED_SUSPENDED_ACCOUNT" but omits the 'StackId' field. This caused a KeyError when the module attempted to generate timeout warning messages.

**Reproduction:**
1. Create a stack set with instances across multiple accounts
2. Suspend one of the AWS accounts
3. Run stack set update operation with wait enabled
4. Module crashes with KeyError: 'StackId' when timeout occurs

**Example payload from suspended account:**
json
{
 "StackSetId": "Stack-Set-Name:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
 "Region": "ap-southeast-2",
 "Account": "xxxxxxxxxxxx",
 "Status": "OUTDATED",
 "StatusReason": "This account is suspended. To remove this instance from the stack set, run DeleteStackInstances with the RetainStacks parameter.",
 "StackInstanceStatus": {
   "DetailedStatus": "SKIPPED_SUSPENDED_ACCOUNT"
 },
 "OrganizationalUnitId": "",
 "DriftStatus": "NOT_CHECKED",
 "LastOperationId": "Ansible-StackSet-Update-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
}

**Fix:**
Changed line 462 to use `.get('StackId', s['StackSetId'].split(':')[1])` which extracts the UUID from StackSetId when StackId is unavailable.
