### PR TITLE
tox: update supported Ansible versions in tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@
 skipsdist = True
 skip_missing_interpreters = True
 envlist =
-    ansible{2.15}-py{39,310,311}-{with_constraints,without_constraints}
-    ansible{2.16,2.17}-py{310,311,312}-{with_constraints,without_constraints}
-    ansible{2.18}-py{311,312,313}-{with_constraints,without_constraints}
+    ansible{2.17}-py{310,311,312}-{with_constraints,without_constraints}
+    ansible{2.18,2.19}-py{311,312,313}-{with_constraints,without_constraints}
+    ansible{2.17}-py{312,313,314}-{with_constraints,without_constraints}
 
 [common]
 collection_name = community.aws
@@ -16,10 +16,10 @@ format_dirs = {toxinidir}/plugins {toxinidir}/tests
 lint_dirs = {toxinidir}/plugins {toxinidir}/tests
 
 ansible_desc =
-    ansible2.15: Ansible-core 2.15
-    ansible2.16: Ansible-core 2.16
     ansible2.17: Ansible-core 2.17
     ansible2.18: Ansible-core 2.18
+    ansible2.19: Ansible-core 2.19
+    ansible2.20: Ansible-core 2.20
 const_desc =
     with_constraints: (With boto3/botocore constraints)
 
@@ -46,10 +46,10 @@ deps =
   pytest-xdist
   -rtest-requirements.txt
   -rtests/unit/requirements.txt
-  ansible2.15: ansible-core>2.15,<2.16
-  ansible2.16: ansible-core>2.16,<2.17
   ansible2.17: ansible-core>2.17,<2.18
   ansible2.18: ansible-core>2.18,<2.19
+  ansible2.19: ansible-core>2.19,<2.20
+  ansible2.20: ansible-core>2.20,<2.21
   with_constraints: -rtests/unit/constraints.txt
 allowlist_externals = rsync
 change_dir = {[common]full_collection_path}


### PR DESCRIPTION
##### SUMMARY

Updated tox configuration to support newer Ansible versions:
- Removed support for ansible-core 2.15 and 2.16 (EOL)
- Added support for ansible-core 2.19 and 2.20
- Adjusted Python version matrix accordingly

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tox.ini

##### ADDITIONAL INFORMATION

Commit message generated by Claude
