### PR TITLE
bugfix: autoscaling_policy - allow float for StepScaling bounds (#2355)

### DIFF
--- a/changelogs/fragments/2355-float-stepscaling-bounds.yml
+++ b/changelogs/fragments/2355-float-stepscaling-bounds.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - autoscaling_policy - allow float type for step_adjustments lower_bound and upper_bound parameters (https://github.com/ansible-collections/community.aws/issues/2355)

--- a/plugins/modules/autoscaling_policy.py
+++ b/plugins/modules/autoscaling_policy.py
@@ -94,12 +94,12 @@ options:
     elements: dict
     suboptions:
       lower_bound:
-        type: int
+        type: float
         description:
           - The lower bound for the difference between the alarm threshold and
             the CloudWatch metric.
       upper_bound:
-        type: int
+        type: float
         description:
           - The upper bound for the difference between the alarm threshold and
             the CloudWatch metric.
@@ -549,7 +549,7 @@ def delete_scaling_policy(connection, module):
 
 def main():
     step_adjustment_spec = dict(
-        lower_bound=dict(type="int"), upper_bound=dict(type="int"), scaling_adjustment=dict(type="int", required=True)
+        lower_bound=dict(type="float"), upper_bound=dict(type="float"), scaling_adjustment=dict(type="int", required=True)
     )
 
     predefined_metric_spec = dict(


### PR DESCRIPTION
SUMMARY
Fixes #2355

This bugfix corrects a type validation issue in the autoscaling_policy module where step_adjustments parameters lower_bound and upper_bound incorrectly enforced integer types. The AWS API and console support float values for these parameters in Step Scaling policies. This change updates the argument specification and documentation to accept float type, allowing users to define valid scaling windows like lower_bound: 0.10 and upper_bound: 0.85.

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
autoscaling_policy
