### PR TITLE
WIP: Fix sanity test failures - bad-return-value-keys

### DIFF
--- a/changelogs/fragments/fix-bad-return-value-keys.yml
+++ b/changelogs/fragments/fix-bad-return-value-keys.yml
@@ -1,0 +1,6 @@
+---
+deprecated_features:
+  - cloudfront_distribution - the ``items`` key in the ``active_trusted_signers`` return value has been deprecated  in favor of ``key_pair_ids`` for Jinja2 compatibility. The ``items`` key will be removed in a release after 2026-12-01 (<pr>)
+
+minor_changes:
+  - cloudfront_distribution - added ``key_pair_ids`` key to ``active_trusted_signers`` return value that can be accessed using Jinja2 dot notation (<pr>)

--- a/plugins/modules/cloudfront_distribution.py
+++ b/plugins/modules/cloudfront_distribution.py
@@ -740,8 +740,16 @@ active_trusted_signers:
       returned: always
       type: int
       sample: 1
+    key_pair_ids:
+      description: List of trusted signers.
+      returned: when there are trusted signers
+      type: list
+      sample:
+      - key_pair_id
     items:
-      description: Number of trusted signers.
+      description:
+        - List of trusted signers.
+        - This return value has been deprecated and will be removed in a release after 2026-12-01. Use RV(active_trusted_signers.key_pair_ids) instead.
       returned: when there are trusted signers
       type: list
       sample:
@@ -2574,6 +2582,16 @@ def main():
     if "distribution_config" in result:
         result.update(result["distribution_config"])
         del result["distribution_config"]
+
+    # Handle deprecation of the items key for Jinja2 compatibility
+    if "items" in result.get("active_trusted_signers", {}):
+        module.deprecate(
+            "The 'items' key in the 'active_trusted_signers' return value has been deprecated. "
+            "Use 'key_pair_ids' instead.",
+            date="2026-12-01",
+            collection_name="community.aws",
+        )
+        result["active_trusted_signers"]["key_pair_ids"] = result["active_trusted_signers"]["items"]
 
     module.exit_json(changed=changed, **result)
 

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-plugins/inventory/aws_mq.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,1 @@
+plugins/modules/cloudfront_distribution.py validate-modules:bad-return-value-key # deprecated `items` keys kept for backward compatibility until 2026-12-01


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
🚧 WIP 
Deprecates the `items` key in several return values in cloudfront_distribution.py and replaces it with a key value compatible with Jinja2 dot notation. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible-collections/community.aws/issues/2378

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

