### PR TITLE
Add managed prefix lists modules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -103,6 +103,8 @@ action_groups:
     - ec2_metric_alarm
     - ec2_scaling_policy
     - ec2_snapshot_copy
+    - ec2_vpc_managed_prefix_list
+    - ec2_vpc_managed_prefix_list_info
     - ec2_win_password
     - ecs_attribute
     - ecs_cluster

--- a/plugins/modules/ec2_vpc_managed_prefix_list.py
+++ b/plugins/modules/ec2_vpc_managed_prefix_list.py
@@ -1,0 +1,461 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: ec2_vpc_managed_prefix_list
+version_added: 11.1.0
+short_description: Manage AWS EC2 Managed Prefix Lists
+description:
+  - Create, update, and delete AWS EC2 Managed Prefix Lists.
+  - Supports idempotent operations and check mode.
+notes:
+  - The I(address_family) of a prefix list cannot be changed after creation.
+author:
+  - Andrii Savchenko (@Ptico)
+options:
+  state:
+    description:
+      - Whether the prefix list should be present or absent.
+    choices: ['present', 'absent']
+    default: present
+    type: str
+  name:
+    description:
+      - The name of the prefix list.
+      - Required when I(state=present) and I(prefix_list_id) is not provided.
+      - One of I(name) or I(prefix_list_id) is required.
+    type: str
+  prefix_list_id:
+    description:
+      - The ID of the prefix list.
+      - One of I(name) or I(prefix_list_id) is required.
+    type: str
+  entries:
+    description:
+      - A list of CIDR entries for the prefix list.
+      - If not specified, entries will not be modified.
+    type: list
+    elements: dict
+    suboptions:
+      cidr:
+        description:
+          - The CIDR block.
+        type: str
+        required: true
+      description:
+        description:
+          - A description for the CIDR block.
+        type: str
+        default: ""
+  max_entries:
+    description:
+      - The maximum number of entries for the prefix list.
+      - Required when I(state=present).
+    type: int
+  address_family:
+    description:
+      - The IP address family (IPv4 or IPv6).
+      - Cannot be changed after the prefix list is created.
+    choices: ['IPv4', 'IPv6']
+    default: IPv4
+    type: str
+  purge_entries:
+    description:
+      - If C(true), entries not present in I(entries) will be removed.
+      - Has no effect when I(entries) is not specified.
+    type: bool
+    default: true
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.tags
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+- name: Create a prefix list
+  community.aws.ec2_vpc_managed_prefix_list:
+    state: present
+    name: my-prefix-list
+    address_family: IPv4
+    max_entries: 10
+    entries:
+      - cidr: 10.0.0.0/24
+        description: My subnet
+  register: prefix_list
+
+- name: Create a prefix list with tags
+  community.aws.ec2_vpc_managed_prefix_list:
+    state: present
+    name: my-prefix-list
+    address_family: IPv4
+    max_entries: 10
+    tags:
+      Environment: production
+      Owner: networking-team
+  register: prefix_list
+
+- name: Update entries in a prefix list
+  community.aws.ec2_vpc_managed_prefix_list:
+    state: present
+    name: my-prefix-list
+    max_entries: 10
+    entries:
+      - cidr: 10.0.0.0/24
+        description: My subnet
+      - cidr: 10.1.0.0/24
+        description: My other subnet
+
+- name: Add entries without removing existing ones
+  community.aws.ec2_vpc_managed_prefix_list:
+    state: present
+    prefix_list_id: pl-0a1b2c3d4e5f6789a
+    max_entries: 10
+    entries:
+      - cidr: 10.2.0.0/24
+        description: New subnet
+    purge_entries: false
+
+- name: Delete a prefix list by ID
+  community.aws.ec2_vpc_managed_prefix_list:
+    state: absent
+    prefix_list_id: pl-0a1b2c3d4e5f6789a
+
+- name: Delete a prefix list by name
+  community.aws.ec2_vpc_managed_prefix_list:
+    state: absent
+    name: my-prefix-list
+"""
+
+RETURN = r"""
+changed:
+  description: Whether any changes were made.
+  type: bool
+  returned: always
+prefix_list_id:
+  description: The ID of the prefix list.
+  type: str
+  returned: I(state=present)
+  sample: "pl-0a1b2c3d4e5f6789a"
+prefix_list:
+  description: The prefix list resource details.
+  type: dict
+  returned: I(state=present)
+  contains:
+    prefix_list_id:
+      description: The ID of the prefix list.
+      type: str
+      sample: "pl-0a1b2c3d4e5f6789a"
+    prefix_list_arn:
+      description: The ARN of the prefix list.
+      type: str
+      sample: "arn:aws:ec2:us-east-1:123456789012:prefix-list/pl-0a1b2c3d4e5f6789a"
+    prefix_list_name:
+      description: The name of the prefix list.
+      type: str
+      sample: "my-prefix-list"
+    address_family:
+      description: The IP address family.
+      type: str
+      sample: "IPv4"
+    max_entries:
+      description: The maximum number of entries allowed.
+      type: int
+      sample: 10
+    state:
+      description: The current state of the prefix list.
+      type: str
+      sample: "create-complete"
+    version:
+      description: The version of the prefix list.
+      type: int
+      sample: 1
+    tags:
+      description: Tags applied to the prefix list.
+      type: dict
+      sample: {"Environment": "production"}
+    entries:
+      description: The current entries in the prefix list.
+      type: list
+      elements: dict
+      contains:
+        cidr:
+          description: The CIDR block.
+          type: str
+          sample: "10.0.0.0/24"
+        description:
+          description: Description of the CIDR block.
+          type: str
+          sample: "My subnet"
+"""
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ensure_ec2_tags
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
+
+from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+
+
+def get_prefix_list(client, module):
+    """Look up an existing prefix list by ID or name."""
+    prefix_list_id = module.params.get("prefix_list_id")
+    prefix_list_name = module.params.get("name")
+
+    params = dict(aws_retry=True)
+
+    if prefix_list_id:
+        params["PrefixListIds"] = [prefix_list_id]
+    elif prefix_list_name:
+        params["Filters"] = [{"Name": "prefix-list-name", "Values": [prefix_list_name]}]
+
+    try:
+        response = client.describe_managed_prefix_lists(**params)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to describe managed prefix lists")
+
+    if response["PrefixLists"]:
+        return response["PrefixLists"][0]
+    return None
+
+
+def get_prefix_list_entries(client, module, prefix_list_id):
+    """Retrieve the current entries for a prefix list."""
+    try:
+        return client.get_managed_prefix_list_entries(
+            aws_retry=True,
+            PrefixListId=prefix_list_id,
+        )["Entries"]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg=f"Failed to get entries for prefix list {prefix_list_id}")
+
+
+def create_prefix_list(client, module):
+    """Create a new managed prefix list."""
+    params = dict(
+        PrefixListName=module.params.get("name"),
+        MaxEntries=module.params.get("max_entries"),
+        AddressFamily=module.params.get("address_family"),
+    )
+
+    if module.params.get("entries"):
+        params["Entries"] = [
+            {"Cidr": e["cidr"], "Description": e.get("description") or ""}
+            for e in module.params.get("entries")
+        ]
+
+    if module.params.get("tags") is not None:
+        params["TagSpecifications"] = boto3_tag_specifications(
+            module.params.get("tags"), types="prefix-list"
+        )
+
+    try:
+        pl = client.create_managed_prefix_list(**params)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to create prefix list")
+
+    return pl["PrefixList"]
+
+
+def update_prefix_list(prefix_list, client, module):
+    """Update an existing prefix list's name, max_entries, and/or entries."""
+    prefix_list_id = prefix_list.get("PrefixListId")
+    changed = False
+
+    params = dict(
+        PrefixListId=prefix_list_id,
+        CurrentVersion=prefix_list.get("Version"),
+    )
+
+    if module.params.get("name") and module.params.get("name") != prefix_list.get("PrefixListName"):
+        params["PrefixListName"] = module.params.get("name")
+        changed = True
+
+    if (
+        module.params.get("max_entries") is not None
+        and module.params.get("max_entries") != prefix_list.get("MaxEntries")
+    ):
+        params["MaxEntries"] = module.params.get("max_entries")
+        changed = True
+
+    # Address family cannot be changed after creation
+    if (
+        module.params.get("address_family")
+        and module.params.get("address_family") != prefix_list.get("AddressFamily")
+    ):
+        module.fail_json(
+            msg=(
+                f"Cannot change address_family of an existing prefix list {prefix_list_id}. "
+                f"Current: {prefix_list.get('AddressFamily')}, "
+                f"Requested: {module.params.get('address_family')}"
+            )
+        )
+
+    # Compute entry changes only when entries are specified
+    if module.params.get("entries") is not None:
+        new_entries = module.params.get("entries")
+        existing_entries = get_prefix_list_entries(client, module, prefix_list_id)
+        purge_entries = module.params.get("purge_entries")
+
+        add_entries = []
+        remove_entries = []
+
+        new_dict = {item["cidr"]: item.get("description") or "" for item in new_entries}
+        existing_dict = {item["Cidr"]: item.get("Description") or "" for item in existing_entries}
+
+        for cidr, desc in new_dict.items():
+            if cidr not in existing_dict:
+                add_entries.append({"Cidr": cidr, "Description": desc})
+            elif desc != existing_dict[cidr]:
+                add_entries.append({"Cidr": cidr, "Description": desc})
+                remove_entries.append({"Cidr": cidr})
+
+        for cidr in existing_dict:
+            if cidr not in new_dict and purge_entries:
+                remove_entries.append({"Cidr": cidr})
+
+        if add_entries:
+            params["AddEntries"] = add_entries
+            changed = True
+        if remove_entries:
+            params["RemoveEntries"] = remove_entries
+            changed = True
+
+    if not changed:
+        return prefix_list, False
+
+    if module.check_mode:
+        return prefix_list, True
+
+    try:
+        prefix_list = client.modify_managed_prefix_list(**params)["PrefixList"]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg=f"Failed to modify prefix list {prefix_list_id}")
+
+    return prefix_list, True
+
+
+def delete_prefix_list(prefix_list, client, module):
+    """Delete an existing managed prefix list."""
+    prefix_list_id = prefix_list["PrefixListId"]
+
+    if module.check_mode:
+        return
+
+    try:
+        client.delete_managed_prefix_list(
+            aws_retry=True,
+            PrefixListId=prefix_list_id,
+        )
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg=f"Failed to delete prefix list {prefix_list_id}")
+
+
+def format_prefix_list(prefix_list, entries):
+    """Convert a boto3 prefix list response to Ansible snake_case format."""
+    result = camel_dict_to_snake_dict(prefix_list, ignore_list=["Tags"])
+    result["tags"] = boto3_tag_list_to_ansible_dict(prefix_list.get("Tags", []))
+    result["entries"] = [
+        {"cidr": e["Cidr"], "description": e.get("Description") or ""}
+        for e in entries
+    ]
+    return result
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str"),
+        prefix_list_id=dict(type="str"),
+        entries=dict(
+            type="list",
+            elements="dict",
+            options=dict(
+                cidr=dict(type="str", required=True),
+                description=dict(type="str", default=""),
+            ),
+        ),
+        max_entries=dict(type="int"),
+        state=dict(type="str", choices=["present", "absent"], default="present"),
+        address_family=dict(type="str", choices=["IPv4", "IPv6"], default="IPv4"),
+        tags=dict(type="dict", aliases=["resource_tags"]),
+        purge_tags=dict(type="bool", default=True),
+        purge_entries=dict(type="bool", default=True),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[("state", "present", ["max_entries"])],
+        required_one_of=[["name", "prefix_list_id"]],
+        supports_check_mode=True,
+    )
+
+    client = module.client("ec2", retry_decorator=AWSRetry.jittered_backoff())
+
+    prefix_list = get_prefix_list(client, module)
+    state = module.params.get("state")
+    changed = False
+
+    if state == "present":
+        if prefix_list:
+            prefix_list, changed = update_prefix_list(prefix_list, client, module)
+
+            tags_changed = ensure_ec2_tags(
+                client,
+                module,
+                prefix_list["PrefixListId"],
+                resource_type="prefix-list",
+                tags=module.params.get("tags"),
+                purge_tags=module.params.get("purge_tags"),
+                retry_codes="InvalidPrefixListID.NotFound",
+            )
+            changed = changed or tags_changed
+
+            # Re-fetch to reflect any changes (tags, entries, etc.)
+            prefix_list = get_prefix_list(client, module)
+            entries = get_prefix_list_entries(client, module, prefix_list["PrefixListId"])
+            pl_info = format_prefix_list(prefix_list, entries)
+
+            module.exit_json(
+                changed=changed,
+                prefix_list_id=prefix_list["PrefixListId"],
+                prefix_list=pl_info,
+            )
+        else:
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            prefix_list = create_prefix_list(client, module)
+            # Re-fetch to get the full current state
+            prefix_list = get_prefix_list(client, module)
+            entries = get_prefix_list_entries(client, module, prefix_list["PrefixListId"])
+            pl_info = format_prefix_list(prefix_list, entries)
+
+            module.exit_json(
+                changed=True,
+                prefix_list_id=prefix_list["PrefixListId"],
+                prefix_list=pl_info,
+            )
+
+    elif state == "absent":
+        if prefix_list:
+            delete_prefix_list(prefix_list, client, module)
+            changed = True
+
+        module.exit_json(changed=changed)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ec2_vpc_managed_prefix_list_info.py
+++ b/plugins/modules/ec2_vpc_managed_prefix_list_info.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: ec2_vpc_managed_prefix_list_info
+version_added: 11.1.0
+short_description: Retrieve information about AWS EC2 Managed Prefix Lists
+description:
+  - Retrieve information about one or more AWS EC2 Managed Prefix Lists.
+  - Optionally retrieves the CIDR entries for each prefix list.
+author:
+  - Andrii Savchenko (@Ptico)
+options:
+  prefix_list_ids:
+    description:
+      - Get details of specific Managed Prefix Lists by ID.
+      - Mutually exclusive with I(filters).
+    type: list
+    elements: str
+    default: []
+  filters:
+    description:
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
+      - See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeManagedPrefixLists.html) for possible filters.
+      - Mutually exclusive with I(prefix_list_ids).
+    type: dict
+    default: {}
+  include_entries:
+    description:
+      - If C(true), the CIDR entries of each prefix list are fetched and included in the output.
+      - Set to C(false) to avoid the extra API call per prefix list when entries are not needed.
+    type: bool
+    default: true
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+- name: Gather information about all managed prefix lists
+  community.aws.ec2_vpc_managed_prefix_list_info:
+  register: result
+
+- name: Gather information about a specific prefix list by ID
+  community.aws.ec2_vpc_managed_prefix_list_info:
+    prefix_list_ids:
+      - pl-0a1b2c3d4e5f6789a
+  register: result
+
+- name: Gather information about multiple prefix lists by ID
+  community.aws.ec2_vpc_managed_prefix_list_info:
+    prefix_list_ids:
+      - pl-0a1b2c3d4e5f6789a
+      - pl-0b2c3d4e5f6789ab1
+  register: result
+
+- name: Gather information filtered by name
+  community.aws.ec2_vpc_managed_prefix_list_info:
+    filters:
+      prefix-list-name: my-prefix-list
+  register: result
+
+- name: Gather information filtered by tag
+  community.aws.ec2_vpc_managed_prefix_list_info:
+    filters:
+      "tag:Environment": production
+  register: result
+
+- name: Gather prefix list metadata only, without fetching CIDR entries
+  community.aws.ec2_vpc_managed_prefix_list_info:
+    include_entries: false
+  register: result
+"""
+
+RETURN = r"""
+prefix_lists:
+  description: List of matching managed prefix lists.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    prefix_list_id:
+      description: The ID of the prefix list.
+      type: str
+      sample: "pl-0a1b2c3d4e5f6789a"
+    prefix_list_arn:
+      description: The ARN of the prefix list.
+      type: str
+      sample: "arn:aws:ec2:us-east-1:123456789012:prefix-list/pl-0a1b2c3d4e5f6789a"
+    prefix_list_name:
+      description: The name of the prefix list.
+      type: str
+      sample: "my-prefix-list"
+    address_family:
+      description: The IP address family.
+      type: str
+      sample: "IPv4"
+    max_entries:
+      description: The maximum number of entries allowed.
+      type: int
+      sample: 10
+    state:
+      description: The current state of the prefix list.
+      type: str
+      sample: "create-complete"
+    version:
+      description: The version of the prefix list.
+      type: int
+      sample: 1
+    tags:
+      description: Tags applied to the prefix list.
+      type: dict
+      sample: {"Name": "my-prefix-list", "Environment": "production"}
+    entries:
+      description: The CIDR entries in the prefix list. Only present when I(include_entries=true).
+      type: list
+      elements: dict
+      contains:
+        cidr:
+          description: The CIDR block.
+          type: str
+          sample: "10.0.0.0/24"
+        description:
+          description: Description of the CIDR block.
+          type: str
+          sample: "My subnet"
+"""
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
+
+from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+
+
+def get_prefix_list_entries(client, module, prefix_list_id):
+    """Retrieve all CIDR entries for a prefix list using pagination."""
+    try:
+        paginator = client.get_paginator("get_managed_prefix_list_entries")
+        entries = paginator.paginate(PrefixListId=prefix_list_id).build_full_result()["Entries"]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg=f"Failed to get entries for prefix list {prefix_list_id}")
+    return [
+        {"cidr": e["Cidr"], "description": e.get("Description") or ""}
+        for e in entries
+    ]
+
+
+def format_prefix_list(prefix_list):
+    """Convert a boto3 prefix list to Ansible snake_case format."""
+    result = camel_dict_to_snake_dict(prefix_list, ignore_list=["Tags"])
+    result["tags"] = boto3_tag_list_to_ansible_dict(prefix_list.get("Tags", []))
+    return result
+
+
+def list_prefix_lists(client, module):
+    params = {}
+
+    if module.params.get("prefix_list_ids"):
+        params["PrefixListIds"] = module.params.get("prefix_list_ids")
+
+    if module.params.get("filters"):
+        params["Filters"] = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
+
+    try:
+        paginator = client.get_paginator("describe_managed_prefix_lists")
+        raw_prefix_lists = paginator.paginate(**params).build_full_result()["PrefixLists"]
+    except is_boto3_error_code("InvalidPrefixListID.NotFound"):
+        module.fail_json(msg="One or more prefix list IDs were not found")
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to describe managed prefix lists")
+
+    include_entries = module.params.get("include_entries")
+    result = []
+
+    for pl in raw_prefix_lists:
+        pl_info = format_prefix_list(pl)
+        if include_entries:
+            pl_info["entries"] = get_prefix_list_entries(client, module, pl["PrefixListId"])
+        result.append(pl_info)
+
+    return result
+
+
+def main():
+    argument_spec = dict(
+        prefix_list_ids=dict(type="list", elements="str", default=[]),
+        filters=dict(type="dict", default={}),
+        include_entries=dict(type="bool", default=True),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[["prefix_list_ids", "filters"]],
+        supports_check_mode=True,
+    )
+
+    try:
+        client = module.client("ec2", retry_decorator=AWSRetry.jittered_backoff())
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to connect to AWS")
+
+    prefix_lists = list_prefix_lists(client, module)
+
+    module.exit_json(prefix_lists=prefix_lists)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/aliases
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/aliases
@@ -1,0 +1,4 @@
+cloud/aws
+
+ec2_vpc_managed_prefix_list
+ec2_vpc_managed_prefix_list_info

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+prefix_list_name: "{{ resource_prefix }}-managed-prefix-list"

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/entries.yml
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/entries.yml
@@ -1,0 +1,215 @@
+---
+# Test management of prefix list entries
+- vars:
+    first_entry:
+      cidr: 10.0.0.0/24
+      description: First subnet
+    second_entry:
+      cidr: 10.1.0.0/24
+      description: Second subnet
+    updated_first_entry:
+      cidr: 10.0.0.0/24
+      description: Updated description
+  module_defaults:
+    community.aws.ec2_vpc_managed_prefix_list:
+      name: "{{ prefix_list_name }}"
+      max_entries: 20
+  block:
+
+    # ============================================================
+    - debug: msg="Testing prefix list entry management"
+
+    # ============================================================
+    # Add first entry (check mode)
+    # ============================================================
+
+    - name: Add an entry (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ first_entry }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Verify no entry was added in check mode
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries: []
+        purge_entries: true
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.entries == []
+
+    # ============================================================
+    # Add first entry
+    # ============================================================
+
+    - name: Add an entry
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ first_entry }}"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.entries | length == 1
+          - result.prefix_list.entries[0].cidr == "10.0.0.0/24"
+          - result.prefix_list.entries[0].description == "First subnet"
+
+    - name: Add entry again (check mode idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ first_entry }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Add entry again (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ first_entry }}"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.entries | length == 1
+
+    # ============================================================
+    # Add second entry without purging first
+    # ============================================================
+
+    - name: Add second entry without purging first (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ second_entry }}"
+        purge_entries: false
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Add second entry without purging first
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ second_entry }}"
+        purge_entries: false
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.entries | length == 2
+
+    - name: Add second entry again (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ second_entry }}"
+        purge_entries: false
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.entries | length == 2
+
+    # ============================================================
+    # Update entry description
+    # ============================================================
+
+    - name: Update entry description (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ updated_first_entry }}"
+          - "{{ second_entry }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Update entry description
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ updated_first_entry }}"
+          - "{{ second_entry }}"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.entries | selectattr('cidr', 'equalto', '10.0.0.0/24') | map(attribute='description') | first == "Updated description"
+
+    - name: Update entry description (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries:
+          - "{{ updated_first_entry }}"
+          - "{{ second_entry }}"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # ============================================================
+    # Remove all entries with purge
+    # ============================================================
+
+    - name: Remove all entries (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries: []
+        purge_entries: true
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Remove all entries
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries: []
+        purge_entries: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.entries == []
+
+    - name: Remove all entries (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        entries: []
+        purge_entries: true
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.entries == []

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/info.yml
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/info.yml
@@ -1,0 +1,175 @@
+---
+# Integration tests for ec2_vpc_managed_prefix_list_info
+- module_defaults:
+    community.aws.ec2_vpc_managed_prefix_list_info:
+      region: "{{ aws_region }}"
+  block:
+
+    # ============================================================
+    - debug: msg="Testing ec2_vpc_managed_prefix_list_info"
+
+    # ============================================================
+    # List all prefix lists
+    # ============================================================
+
+    - name: Gather info about all prefix lists
+      community.aws.ec2_vpc_managed_prefix_list_info:
+      register: result
+
+    - name: Verify our prefix list is in results
+      vars:
+        our_pls: "{{ result.prefix_lists | selectattr('prefix_list_id', 'equalto', prefix_list_id) | list }}"
+      assert:
+        that:
+          - result.prefix_lists is defined
+          - our_pls | length == 1
+          - our_pls[0].prefix_list_name == prefix_list_name
+          - our_pls[0].address_family == "IPv4"
+          - our_pls[0].max_entries == 20
+          - our_pls[0].state is defined
+          - our_pls[0].version is defined
+          - our_pls[0].tags is defined
+          - our_pls[0].entries is defined
+
+    # ============================================================
+    # Lookup by ID
+    # ============================================================
+
+    - name: Gather info about a specific prefix list by ID
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        prefix_list_ids:
+          - "{{ prefix_list_id }}"
+      register: result
+
+    - assert:
+        that:
+          - result.prefix_lists | length == 1
+          - result.prefix_lists[0].prefix_list_id == prefix_list_id
+          - result.prefix_lists[0].prefix_list_name == prefix_list_name
+
+    # ============================================================
+    # Lookup by name filter
+    # ============================================================
+
+    - name: Gather info filtered by prefix list name
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        filters:
+          prefix-list-name: "{{ prefix_list_name }}"
+      register: result
+
+    - assert:
+        that:
+          - result.prefix_lists | length == 1
+          - result.prefix_lists[0].prefix_list_id == prefix_list_id
+          - result.prefix_lists[0].prefix_list_name == prefix_list_name
+
+    # ============================================================
+    # Lookup by tag filter
+    # ============================================================
+
+    - name: Add a tag for filter testing
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        prefix_list_id: "{{ prefix_list_id }}"
+        max_entries: 20
+        tags:
+          InfoTestTag: "{{ resource_prefix }}"
+      register: tag_result
+
+    - name: Gather info filtered by tag
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        filters:
+          "tag:InfoTestTag": "{{ resource_prefix }}"
+      register: result
+
+    - assert:
+        that:
+          - result.prefix_lists | length == 1
+          - result.prefix_lists[0].prefix_list_id == prefix_list_id
+          - result.prefix_lists[0].tags.InfoTestTag == resource_prefix
+
+    - name: Clean up test tag
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        prefix_list_id: "{{ prefix_list_id }}"
+        max_entries: 20
+        tags: {}
+        purge_tags: true
+
+    # ============================================================
+    # Entries are included by default
+    # ============================================================
+
+    - name: Add entries to the prefix list for info testing
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        prefix_list_id: "{{ prefix_list_id }}"
+        max_entries: 20
+        entries:
+          - cidr: 192.168.0.0/24
+            description: Info test entry
+
+    - name: Gather info with entries (default)
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        prefix_list_ids:
+          - "{{ prefix_list_id }}"
+      register: result
+
+    - assert:
+        that:
+          - result.prefix_lists[0].entries | length == 1
+          - result.prefix_lists[0].entries[0].cidr == "192.168.0.0/24"
+          - result.prefix_lists[0].entries[0].description == "Info test entry"
+
+    # ============================================================
+    # Entries excluded when include_entries=false
+    # ============================================================
+
+    - name: Gather info without entries
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        prefix_list_ids:
+          - "{{ prefix_list_id }}"
+        include_entries: false
+      register: result
+
+    - assert:
+        that:
+          - "'entries' not in result.prefix_lists[0]"
+
+    - name: Clean up entries after info tests
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        prefix_list_id: "{{ prefix_list_id }}"
+        max_entries: 20
+        entries: []
+        purge_entries: true
+
+    # ============================================================
+    # Non-existent ID returns empty list
+    # ============================================================
+
+    - name: Gather info for a non-existent prefix list name (filter)
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        filters:
+          prefix-list-name: "definitely-does-not-exist-{{ resource_prefix }}"
+      register: result
+
+    - assert:
+        that:
+          - result.prefix_lists == []
+
+    # ============================================================
+    # check_mode works (read-only)
+    # ============================================================
+
+    - name: Gather info in check mode
+      community.aws.ec2_vpc_managed_prefix_list_info:
+        prefix_list_ids:
+          - "{{ prefix_list_id }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result.prefix_lists | length == 1
+          - result.prefix_lists[0].prefix_list_id == prefix_list_id

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/main.yml
@@ -1,0 +1,256 @@
+---
+- name: ec2_vpc_managed_prefix_list integration tests
+  collections:
+    - community.aws
+  module_defaults:
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+
+    # ============================================================
+    - debug: msg="Running ec2_vpc_managed_prefix_list tests"
+
+    # ============================================================
+    # CREATE (check mode)
+    # ============================================================
+
+    - name: Create prefix list (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        address_family: IPv4
+        max_entries: 10
+      register: result
+      check_mode: true
+
+    - name: Verify check mode reported a change
+      assert:
+        that:
+          - result is changed
+
+    - name: Verify prefix list was not actually created
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: absent
+        name: "{{ prefix_list_name }}"
+      register: absent_check
+
+    - assert:
+        that:
+          - absent_check is not changed
+
+    # ============================================================
+    # CREATE
+    # ============================================================
+
+    - name: Create prefix list
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        address_family: IPv4
+        max_entries: 10
+      register: result
+
+    - name: Verify prefix list was created
+      assert:
+        that:
+          - result is changed
+          - result.prefix_list_id is defined
+          - result.prefix_list_id is match("pl-")
+          - result.prefix_list.prefix_list_name == prefix_list_name
+          - result.prefix_list.address_family == "IPv4"
+          - result.prefix_list.max_entries == 10
+          - result.prefix_list.entries == []
+          - result.prefix_list.tags == {}
+
+    - name: Store prefix list ID
+      set_fact:
+        prefix_list_id: "{{ result.prefix_list_id }}"
+
+    # ============================================================
+    # CREATE (idempotency)
+    # ============================================================
+
+    - name: Create prefix list again (check mode idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        address_family: IPv4
+        max_entries: 10
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Create prefix list again (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        address_family: IPv4
+        max_entries: 10
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list_id == prefix_list_id
+
+    # ============================================================
+    # UPDATE max_entries (check mode)
+    # ============================================================
+
+    - name: Update max_entries (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        max_entries: 20
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Verify max_entries was not changed in check mode
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        max_entries: 10
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # ============================================================
+    # UPDATE max_entries
+    # ============================================================
+
+    - name: Update max_entries
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        max_entries: 20
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.max_entries == 20
+
+    - name: Update max_entries again (idempotency check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        max_entries: 20
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Update max_entries again (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        name: "{{ prefix_list_name }}"
+        max_entries: 20
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # ============================================================
+    # Entries tests
+    # ============================================================
+
+    - include_tasks: entries.yml
+
+    # ============================================================
+    # Tags tests
+    # ============================================================
+
+    - include_tasks: tags.yml
+
+    # ============================================================
+    # Info module tests
+    # ============================================================
+
+    - include_tasks: info.yml
+
+    # ============================================================
+    # DELETE (check mode)
+    # ============================================================
+
+    - name: Delete prefix list (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: absent
+        prefix_list_id: "{{ prefix_list_id }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Verify prefix list still exists after check mode delete
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        prefix_list_id: "{{ prefix_list_id }}"
+        max_entries: 20
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # ============================================================
+    # DELETE
+    # ============================================================
+
+    - name: Delete prefix list
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: absent
+        prefix_list_id: "{{ prefix_list_id }}"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Delete prefix list again (check mode idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: absent
+        name: "{{ prefix_list_name }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Delete prefix list again (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: absent
+        name: "{{ prefix_list_name }}"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+  always:
+
+    # ============================================================
+    - debug: msg="Cleaning up test resources"
+
+    - name: Delete prefix list (cleanup)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: absent
+        name: "{{ prefix_list_name }}"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/tags.yml
+++ b/tests/integration/targets/ec2_vpc_managed_prefix_list/tasks/tags.yml
@@ -1,0 +1,244 @@
+---
+# Test tag management for prefix lists
+- vars:
+    first_tags:
+      "Key with Spaces": Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+    second_tags:
+      "New Key with Spaces": Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+    third_tags:
+      "Key with Spaces": Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      "New Key with Spaces": Updated Value with spaces
+    final_tags:
+      "Key with Spaces": Value with spaces
+      CamelCaseKey: CamelCaseValue
+      pascalCaseKey: pascalCaseValue
+      snake_case_key: snake_case_value
+      "New Key with Spaces": Updated Value with spaces
+      NewCamelCaseKey: CamelCaseValue
+      newPascalCaseKey: pascalCaseValue
+      new_snake_case_key: snake_case_value
+  module_defaults:
+    community.aws.ec2_vpc_managed_prefix_list:
+      name: "{{ prefix_list_name }}"
+      max_entries: 20
+  block:
+
+    # ============================================================
+    - debug: msg="Testing prefix list tag management"
+
+    # ============================================================
+    # Add tags (check mode)
+    # ============================================================
+
+    - name: Add tags (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ first_tags }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Verify no tags were added in check mode
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.tags == {}
+
+    # ============================================================
+    # Add tags
+    # ============================================================
+
+    - name: Add tags
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ first_tags }}"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.tags == first_tags
+
+    - name: Add tags again (check mode idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ first_tags }}"
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Add tags again (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ first_tags }}"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.tags == first_tags
+
+    # ============================================================
+    # Modify tags with purge (replace tag set)
+    # ============================================================
+
+    - name: Modify tags with purge (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Modify tags with purge
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.tags == second_tags
+
+    - name: Modify tags with purge (idempotency check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Modify tags with purge (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.tags == second_tags
+
+    # ============================================================
+    # Modify tags without purge (merge tag set)
+    # ============================================================
+
+    - name: Modify tags without purge (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Modify tags without purge
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.tags == final_tags
+
+    - name: Modify tags without purge (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.tags == final_tags
+
+    # ============================================================
+    # No change when tags not specified
+    # ============================================================
+
+    - name: No tags change when tags parameter not set
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.tags == final_tags
+
+    # ============================================================
+    # Remove all tags
+    # ============================================================
+
+    - name: Remove all tags (check mode)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: {}
+        purge_tags: true
+      register: result
+      check_mode: true
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Remove all tags
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: {}
+        purge_tags: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.prefix_list.tags == {}
+
+    - name: Remove all tags (idempotency)
+      community.aws.ec2_vpc_managed_prefix_list:
+        state: present
+        tags: {}
+        purge_tags: true
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.prefix_list.tags == {}

--- a/tests/unit/plugins/modules/test_ec2_vpc_managed_prefix_list.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_managed_prefix_list.py
@@ -1,0 +1,549 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip(
+        "test_ec2_vpc_managed_prefix_list.py requires the `boto3` and `botocore` modules"
+    )
+
+from ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list import (
+    create_prefix_list,
+    delete_prefix_list,
+    format_prefix_list,
+    get_prefix_list,
+    get_prefix_list_entries,
+    update_prefix_list,
+)
+from ansible_collections.community.aws.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    ModuleTestCase,
+    set_module_args,
+)
+
+EXAMPLE_PREFIX_LIST = {
+    "PrefixListId": "pl-0a1b2c3d4e5f6789a",
+    "AddressFamily": "IPv4",
+    "State": "create-complete",
+    "StateMessage": "",
+    "PrefixListArn": "arn:aws:ec2:us-east-1:123456789012:prefix-list/pl-0a1b2c3d4e5f6789a",
+    "PrefixListName": "test-prefix-list",
+    "MaxEntries": 10,
+    "Version": 1,
+    "Tags": [],
+}
+
+EXAMPLE_ENTRIES = [
+    {"Cidr": "10.0.0.0/24", "Description": "My subnet"},
+    {"Cidr": "10.1.0.0/24", "Description": "My other subnet"},
+]
+
+
+def make_module(params, check_mode=False):
+    """Helper to create a mock module with given params."""
+    module = MagicMock()
+    module.params = params
+    module.check_mode = check_mode
+    return module
+
+
+def make_client(describe_results=None, entries_results=None):
+    """Helper to create a mock boto3 EC2 client."""
+    client = MagicMock()
+    if describe_results is not None:
+        client.describe_managed_prefix_lists.return_value = {"PrefixLists": describe_results}
+    if entries_results is not None:
+        client.get_managed_prefix_list_entries.return_value = {"Entries": entries_results}
+    return client
+
+
+# ============================================================
+# Tests for get_prefix_list
+# ============================================================
+
+
+class TestGetPrefixList:
+    def test_lookup_by_name(self):
+        client = make_client(describe_results=[EXAMPLE_PREFIX_LIST])
+        module = make_module({"prefix_list_id": None, "name": "test-prefix-list"})
+
+        result = get_prefix_list(client, module)
+
+        assert result["PrefixListId"] == "pl-0a1b2c3d4e5f6789a"
+        client.describe_managed_prefix_lists.assert_called_once_with(
+            aws_retry=True,
+            Filters=[{"Name": "prefix-list-name", "Values": ["test-prefix-list"]}],
+        )
+
+    def test_lookup_by_id(self):
+        client = make_client(describe_results=[EXAMPLE_PREFIX_LIST])
+        module = make_module({"prefix_list_id": "pl-0a1b2c3d4e5f6789a", "name": None})
+
+        result = get_prefix_list(client, module)
+
+        assert result["PrefixListId"] == "pl-0a1b2c3d4e5f6789a"
+        client.describe_managed_prefix_lists.assert_called_once_with(
+            aws_retry=True,
+            PrefixListIds=["pl-0a1b2c3d4e5f6789a"],
+        )
+
+    def test_returns_none_when_not_found(self):
+        client = make_client(describe_results=[])
+        module = make_module({"prefix_list_id": None, "name": "nonexistent"})
+
+        result = get_prefix_list(client, module)
+
+        assert result is None
+
+
+# ============================================================
+# Tests for format_prefix_list
+# ============================================================
+
+
+class TestFormatPrefixList:
+    def test_converts_to_snake_case(self):
+        result = format_prefix_list(EXAMPLE_PREFIX_LIST, EXAMPLE_ENTRIES)
+
+        assert result["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+        assert result["prefix_list_name"] == "test-prefix-list"
+        assert result["address_family"] == "IPv4"
+        assert result["max_entries"] == 10
+        assert result["version"] == 1
+
+    def test_converts_tags(self):
+        pl_with_tags = {**EXAMPLE_PREFIX_LIST, "Tags": [{"Key": "Env", "Value": "prod"}]}
+        result = format_prefix_list(pl_with_tags, [])
+
+        assert result["tags"] == {"Env": "prod"}
+
+    def test_converts_entries(self):
+        result = format_prefix_list(EXAMPLE_PREFIX_LIST, EXAMPLE_ENTRIES)
+
+        assert len(result["entries"]) == 2
+        assert result["entries"][0] == {"cidr": "10.0.0.0/24", "description": "My subnet"}
+        assert result["entries"][1] == {"cidr": "10.1.0.0/24", "description": "My other subnet"}
+
+    def test_empty_entries(self):
+        result = format_prefix_list(EXAMPLE_PREFIX_LIST, [])
+
+        assert result["entries"] == []
+
+    def test_empty_tags(self):
+        result = format_prefix_list(EXAMPLE_PREFIX_LIST, [])
+
+        assert result["tags"] == {}
+
+
+# ============================================================
+# Tests for update_prefix_list
+# ============================================================
+
+
+class TestUpdatePrefixList:
+    def test_no_changes_returns_false(self):
+        client = make_client(entries_results=[])
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": [],
+            "purge_entries": True,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is False
+        client.modify_managed_prefix_list.assert_not_called()
+
+    def test_name_change_triggers_update(self):
+        updated = {**EXAMPLE_PREFIX_LIST, "PrefixListName": "new-name"}
+        client = make_client(entries_results=[])
+        client.modify_managed_prefix_list.return_value = {"PrefixList": updated}
+        module = make_module({
+            "name": "new-name",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": None,
+            "purge_entries": True,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is True
+        client.modify_managed_prefix_list.assert_called_once()
+        call_kwargs = client.modify_managed_prefix_list.call_args[1]
+        assert call_kwargs["PrefixListName"] == "new-name"
+
+    def test_max_entries_change_triggers_update(self):
+        updated = {**EXAMPLE_PREFIX_LIST, "MaxEntries": 20}
+        client = make_client(entries_results=[])
+        client.modify_managed_prefix_list.return_value = {"PrefixList": updated}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 20,
+            "address_family": "IPv4",
+            "entries": None,
+            "purge_entries": True,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is True
+        call_kwargs = client.modify_managed_prefix_list.call_args[1]
+        assert call_kwargs["MaxEntries"] == 20
+
+    def test_address_family_change_fails(self):
+        client = make_client(entries_results=[])
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv6",
+            "entries": None,
+            "purge_entries": True,
+        })
+
+        update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        module.fail_json.assert_called_once()
+        assert "address_family" in module.fail_json.call_args[1]["msg"]
+
+    def test_new_entry_added(self):
+        updated = {**EXAMPLE_PREFIX_LIST, "Version": 2}
+        client = make_client(entries_results=[])
+        client.modify_managed_prefix_list.return_value = {"PrefixList": updated}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": [{"cidr": "10.0.0.0/24", "description": "New"}],
+            "purge_entries": True,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is True
+        call_kwargs = client.modify_managed_prefix_list.call_args[1]
+        assert {"Cidr": "10.0.0.0/24", "Description": "New"} in call_kwargs["AddEntries"]
+
+    def test_existing_entry_removed_with_purge(self):
+        updated = {**EXAMPLE_PREFIX_LIST, "Version": 2}
+        client = make_client(entries_results=[{"Cidr": "10.0.0.0/24", "Description": "Old"}])
+        client.modify_managed_prefix_list.return_value = {"PrefixList": updated}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": [],
+            "purge_entries": True,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is True
+        call_kwargs = client.modify_managed_prefix_list.call_args[1]
+        assert {"Cidr": "10.0.0.0/24"} in call_kwargs["RemoveEntries"]
+
+    def test_existing_entry_kept_without_purge(self):
+        client = make_client(entries_results=[{"Cidr": "10.0.0.0/24", "Description": "Keep me"}])
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": [],
+            "purge_entries": False,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is False
+        client.modify_managed_prefix_list.assert_not_called()
+
+    def test_entry_description_update(self):
+        updated = {**EXAMPLE_PREFIX_LIST, "Version": 2}
+        client = make_client(entries_results=[{"Cidr": "10.0.0.0/24", "Description": "Old desc"}])
+        client.modify_managed_prefix_list.return_value = {"PrefixList": updated}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": [{"cidr": "10.0.0.0/24", "description": "New desc"}],
+            "purge_entries": True,
+        })
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is True
+        call_kwargs = client.modify_managed_prefix_list.call_args[1]
+        assert {"Cidr": "10.0.0.0/24", "Description": "New desc"} in call_kwargs["AddEntries"]
+        assert {"Cidr": "10.0.0.0/24"} in call_kwargs["RemoveEntries"]
+
+    def test_check_mode_returns_changed_without_api_call(self):
+        client = make_client(entries_results=[])
+        module = make_module(
+            {
+                "name": "new-name",
+                "max_entries": 10,
+                "address_family": "IPv4",
+                "entries": None,
+                "purge_entries": True,
+            },
+            check_mode=True,
+        )
+
+        result_pl, changed = update_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        assert changed is True
+        client.modify_managed_prefix_list.assert_not_called()
+        # Returns original (unmodified) prefix list
+        assert result_pl["PrefixListName"] == "test-prefix-list"
+
+
+# ============================================================
+# Tests for create_prefix_list
+# ============================================================
+
+
+class TestCreatePrefixList:
+    def test_basic_creation(self):
+        client = MagicMock()
+        client.create_managed_prefix_list.return_value = {"PrefixList": EXAMPLE_PREFIX_LIST}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": None,
+            "tags": None,
+        })
+
+        result = create_prefix_list(client, module)
+
+        assert result["PrefixListId"] == "pl-0a1b2c3d4e5f6789a"
+        client.create_managed_prefix_list.assert_called_once()
+        call_kwargs = client.create_managed_prefix_list.call_args[1]
+        assert call_kwargs["PrefixListName"] == "test-prefix-list"
+        assert call_kwargs["MaxEntries"] == 10
+        assert call_kwargs["AddressFamily"] == "IPv4"
+        assert "Entries" not in call_kwargs
+        assert "TagSpecifications" not in call_kwargs
+
+    def test_creation_with_entries(self):
+        client = MagicMock()
+        client.create_managed_prefix_list.return_value = {"PrefixList": EXAMPLE_PREFIX_LIST}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": [{"cidr": "10.0.0.0/24", "description": "My subnet"}],
+            "tags": None,
+        })
+
+        create_prefix_list(client, module)
+
+        call_kwargs = client.create_managed_prefix_list.call_args[1]
+        assert call_kwargs["Entries"] == [{"Cidr": "10.0.0.0/24", "Description": "My subnet"}]
+
+    def test_creation_with_tags(self):
+        client = MagicMock()
+        client.create_managed_prefix_list.return_value = {"PrefixList": EXAMPLE_PREFIX_LIST}
+        module = make_module({
+            "name": "test-prefix-list",
+            "max_entries": 10,
+            "address_family": "IPv4",
+            "entries": None,
+            "tags": {"Env": "prod"},
+        })
+
+        create_prefix_list(client, module)
+
+        call_kwargs = client.create_managed_prefix_list.call_args[1]
+        assert "TagSpecifications" in call_kwargs
+
+
+# ============================================================
+# Tests for delete_prefix_list
+# ============================================================
+
+
+class TestDeletePrefixList:
+    def test_delete_calls_api(self):
+        client = MagicMock()
+        module = make_module({})
+
+        delete_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        client.delete_managed_prefix_list.assert_called_once_with(
+            aws_retry=True,
+            PrefixListId="pl-0a1b2c3d4e5f6789a",
+        )
+
+    def test_check_mode_skips_api_call(self):
+        client = MagicMock()
+        module = make_module({}, check_mode=True)
+
+        delete_prefix_list(EXAMPLE_PREFIX_LIST, client, module)
+
+        client.delete_managed_prefix_list.assert_not_called()
+
+
+# ============================================================
+# Tests for main() via module-level mocking
+# ============================================================
+
+
+class TestMain(ModuleTestCase):
+    def setUp(self):
+        super().setUp()
+        # Patch module.client to return our mock EC2 client
+        self.mock_ec2 = MagicMock()
+        self.client_patcher = patch(
+            "ansible_collections.community.aws.plugins.modules"
+            ".ec2_vpc_managed_prefix_list.AnsibleAWSModule.client",
+            return_value=self.mock_ec2,
+        )
+        self.client_patcher.start()
+        self.addCleanup(self.client_patcher.stop)
+
+        # Default mock responses
+        self.mock_ec2.describe_managed_prefix_lists.return_value = {
+            "PrefixLists": [EXAMPLE_PREFIX_LIST]
+        }
+        self.mock_ec2.get_managed_prefix_list_entries.return_value = {"Entries": []}
+        self.mock_ec2.describe_tags.return_value = {"Tags": []}
+
+    def test_create_prefix_list(self):
+        set_module_args({
+            "state": "present",
+            "name": "test-prefix-list",
+            "address_family": "IPv4",
+            "max_entries": 10,
+        })
+        self.mock_ec2.describe_managed_prefix_lists.side_effect = [
+            {"PrefixLists": []},
+            {"PrefixLists": [EXAMPLE_PREFIX_LIST]},
+        ]
+        self.mock_ec2.create_managed_prefix_list.return_value = {"PrefixList": EXAMPLE_PREFIX_LIST}
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["changed"] is True
+        assert result["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+        assert "prefix_list" in result
+
+    def test_create_check_mode(self):
+        set_module_args({
+            "state": "present",
+            "name": "test-prefix-list",
+            "address_family": "IPv4",
+            "max_entries": 10,
+            "_ansible_check_mode": True,
+        })
+        self.mock_ec2.describe_managed_prefix_lists.return_value = {"PrefixLists": []}
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["changed"] is True
+        self.mock_ec2.create_managed_prefix_list.assert_not_called()
+
+    def test_idempotent_no_change(self):
+        set_module_args({
+            "state": "present",
+            "name": "test-prefix-list",
+            "address_family": "IPv4",
+            "max_entries": 10,
+        })
+        self.mock_ec2.describe_managed_prefix_lists.return_value = {
+            "PrefixLists": [EXAMPLE_PREFIX_LIST]
+        }
+        self.mock_ec2.get_managed_prefix_list_entries.return_value = {"Entries": []}
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["changed"] is False
+        self.mock_ec2.modify_managed_prefix_list.assert_not_called()
+        self.mock_ec2.create_managed_prefix_list.assert_not_called()
+
+    def test_delete_existing(self):
+        set_module_args({
+            "state": "absent",
+            "prefix_list_id": "pl-0a1b2c3d4e5f6789a",
+        })
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["changed"] is True
+        self.mock_ec2.delete_managed_prefix_list.assert_called_once_with(
+            aws_retry=True,
+            PrefixListId="pl-0a1b2c3d4e5f6789a",
+        )
+
+    def test_delete_nonexistent(self):
+        set_module_args({
+            "state": "absent",
+            "prefix_list_id": "pl-nonexistent",
+        })
+        self.mock_ec2.describe_managed_prefix_lists.return_value = {"PrefixLists": []}
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["changed"] is False
+        self.mock_ec2.delete_managed_prefix_list.assert_not_called()
+
+    def test_delete_check_mode(self):
+        set_module_args({
+            "state": "absent",
+            "prefix_list_id": "pl-0a1b2c3d4e5f6789a",
+            "_ansible_check_mode": True,
+        })
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["changed"] is True
+        self.mock_ec2.delete_managed_prefix_list.assert_not_called()
+
+    def test_prefix_list_info_returned(self):
+        set_module_args({
+            "state": "present",
+            "name": "test-prefix-list",
+            "address_family": "IPv4",
+            "max_entries": 10,
+        })
+        self.mock_ec2.get_managed_prefix_list_entries.return_value = {
+            "Entries": [{"Cidr": "10.0.0.0/24", "Description": "My subnet"}]
+        }
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list as m
+            m.main()
+
+        result = cm.exception.args[0]
+        pl = result["prefix_list"]
+        assert pl["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+        assert pl["address_family"] == "IPv4"
+        assert pl["max_entries"] == 10
+        assert pl["entries"] == [{"cidr": "10.0.0.0/24", "description": "My subnet"}]

--- a/tests/unit/plugins/modules/test_ec2_vpc_managed_prefix_list_info.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_managed_prefix_list_info.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip(
+        "test_ec2_vpc_managed_prefix_list_info.py requires the `boto3` and `botocore` modules"
+    )
+
+from ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list_info import (
+    format_prefix_list,
+    get_prefix_list_entries,
+    list_prefix_lists,
+)
+from ansible_collections.community.aws.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    ModuleTestCase,
+    set_module_args,
+)
+
+EXAMPLE_PREFIX_LIST = {
+    "PrefixListId": "pl-0a1b2c3d4e5f6789a",
+    "AddressFamily": "IPv4",
+    "State": "create-complete",
+    "StateMessage": "",
+    "PrefixListArn": "arn:aws:ec2:us-east-1:123456789012:prefix-list/pl-0a1b2c3d4e5f6789a",
+    "PrefixListName": "test-prefix-list",
+    "MaxEntries": 10,
+    "Version": 1,
+    "Tags": [{"Key": "Name", "Value": "test-prefix-list"}],
+}
+
+EXAMPLE_ENTRIES = [
+    {"Cidr": "10.0.0.0/24", "Description": "My subnet"},
+    {"Cidr": "10.1.0.0/24", "Description": "Other subnet"},
+]
+
+
+def make_module(params):
+    module = MagicMock()
+    module.params = params
+    return module
+
+
+def make_paginator_result(items):
+    """Create a mock paginator that returns items when build_full_result() is called."""
+    paginator = MagicMock()
+    paginator.paginate.return_value.build_full_result.return_value = items
+    return paginator
+
+
+# ============================================================
+# Tests for format_prefix_list
+# ============================================================
+
+
+class TestFormatPrefixList:
+    def test_converts_camel_to_snake(self):
+        result = format_prefix_list(EXAMPLE_PREFIX_LIST)
+
+        assert result["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+        assert result["prefix_list_arn"] == EXAMPLE_PREFIX_LIST["PrefixListArn"]
+        assert result["prefix_list_name"] == "test-prefix-list"
+        assert result["address_family"] == "IPv4"
+        assert result["max_entries"] == 10
+        assert result["state"] == "create-complete"
+        assert result["version"] == 1
+
+    def test_converts_tags_from_list_to_dict(self):
+        result = format_prefix_list(EXAMPLE_PREFIX_LIST)
+
+        assert result["tags"] == {"Name": "test-prefix-list"}
+
+    def test_empty_tags(self):
+        pl = {**EXAMPLE_PREFIX_LIST, "Tags": []}
+        result = format_prefix_list(pl)
+
+        assert result["tags"] == {}
+
+    def test_missing_tags_key(self):
+        pl = {k: v for k, v in EXAMPLE_PREFIX_LIST.items() if k != "Tags"}
+        result = format_prefix_list(pl)
+
+        assert result["tags"] == {}
+
+
+# ============================================================
+# Tests for get_prefix_list_entries
+# ============================================================
+
+
+class TestGetPrefixListEntries:
+    def test_returns_entries_as_snake_case(self):
+        client = MagicMock()
+        client.get_paginator.return_value = make_paginator_result({"Entries": EXAMPLE_ENTRIES})
+        module = make_module({})
+
+        result = get_prefix_list_entries(client, module, "pl-0a1b2c3d4e5f6789a")
+
+        assert len(result) == 2
+        assert result[0] == {"cidr": "10.0.0.0/24", "description": "My subnet"}
+        assert result[1] == {"cidr": "10.1.0.0/24", "description": "Other subnet"}
+
+    def test_empty_entries(self):
+        client = MagicMock()
+        client.get_paginator.return_value = make_paginator_result({"Entries": []})
+        module = make_module({})
+
+        result = get_prefix_list_entries(client, module, "pl-0a1b2c3d4e5f6789a")
+
+        assert result == []
+
+    def test_uses_correct_paginator(self):
+        client = MagicMock()
+        client.get_paginator.return_value = make_paginator_result({"Entries": []})
+        module = make_module({})
+
+        get_prefix_list_entries(client, module, "pl-0a1b2c3d4e5f6789a")
+
+        client.get_paginator.assert_called_once_with("get_managed_prefix_list_entries")
+        client.get_paginator.return_value.paginate.assert_called_once_with(
+            PrefixListId="pl-0a1b2c3d4e5f6789a"
+        )
+
+    def test_empty_description_normalized(self):
+        entries = [{"Cidr": "10.0.0.0/24", "Description": None}]
+        client = MagicMock()
+        client.get_paginator.return_value = make_paginator_result({"Entries": entries})
+        module = make_module({})
+
+        result = get_prefix_list_entries(client, module, "pl-0a1b2c3d4e5f6789a")
+
+        assert result[0]["description"] == ""
+
+
+# ============================================================
+# Tests for list_prefix_lists
+# ============================================================
+
+
+class TestListPrefixLists:
+    def test_lists_all_when_no_filters(self):
+        client = MagicMock()
+        client.get_paginator.side_effect = [
+            make_paginator_result({"PrefixLists": [EXAMPLE_PREFIX_LIST]}),
+            make_paginator_result({"Entries": []}),
+        ]
+        module = make_module({
+            "prefix_list_ids": [],
+            "filters": {},
+            "include_entries": True,
+        })
+
+        result = list_prefix_lists(client, module)
+
+        assert len(result) == 1
+        assert result[0]["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+
+    def test_filters_by_id(self):
+        client = MagicMock()
+        client.get_paginator.side_effect = [
+            make_paginator_result({"PrefixLists": [EXAMPLE_PREFIX_LIST]}),
+            make_paginator_result({"Entries": []}),
+        ]
+        module = make_module({
+            "prefix_list_ids": ["pl-0a1b2c3d4e5f6789a"],
+            "filters": {},
+            "include_entries": True,
+        })
+
+        list_prefix_lists(client, module)
+
+        describe_paginator = client.get_paginator.return_value
+        describe_paginator.paginate.assert_called_once_with(
+            PrefixListIds=["pl-0a1b2c3d4e5f6789a"]
+        )
+
+    def test_filters_by_dict(self):
+        client = MagicMock()
+        client.get_paginator.side_effect = [
+            make_paginator_result({"PrefixLists": [EXAMPLE_PREFIX_LIST]}),
+            make_paginator_result({"Entries": []}),
+        ]
+        module = make_module({
+            "prefix_list_ids": [],
+            "filters": {"prefix-list-name": "test-prefix-list"},
+            "include_entries": True,
+        })
+
+        list_prefix_lists(client, module)
+
+        describe_paginator = client.get_paginator.return_value
+        call_kwargs = describe_paginator.paginate.call_args[1]
+        assert "Filters" in call_kwargs
+        assert any(f["Name"] == "prefix-list-name" for f in call_kwargs["Filters"])
+
+    def test_includes_entries_when_requested(self):
+        entries_paginator = make_paginator_result({"Entries": EXAMPLE_ENTRIES})
+        describe_paginator = make_paginator_result({"PrefixLists": [EXAMPLE_PREFIX_LIST]})
+        client = MagicMock()
+        client.get_paginator.side_effect = [describe_paginator, entries_paginator]
+        module = make_module({
+            "prefix_list_ids": [],
+            "filters": {},
+            "include_entries": True,
+        })
+
+        result = list_prefix_lists(client, module)
+
+        assert "entries" in result[0]
+        assert len(result[0]["entries"]) == 2
+
+    def test_excludes_entries_when_not_requested(self):
+        client = MagicMock()
+        client.get_paginator.return_value = make_paginator_result(
+            {"PrefixLists": [EXAMPLE_PREFIX_LIST]}
+        )
+        module = make_module({
+            "prefix_list_ids": [],
+            "filters": {},
+            "include_entries": False,
+        })
+
+        result = list_prefix_lists(client, module)
+
+        assert "entries" not in result[0]
+        # Only one paginator call (describe only, no entries fetch)
+        assert client.get_paginator.call_count == 1
+
+    def test_empty_result(self):
+        client = MagicMock()
+        client.get_paginator.return_value = make_paginator_result({"PrefixLists": []})
+        module = make_module({
+            "prefix_list_ids": [],
+            "filters": {},
+            "include_entries": True,
+        })
+
+        result = list_prefix_lists(client, module)
+
+        assert result == []
+
+    def test_multiple_prefix_lists(self):
+        second_pl = {**EXAMPLE_PREFIX_LIST, "PrefixListId": "pl-other", "PrefixListName": "other"}
+        entries_paginator_1 = make_paginator_result({"Entries": []})
+        entries_paginator_2 = make_paginator_result({"Entries": []})
+        describe_paginator = make_paginator_result(
+            {"PrefixLists": [EXAMPLE_PREFIX_LIST, second_pl]}
+        )
+        client = MagicMock()
+        client.get_paginator.side_effect = [
+            describe_paginator,
+            entries_paginator_1,
+            entries_paginator_2,
+        ]
+        module = make_module({
+            "prefix_list_ids": [],
+            "filters": {},
+            "include_entries": True,
+        })
+
+        result = list_prefix_lists(client, module)
+
+        assert len(result) == 2
+        assert result[0]["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+        assert result[1]["prefix_list_id"] == "pl-other"
+
+
+# ============================================================
+# Tests for main()
+# ============================================================
+
+
+class TestMain(ModuleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_ec2 = MagicMock()
+        self.client_patcher = patch(
+            "ansible_collections.community.aws.plugins.modules"
+            ".ec2_vpc_managed_prefix_list_info.AnsibleAWSModule.client",
+            return_value=self.mock_ec2,
+        )
+        self.client_patcher.start()
+        self.addCleanup(self.client_patcher.stop)
+
+        entries_paginator = make_paginator_result({"Entries": []})
+        describe_paginator = make_paginator_result({"PrefixLists": [EXAMPLE_PREFIX_LIST]})
+        self.mock_ec2.get_paginator.side_effect = [describe_paginator, entries_paginator]
+
+    def test_returns_prefix_lists(self):
+        set_module_args({})
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list_info as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert "prefix_lists" in result
+        assert len(result["prefix_lists"]) == 1
+        pl = result["prefix_lists"][0]
+        assert pl["prefix_list_id"] == "pl-0a1b2c3d4e5f6789a"
+        assert pl["prefix_list_name"] == "test-prefix-list"
+        assert pl["tags"] == {"Name": "test-prefix-list"}
+        assert pl["entries"] == []
+
+    def test_filter_by_id(self):
+        set_module_args({"prefix_list_ids": ["pl-0a1b2c3d4e5f6789a"]})
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list_info as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert len(result["prefix_lists"]) == 1
+
+    def test_no_entries_when_include_entries_false(self):
+        self.mock_ec2.get_paginator.side_effect = None
+        self.mock_ec2.get_paginator.return_value = make_paginator_result(
+            {"PrefixLists": [EXAMPLE_PREFIX_LIST]}
+        )
+        set_module_args({"include_entries": False})
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list_info as m
+            m.main()
+
+        result = cm.exception.args[0]
+        pl = result["prefix_lists"][0]
+        assert "entries" not in pl
+
+    def test_empty_result(self):
+        self.mock_ec2.get_paginator.side_effect = None
+        self.mock_ec2.get_paginator.return_value = make_paginator_result({"PrefixLists": []})
+        set_module_args({})
+
+        with self.assertRaises(AnsibleExitJson) as cm:
+            import ansible_collections.community.aws.plugins.modules.ec2_vpc_managed_prefix_list_info as m
+            m.main()
+
+        result = cm.exception.args[0]
+        assert result["prefix_lists"] == []


### PR DESCRIPTION
##### SUMMARY
Add two new modules for managing and querying AWS EC2 Managed Prefix Lists.

  - `ec2_vpc_managed_prefix_list` allows creating, updating, and deleting Managed Prefix Lists including full lifecycle management of CIDR entries and tags
  - `ec2_vpc_managed_prefix_list_info` allows querying prefix lists by ID or filter, optionally including their CIDR entries

##### ISSUE TYPE
- New Module Pull Request