### PR TITLE
Remove deprecated create_instance_profile from glue_job test

### DIFF
--- a/tests/integration/targets/glue_job/tasks/main.yml
+++ b/tests/integration/targets/glue_job/tasks/main.yml
@@ -25,7 +25,6 @@
               Effect: Allow
               Principal:
                 Service: glue.amazonaws.com
-        create_instance_profile: false
         managed_policies:
           - "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
 


### PR DESCRIPTION
##### SUMMARY
The create_instance_profile parameter has been deprecated in iam_role. Since instance profile creation is now opt-in, this parameter can be removed from the test.

See also: https://github.com/ansible-collections/amazon.aws/pull/2926

##### ISSUE TYPE
Test Pull Request

##### COMPONENT NAME
glue_job



Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>