### PR TITLE
wafv2_web_acl - Fix idempotency issue with rate_based_statement

### DIFF
--- a/changelogs/fragments/wafv2-rate-based-idempotency.yml
+++ b/changelogs/fragments/wafv2-rate-based-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - wafv2_web_acl - Fixed idempotency issue where rules with rate_based_statement would always show as changed when evaluation_window_sec was not explicitly specified due to AWS returning the default value of 300 (https://github.com/ansible-collections/community.aws/pull/2427).

--- a/plugins/module_utils/wafv2.py
+++ b/plugins/module_utils/wafv2.py
@@ -166,11 +166,26 @@ def byte_values_to_strings_before_compare(rules):
     return rules
 
 
+def apply_rate_based_statement_defaults(rules):
+    """
+    Apply default values to rate_based_statement fields to match AWS API behaviour.
+    AWS returns evaluation_window_sec with a default value of 300 even when not specified,
+    so we add it to requested rules to ensure idempotent comparisons.
+    """
+    for idx in range(len(rules)):
+        rate_based_stmt = rules[idx].get("Statement", {}).get("RateBasedStatement")
+        if rate_based_stmt and "EvaluationWindowSec" not in rate_based_stmt:
+            rules[idx]["Statement"]["RateBasedStatement"]["EvaluationWindowSec"] = 300
+
+    return rules
+
+
 def compare_priority_rules(existing_rules, requested_rules, purge_rules, state):
     diff = False
     existing_rules = sorted(existing_rules, key=lambda k: k["Priority"])
     existing_rules = byte_values_to_strings_before_compare(existing_rules)
     requested_rules = sorted(requested_rules, key=lambda k: k["Priority"])
+    requested_rules = apply_rate_based_statement_defaults(requested_rules)
 
     if purge_rules and state == "present":
         merged_rules = requested_rules

--- a/plugins/modules/wafv2_web_acl.py
+++ b/plugins/modules/wafv2_web_acl.py
@@ -73,15 +73,26 @@ options:
           type: int
         action:
           description:
-            - Wether a rule is blocked, allowed or counted.
+            - Whether a rule is blocked, allowed, counted, uses CAPTCHA, or uses Challenge.
+            - Mutually exclusive with O(rules.override_action).
+            - Required for normal rules. Not used for managed rule group reference statements.
+          type: dict
+        override_action:
+          description:
+            - Override action for rule group reference statements.
+            - Can override the rule group evaluation result.
+            - Mutually exclusive with O(rules.action).
+            - Required when using managed rule group statements.
           type: dict
         visibility_config:
           description:
             - Visibility of single wafv2 rule.
+            - Enables CloudWatch metrics and web request sample collection.
           type: dict
         statement:
           description:
             - Rule configuration.
+            - Defines the AWS WAF processing logic for the rule.
           type: dict
     custom_response_bodies:
       description:
@@ -176,6 +187,7 @@ EXAMPLES = r"""
           rate_based_statement:
             limit: 1500
             aggregate_key_type: IP
+            evaluation_window_sec: 300  # Time window in seconds (60, 120, 300, or 600). Default is 300.
             scope_down_statement:
               or_statement:
                 statements:
@@ -300,6 +312,51 @@ custom_response_bodies:
       content_type: APPLICATION_JSON
       content: '{ message: "Your request has been blocked due to too many HTTP requests coming from your IP" }'
   returned: Always, as long as the web acl exists
+id:
+  description: Unique identifier for the web acl
+  sample: c3261c16-f284-4417-8330-2937b59aab88
+  type: str
+  returned: Always, as long as the web acl exists
+label_namespace:
+  description: Label namespace for the web acl
+  sample: 'awswaf:966509639900:webacl:my-web-acl:'
+  type: str
+  returned: Always, as long as the web acl exists
+managed_by_firewall_manager:
+  description: Whether the web acl is managed by AWS Firewall Manager
+  sample: false
+  type: bool
+  returned: Always, as long as the web acl exists
+captcha_config:
+  description: Default CAPTCHA configuration for the web ACL
+  type: dict
+  returned: When configured on the web ACL
+  sample:
+    immunity_time_property:
+      immunity_time: 300
+challenge_config:
+  description: Default challenge configuration for the web ACL
+  type: dict
+  returned: When configured on the web ACL
+  sample:
+    immunity_time_property:
+      immunity_time: 300
+token_domains:
+  description: Domains configured for web request token acceptance
+  type: list
+  elements: str
+  returned: When configured on the web ACL
+  sample:
+    - example.com
+    - subdomain.example.com
+association_config:
+  description: Customised request body size inspection limits for associated resources
+  type: dict
+  returned: When configured on the web ACL
+  sample:
+    request_body:
+      cloudfront:
+        default_size_inspection_limit: KB_16
 visibility_config:
   description: Visibility config of the web acl
   returned: Always, as long as the web acl exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 skip-string-normalization = false
 line-length = 120
-target-version = ['py37', 'py38']
+target-version = ['py38', 'py39']
 extend-exclude = '''
 /(
   | plugins/module_utils/_version.py
@@ -26,11 +26,6 @@ src_paths = [
     "plugins",
     "tests/unit",
     "tests/integration",
-]
-
-# Unstable
-skip = [
-    "aws_ssm.py"
 ]
 
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "ANSIBLE_CORE", "ANSIBLE_AMAZON_AWS", "ANSIBLE_COMMUNITY_AWS", "LOCALFOLDER"]
@@ -61,13 +56,29 @@ line-length = 120
 unfixable = ["F401"]
 ignore = ["F401", "E402"]
 
-[tool.pytest]
+[tool.pytest.ini_options]
 xfail_strict = true
+markers = [
+    "limit_memory: Mark test with memory limit for pytest-memray",
+]
+
+[tool.coverage.run]
+source = [
+    "plugins/",
+]
+relative_files = true
 
 [tool.coverage.report]
-exclude_lines = [
-    # Have to re-enable the standard pragma
-    "pragma: no cover",
+exclude_also = [
     # Don't complain if tests don't hit defensive assertion code:
     "raise NotImplementedError",
+    # Handling for botocore not being available is performed by AnsibleAWSModule
+    "try:\n(    import botocore\n|    import boto3\n)*except ImportError:\n    pass",
 ]
+include_namespace_packages = true
+
+[tool.coverage.html]
+directory = "coverage-report"
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/tests/integration/targets/wafv2_web_acl/tasks/main.yml
+++ b/tests/integration/targets/wafv2_web_acl/tasks/main.yml
@@ -547,6 +547,108 @@
         that:
           - out is not changed
 
+    #####################################################
+    # Test ByteMatch and RateBasedStatement idempotency
+    #####################################################
+    - name: Create web ACL with ByteMatch and RateBased rules
+      wafv2_web_acl:
+        name: "{{ resource_prefix }}-test-idempotency"
+        state: present
+        scope: REGIONAL
+        default_action: Allow
+        sampled_requests: no
+        cloudwatch_metrics: no
+        rules:
+          - name: byte-match-rule
+            priority: 1
+            action:
+              block: {}
+            statement:
+              byte_match_statement:
+                search_string: "badbot"
+                field_to_match:
+                  single_header:
+                    name: user-agent
+                text_transformations:
+                  - type: LOWERCASE
+                    priority: 0
+                positional_constraint: CONTAINS
+            visibility_config:
+              sampled_requests_enabled: yes
+              cloud_watch_metrics_enabled: no
+              metric_name: byte-match
+          - name: rate-limit-rule
+            priority: 2
+            action:
+              block: {}
+            statement:
+              rate_based_statement:
+                limit: 2000
+                aggregate_key_type: IP
+            visibility_config:
+              sampled_requests_enabled: yes
+              cloud_watch_metrics_enabled: no
+              metric_name: rate-limit
+      register: out
+
+    - name: Verify creation
+      assert:
+        that:
+          - out is changed
+
+    - name: Re-run same configuration (test idempotency)
+      wafv2_web_acl:
+        name: "{{ resource_prefix }}-test-idempotency"
+        state: present
+        scope: REGIONAL
+        default_action: Allow
+        sampled_requests: no
+        cloudwatch_metrics: no
+        rules:
+          - name: byte-match-rule
+            priority: 1
+            action:
+              block: {}
+            statement:
+              byte_match_statement:
+                search_string: "badbot"
+                field_to_match:
+                  single_header:
+                    name: user-agent
+                text_transformations:
+                  - type: LOWERCASE
+                    priority: 0
+                positional_constraint: CONTAINS
+            visibility_config:
+              sampled_requests_enabled: yes
+              cloud_watch_metrics_enabled: no
+              metric_name: byte-match
+          - name: rate-limit-rule
+            priority: 2
+            action:
+              block: {}
+            statement:
+              rate_based_statement:
+                limit: 2000
+                aggregate_key_type: IP
+            visibility_config:
+              sampled_requests_enabled: yes
+              cloud_watch_metrics_enabled: no
+              metric_name: rate-limit
+      register: out
+
+    - name: Verify idempotency (no changes)
+      assert:
+        that:
+          - out is not changed
+
+    - name: Cleanup idempotency test ACL
+      wafv2_web_acl:
+        name: "{{ resource_prefix }}-test-idempotency"
+        state: absent
+        scope: REGIONAL
+      ignore_errors: true
+
   always:
     ###################################
     # always delete wafv2 components

--- a/tests/unit/plugins/module_utils/wafv2/test_apply_rate_based_statement_defaults.py
+++ b/tests/unit/plugins/module_utils/wafv2/test_apply_rate_based_statement_defaults.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import apply_rate_based_statement_defaults
+
+
+class TestApplyRateBasedStatementDefaults:
+    """Test the apply_rate_based_statement_defaults function."""
+
+    def test_adds_default_evaluation_window_sec_when_missing(self):
+        """Test that evaluation_window_sec is added with default value 300 when not present."""
+        rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+            }
+        ]
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        assert result[0]["Statement"]["RateBasedStatement"]["EvaluationWindowSec"] == 300
+        assert result[0]["Statement"]["RateBasedStatement"]["Limit"] == 5000
+        assert result[0]["Statement"]["RateBasedStatement"]["AggregateKeyType"] == "IP"
+
+    def test_preserves_existing_evaluation_window_sec(self):
+        """Test that existing evaluation_window_sec values are not overwritten."""
+        rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                        "EvaluationWindowSec": 600,
+                    }
+                },
+            }
+        ]
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        assert result[0]["Statement"]["RateBasedStatement"]["EvaluationWindowSec"] == 600
+
+    def test_handles_multiple_rules(self):
+        """Test that function handles multiple rules correctly."""
+        rules = [
+            {
+                "Name": "rule-without-eval-window",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+            },
+            {
+                "Name": "rule-with-eval-window",
+                "Priority": 2,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 1000,
+                        "AggregateKeyType": "FORWARDED_IP",
+                        "EvaluationWindowSec": 120,
+                    }
+                },
+            },
+        ]
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        assert result[0]["Statement"]["RateBasedStatement"]["EvaluationWindowSec"] == 300
+        assert result[1]["Statement"]["RateBasedStatement"]["EvaluationWindowSec"] == 120
+
+    def test_ignores_non_rate_based_statements(self):
+        """Test that non-rate-based statements are not modified."""
+        rules = [
+            {
+                "Name": "byte-match-rule",
+                "Priority": 1,
+                "Statement": {
+                    "ByteMatchStatement": {
+                        "SearchString": "test",
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                        "PositionalConstraint": "CONTAINS",
+                    }
+                },
+            }
+        ]
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        # Should not add EvaluationWindowSec to non-rate-based statements
+        assert "RateBasedStatement" not in result[0]["Statement"]
+        assert "ByteMatchStatement" in result[0]["Statement"]
+
+    def test_handles_empty_rules_list(self):
+        """Test that function handles empty rules list."""
+        rules = []
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        assert result == []
+
+    def test_handles_rule_without_statement(self):
+        """Test that function handles rules without Statement field."""
+        rules = [
+            {
+                "Name": "incomplete-rule",
+                "Priority": 1,
+            }
+        ]
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        # Should not crash, just return the rule as-is
+        assert len(result) == 1
+        assert result[0]["Name"] == "incomplete-rule"
+
+    def test_does_not_modify_original_rules(self):
+        """Test that the function returns the same list object (modifies in place)."""
+        rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+            }
+        ]
+
+        result = apply_rate_based_statement_defaults(rules)
+
+        # The function modifies in place and returns the same list
+        assert result is rules
+        assert result[0]["Statement"]["RateBasedStatement"]["EvaluationWindowSec"] == 300

--- a/tests/unit/plugins/module_utils/wafv2/test_byte_values_to_strings.py
+++ b/tests/unit/plugins/module_utils/wafv2/test_byte_values_to_strings.py
@@ -1,0 +1,336 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import byte_values_to_strings_before_compare
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import nested_byte_values_to_strings
+
+
+class TestByteValuesToStringsBeforeCompare:
+    """Test the byte_values_to_strings_before_compare function."""
+
+    def test_converts_byte_match_statement_search_string(self):
+        """Test that ByteMatchStatement SearchString is converted from bytes to string."""
+        rules = [
+            {
+                "Name": "byte-match-rule",
+                "Priority": 1,
+                "Statement": {
+                    "ByteMatchStatement": {
+                        "SearchString": b"badbot",
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                        "PositionalConstraint": "CONTAINS",
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert result[0]["Statement"]["ByteMatchStatement"]["SearchString"] == "badbot"
+        assert isinstance(result[0]["Statement"]["ByteMatchStatement"]["SearchString"], str)
+
+    def test_handles_multiple_rules_with_byte_match(self):
+        """Test that function handles multiple rules with ByteMatchStatement."""
+        rules = [
+            {
+                "Name": "rule-1",
+                "Priority": 1,
+                "Statement": {
+                    "ByteMatchStatement": {
+                        "SearchString": b"bot1",
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                        "PositionalConstraint": "CONTAINS",
+                    }
+                },
+            },
+            {
+                "Name": "rule-2",
+                "Priority": 2,
+                "Statement": {
+                    "ByteMatchStatement": {
+                        "SearchString": b"bot2",
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                        "PositionalConstraint": "CONTAINS",
+                    }
+                },
+            },
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert result[0]["Statement"]["ByteMatchStatement"]["SearchString"] == "bot1"
+        assert result[1]["Statement"]["ByteMatchStatement"]["SearchString"] == "bot2"
+
+    def test_handles_non_byte_match_statements(self):
+        """Test that non-ByteMatchStatement rules are not modified."""
+        rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        # Should not modify non-ByteMatchStatement rules
+        assert "RateBasedStatement" in result[0]["Statement"]
+        assert result[0]["Statement"]["RateBasedStatement"]["Limit"] == 5000
+
+    def test_handles_or_statement_with_byte_match(self):
+        """Test that OrStatement with nested ByteMatchStatement is handled."""
+        rules = [
+            {
+                "Name": "or-statement-rule",
+                "Priority": 1,
+                "Statement": {
+                    "OrStatement": {
+                        "Statements": [
+                            {
+                                "ByteMatchStatement": {
+                                    "SearchString": b"bot1",
+                                    "FieldToMatch": {"UriPath": {}},
+                                    "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                    "PositionalConstraint": "CONTAINS",
+                                }
+                            },
+                            {
+                                "ByteMatchStatement": {
+                                    "SearchString": b"bot2",
+                                    "FieldToMatch": {"UriPath": {}},
+                                    "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                    "PositionalConstraint": "CONTAINS",
+                                }
+                            },
+                        ]
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert result[0]["Statement"]["OrStatement"]["Statements"][0]["ByteMatchStatement"]["SearchString"] == "bot1"
+        assert result[0]["Statement"]["OrStatement"]["Statements"][1]["ByteMatchStatement"]["SearchString"] == "bot2"
+
+    def test_handles_and_statement_with_byte_match(self):
+        """Test that AndStatement with nested ByteMatchStatement is handled."""
+        rules = [
+            {
+                "Name": "and-statement-rule",
+                "Priority": 1,
+                "Statement": {
+                    "AndStatement": {
+                        "Statements": [
+                            {
+                                "ByteMatchStatement": {
+                                    "SearchString": b"test",
+                                    "FieldToMatch": {"UriPath": {}},
+                                    "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                    "PositionalConstraint": "CONTAINS",
+                                }
+                            }
+                        ]
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert result[0]["Statement"]["AndStatement"]["Statements"][0]["ByteMatchStatement"]["SearchString"] == "test"
+
+    def test_handles_not_statement_with_byte_match(self):
+        """Test that NotStatement with nested ByteMatchStatement is handled."""
+        rules = [
+            {
+                "Name": "not-statement-rule",
+                "Priority": 1,
+                "Statement": {
+                    "NotStatement": {
+                        "Statements": [
+                            {
+                                "ByteMatchStatement": {
+                                    "SearchString": b"goodbot",
+                                    "FieldToMatch": {"UriPath": {}},
+                                    "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                    "PositionalConstraint": "CONTAINS",
+                                }
+                            }
+                        ]
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert (
+            result[0]["Statement"]["NotStatement"]["Statements"][0]["ByteMatchStatement"]["SearchString"] == "goodbot"
+        )
+
+    def test_handles_empty_rules_list(self):
+        """Test that function handles empty rules list."""
+        rules = []
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert result == []
+
+    def test_handles_utf8_characters(self):
+        """Test that UTF-8 characters are properly decoded."""
+        rules = [
+            {
+                "Name": "utf8-rule",
+                "Priority": 1,
+                "Statement": {
+                    "ByteMatchStatement": {
+                        "SearchString": "tëst".encode("utf-8"),
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                        "PositionalConstraint": "CONTAINS",
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        assert result[0]["Statement"]["ByteMatchStatement"]["SearchString"] == "tëst"
+
+    def test_modifies_in_place(self):
+        """Test that the function modifies the list in place."""
+        rules = [
+            {
+                "Name": "byte-match-rule",
+                "Priority": 1,
+                "Statement": {
+                    "ByteMatchStatement": {
+                        "SearchString": b"test",
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                        "PositionalConstraint": "CONTAINS",
+                    }
+                },
+            }
+        ]
+
+        result = byte_values_to_strings_before_compare(rules)
+
+        # The function modifies in place and returns the same list
+        assert result is rules
+        assert result[0]["Statement"]["ByteMatchStatement"]["SearchString"] == "test"
+
+
+class TestNestedByteValuesToStrings:
+    """Test the nested_byte_values_to_strings function."""
+
+    def test_converts_or_statement_byte_match(self):
+        """Test that OrStatement ByteMatchStatement is converted."""
+        rule = {
+            "Name": "or-rule",
+            "Priority": 1,
+            "Statement": {
+                "OrStatement": {
+                    "Statements": [
+                        {
+                            "ByteMatchStatement": {
+                                "SearchString": b"bot",
+                                "FieldToMatch": {"UriPath": {}},
+                                "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                "PositionalConstraint": "CONTAINS",
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+
+        result = nested_byte_values_to_strings(rule, "OrStatement")
+
+        assert result["Statement"]["OrStatement"]["Statements"][0]["ByteMatchStatement"]["SearchString"] == "bot"
+
+    def test_converts_and_statement_byte_match(self):
+        """Test that AndStatement ByteMatchStatement is converted."""
+        rule = {
+            "Name": "and-rule",
+            "Priority": 1,
+            "Statement": {
+                "AndStatement": {
+                    "Statements": [
+                        {
+                            "ByteMatchStatement": {
+                                "SearchString": b"test",
+                                "FieldToMatch": {"UriPath": {}},
+                                "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                "PositionalConstraint": "CONTAINS",
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+
+        result = nested_byte_values_to_strings(rule, "AndStatement")
+
+        assert result["Statement"]["AndStatement"]["Statements"][0]["ByteMatchStatement"]["SearchString"] == "test"
+
+    def test_converts_not_statement_byte_match(self):
+        """Test that NotStatement ByteMatchStatement is converted."""
+        rule = {
+            "Name": "not-rule",
+            "Priority": 1,
+            "Statement": {
+                "NotStatement": {
+                    "Statements": [
+                        {
+                            "ByteMatchStatement": {
+                                "SearchString": b"bad",
+                                "FieldToMatch": {"UriPath": {}},
+                                "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                                "PositionalConstraint": "CONTAINS",
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+
+        result = nested_byte_values_to_strings(rule, "NotStatement")
+
+        assert result["Statement"]["NotStatement"]["Statements"][0]["ByteMatchStatement"]["SearchString"] == "bad"
+
+    def test_handles_rule_without_specified_statement(self):
+        """Test that function handles rules without the specified statement type."""
+        rule = {
+            "Name": "simple-rule",
+            "Priority": 1,
+            "Statement": {
+                "RateBasedStatement": {
+                    "Limit": 5000,
+                    "AggregateKeyType": "IP",
+                }
+            },
+        }
+
+        result = nested_byte_values_to_strings(rule, "OrStatement")
+
+        # Should not modify the rule if it doesn't have the specified statement
+        assert "RateBasedStatement" in result["Statement"]
+        assert "OrStatement" not in result["Statement"]

--- a/tests/unit/plugins/module_utils/wafv2/test_compare_priority_rules.py
+++ b/tests/unit/plugins/module_utils/wafv2/test_compare_priority_rules.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+from ansible_collections.community.aws.plugins.module_utils.wafv2 import compare_priority_rules
+
+
+class TestComparePriorityRulesWithRateBasedDefaults:
+    """Test that compare_priority_rules correctly applies rate_based_statement defaults."""
+
+    def test_idempotency_with_default_evaluation_window_sec(self):
+        """Test that rules are considered equal when evaluation_window_sec matches AWS default."""
+        # User's rule (no evaluation_window_sec specified)
+        requested_rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit",
+                },
+            }
+        ]
+
+        # AWS returns with default evaluation_window_sec
+        existing_rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                        "EvaluationWindowSec": 300,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit",
+                },
+            }
+        ]
+
+        diff, merged_rules = compare_priority_rules(existing_rules, requested_rules, purge_rules=True, state="present")
+
+        # Should not detect a difference because the default is applied
+        assert diff is False
+        assert len(merged_rules) == 1
+
+    def test_detects_difference_with_non_default_evaluation_window_sec(self):
+        """Test that changes are detected when evaluation_window_sec differs from default."""
+        # User's rule with custom evaluation_window_sec
+        requested_rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                        "EvaluationWindowSec": 600,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit",
+                },
+            }
+        ]
+
+        # AWS returns with default evaluation_window_sec
+        existing_rules = [
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                        "EvaluationWindowSec": 300,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit",
+                },
+            }
+        ]
+
+        diff, merged_rules = compare_priority_rules(existing_rules, requested_rules, purge_rules=True, state="present")
+
+        # Should detect a difference because 600 != 300
+        assert diff is True
+
+    def test_idempotency_with_multiple_rate_based_rules(self):
+        """Test idempotency with multiple rate-based rules."""
+        requested_rules = [
+            {
+                "Name": "rule-1",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rule-1",
+                },
+            },
+            {
+                "Name": "rule-2",
+                "Priority": 2,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 1000,
+                        "AggregateKeyType": "FORWARDED_IP",
+                        "EvaluationWindowSec": 120,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rule-2",
+                },
+            },
+        ]
+
+        existing_rules = [
+            {
+                "Name": "rule-1",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                        "EvaluationWindowSec": 300,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rule-1",
+                },
+            },
+            {
+                "Name": "rule-2",
+                "Priority": 2,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 1000,
+                        "AggregateKeyType": "FORWARDED_IP",
+                        "EvaluationWindowSec": 120,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rule-2",
+                },
+            },
+        ]
+
+        diff, merged_rules = compare_priority_rules(existing_rules, requested_rules, purge_rules=True, state="present")
+
+        assert diff is False
+        assert len(merged_rules) == 2
+
+    def test_idempotency_with_mixed_rule_types(self):
+        """Test that non-rate-based rules are unaffected by the defaults when mixed with rate-based rules."""
+        requested_rules = [
+            {
+                "Name": "managed-rule",
+                "Priority": 1,
+                "OverrideAction": {"None": {}},
+                "Statement": {
+                    "ManagedRuleGroupStatement": {
+                        "VendorName": "AWS",
+                        "Name": "AWSManagedRulesCommonRuleSet",
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "managed-rule",
+                },
+            },
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 2,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit",
+                },
+            },
+        ]
+
+        existing_rules = [
+            {
+                "Name": "managed-rule",
+                "Priority": 1,
+                "OverrideAction": {"None": {}},
+                "Statement": {
+                    "ManagedRuleGroupStatement": {
+                        "VendorName": "AWS",
+                        "Name": "AWSManagedRulesCommonRuleSet",
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "managed-rule",
+                },
+            },
+            {
+                "Name": "rate-limit-rule",
+                "Priority": 2,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 5000,
+                        "AggregateKeyType": "IP",
+                        "EvaluationWindowSec": 300,
+                    }
+                },
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit",
+                },
+            },
+        ]
+
+        diff, merged_rules = compare_priority_rules(existing_rules, requested_rules, purge_rules=True, state="present")
+
+        assert diff is False
+        assert len(merged_rules) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = True
 envlist =
     ansible{2.17}-py{310,311,312}-{with_constraints,without_constraints}
     ansible{2.18,2.19}-py{311,312,313}-{with_constraints,without_constraints}
-    ansible{2.17}-py{312,313,314}-{with_constraints,without_constraints}
+    ansible{2.20}-py{312,313,314}-{with_constraints,without_constraints}
 
 [common]
 collection_name = community.aws
@@ -36,7 +36,10 @@ set_env =
 # not needed if unit tests are under tests/unit/plugins rather than directly under tests/unit
 #  ANSIBLE_CONTROLLER_MIN_PYTHON_VERSION=3.11
 #  PYTEST_PLUGINS=ansible_test._util.target.pytest.plugins.ansible_pytest_collections
-labels = unit
+labels =
+    unit
+    ansible2.17-py310-with_constraints: unit-oldest
+    ansible2.20-py314-without_constraints: unit-newest
 deps =
   pytest
   mock
@@ -44,6 +47,7 @@ deps =
   pytest-cov
   pytest-ansible
   pytest-xdist
+  pytest-memray
   -rtest-requirements.txt
   -rtests/unit/requirements.txt
   ansible2.17: ansible-core>2.17,<2.18
@@ -54,31 +58,26 @@ deps =
 allowlist_externals = rsync
 change_dir = {[common]full_collection_path}
 commands_pre =
-  rsync --delete --exclude=.tox -qraugpo {toxinidir}/ {[common]full_collection_path}/
+  rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
   ansible-galaxy collection install git+https://github.com/ansible-collections/amazon.aws.git
 commands =
     pytest \
+        --cov \
         --cov-report html \
-        --cov plugins/inventory \
-        --cov plugins/module_utils \
-        --cov plugins/modules \
-        --cov plugins \
+        --cov-report xml \
         --ansible-host-pattern localhost \
         {posargs:tests/unit/}
-# We don't have these in community
-#        --cov plugins/plugin_utils \
-#        --cov plugins/callback \
-#        --cov plugins/lookup \
 
 [testenv:clean]
 description = Remove test results and caches
-allowlist_externals = rm
+allowlist_externals = rm, find
 deps = coverage
 skip_install = true
 change_dir = {toxinidir}
 commands_pre =
 commands =
     coverage erase
+    find .tox -name coverage.xml -delete
     rm -rf tests/output/ htmlcov/ .mypy_cache/ complexity/ .ruff_cache/
 
 [testenv:complexity-report]
@@ -266,7 +265,7 @@ deps =
   placebo
   typing_extensions
 commands_pre =
-  rsync --delete --exclude=.tox -qraugpo {toxinidir}/ {[common]full_collection_path}/
+  rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
   ansible-galaxy collection install git+https://github.com/ansible-collections/amazon.aws.git
   ln -s {env_site_packages_dir}/ansible {[common]ansible_collections_path}/ansible
   ln -s {[common]ansible_home}/collections/ansible_collections {[common]ansible_home}/ansible_collections


### PR DESCRIPTION
##### SUMMARY
Fixed idempotency issue where rules with rate_based_statement would always show as changed when evaluation_window_sec was not explicitly specified. AWS returns the default value of 300, but the module was not applying this default before comparison. Also updated documentation and test infrastructure.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
wafv2_web_acl

##### ADDITIONAL INFORMATION
- Added apply_rate_based_statement_defaults() function to apply AWS default values before comparison
- Added comprehensive unit tests for wafv2 module_utils functions
- Added integration test for ByteMatch and RateBased statement idempotency
- Updated RETURN documentation for read-only web ACL fields
- Updated PARAMETERS documentation to include rules.override_action which was automatically supported when the API was updated.
- Synced tox.ini and pyproject.toml configuration with amazon.aws collection

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>