### PR TITLE
api_gateway_domain - Add TLS1.2 and TLS1.3 security policies

### DIFF
--- a/changelogs/fragments/api_gateway_domain-add-security-policies.yml
+++ b/changelogs/fragments/api_gateway_domain-add-security-policies.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_gateway_domain - Add additional TLS1.2 and TLS1.3 security policies (https://github.com/ansible-collections/community.aws/issues/2431).

--- a/plugins/modules/api_gateway_domain.py
+++ b/plugins/modules/api_gateway_domain.py
@@ -32,7 +32,7 @@ options:
     description:
       - Set allowed TLS versions through AWS defined policies. Currently only C(TLS_1_0) and C(TLS_1_2) are available.
     default: TLS_1_2
-    choices: ['TLS_1_0', 'TLS_1_2']
+    choices: ['TLS_1_0', 'TLS_1_2', 'SecurityPolicy_TLS13_1_3_2025_09', 'SecurityPolicy_TLS13_1_3_FIPS_2025_09', 'SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_2021_06', 'SecurityPolicy_TLS13_2025_EDGE', 'SecurityPolicy_TLS12_PFS_2025_EDGE', 'SecurityPolicy_TLS12_2018_EDGE']
     type: str
   endpoint_type:
     description:
@@ -305,7 +305,24 @@ def main():
     argument_spec = dict(
         domain_name=dict(type="str", required=True),
         certificate_arn=dict(type="str", required=True),
-        security_policy=dict(type="str", default="TLS_1_2", choices=["TLS_1_0", "TLS_1_2"]),
+        security_policy=dict(
+            type="str",
+            default="TLS_1_2",
+            choices=[
+                "SecurityPolicy_TLS12_2018_EDGE",
+                "SecurityPolicy_TLS12_PFS_2025_EDGE",
+                "SecurityPolicy_TLS13_1_2_2021_06",
+                "SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09",
+                "SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09",
+                "SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09",
+                "SecurityPolicy_TLS13_1_2_PQ_2025_09",
+                "SecurityPolicy_TLS13_1_3_2025_09",
+                "SecurityPolicy_TLS13_1_3_FIPS_2025_09",
+                "SecurityPolicy_TLS13_2025_EDGE",
+                "TLS_1_0",
+                "TLS_1_2",
+            ],
+        ),
         endpoint_type=dict(type="str", default="EDGE", choices=["EDGE", "REGIONAL", "PRIVATE"]),
         domain_mappings=dict(type="list", required=True, elements="dict"),
         state=dict(type="str", default="present", choices=["present", "absent"]),

--- a/plugins/modules/api_gateway_domain.py
+++ b/plugins/modules/api_gateway_domain.py
@@ -32,7 +32,19 @@ options:
     description:
       - Set allowed TLS versions through AWS defined policies. Currently only C(TLS_1_0) and C(TLS_1_2) are available.
     default: TLS_1_2
-    choices: ['TLS_1_0', 'TLS_1_2', 'SecurityPolicy_TLS13_1_3_2025_09', 'SecurityPolicy_TLS13_1_3_FIPS_2025_09', 'SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_PQ_2025_09', 'SecurityPolicy_TLS13_1_2_2021_06', 'SecurityPolicy_TLS13_2025_EDGE', 'SecurityPolicy_TLS12_PFS_2025_EDGE', 'SecurityPolicy_TLS12_2018_EDGE']
+    choices:
+      - SecurityPolicy_TLS12_2018_EDGE
+      - SecurityPolicy_TLS12_PFS_2025_EDGE
+      - SecurityPolicy_TLS13_1_2_2021_06
+      - SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09
+      - SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09
+      - SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09
+      - SecurityPolicy_TLS13_1_2_PQ_2025_09
+      - SecurityPolicy_TLS13_1_3_2025_09
+      - SecurityPolicy_TLS13_1_3_FIPS_2025_09
+      - SecurityPolicy_TLS13_2025_EDGE
+      - TLS_1_0
+      - TLS_1_2
     type: str
   endpoint_type:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AWS recently introduced additional security policies for custom domain names used by API Gateways:

https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies-list.html https://docs.aws.amazon.com/boto3/latest/reference/services/apigateway/client/create_domain_name.html

This pull request adds the newly added policies to the list of available options:

- `SecurityPolicy_TLS12_2018_EDGE`
- `SecurityPolicy_TLS12_PFS_2025_EDGE`
- `SecurityPolicy_TLS13_1_2_2021_06`
- `SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09`
- `SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09`
- `SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09`
- `SecurityPolicy_TLS13_1_2_PQ_2025_09`
- `SecurityPolicy_TLS13_1_3_2025_09`
- `SecurityPolicy_TLS13_1_3_FIPS_2025_09`
- `SecurityPolicy_TLS13_2025_EDGE`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
api_gateway_domain

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->