### PR TITLE
cloudfront_distribution_info: Add integration tests

### DIFF
--- a/tests/integration/targets/cloudfront_distribution/aliases
+++ b/tests/integration/targets/cloudfront_distribution/aliases
@@ -1,1 +1,3 @@
 cloud/aws
+
+cloudfront_distribution_info

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -709,9 +709,9 @@
       that:
         - not cf_oai_info.changed
         - cf_oai_info.cloudfront is defined
-        - cf_oai_info.cloudfront.origin_access_identity is defined
-        - cf_oai_info.cloudfront.origin_access_identity.CloudFrontOriginAccessIdentity.Id == _origin_access_id.cloud_front_origin_access_identity.id
-        - cf_oai_info.cloudfront.origin_access_identity.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig.Comment == "this is a sample origin access identity"
+        - _origin_access_id.cloud_front_origin_access_identity.id in cf_oai_info.cloudfront
+        - cf_oai_info.cloudfront[_origin_access_id.cloud_front_origin_access_identity.id].CloudFrontOriginAccessIdentity.Id == _origin_access_id.cloud_front_origin_access_identity.id
+        - cf_oai_info.cloudfront[_origin_access_id.cloud_front_origin_access_identity.id].CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig.Comment == "this is a sample origin access identity"
 
   - name: get origin access identity config
     cloudfront_distribution_info:
@@ -724,8 +724,9 @@
       that:
         - not cf_oai_config.changed
         - cf_oai_config.cloudfront is defined
-        - cf_oai_config.cloudfront.origin_access_identity_configuration is defined
-        - cf_oai_config.cloudfront.origin_access_identity_configuration.Comment == "this is a sample origin access identity"
+        - _origin_access_id.cloud_front_origin_access_identity.id in cf_oai_config.cloudfront
+        - cf_oai_config.cloudfront[_origin_access_id.cloud_front_origin_access_identity.id].CloudFrontOriginAccessIdentityConfig is defined
+        - cf_oai_config.cloudfront[_origin_access_id.cloud_front_origin_access_identity.id].CloudFrontOriginAccessIdentityConfig.Comment == "this is a sample origin access identity"
 
   - name: list origin access identities
     cloudfront_distribution_info:
@@ -738,7 +739,7 @@
         - not cf_oai_list.changed
         - cf_oai_list.cloudfront is defined
         - cf_oai_list.cloudfront.origin_access_identities is defined
-        - cf_oai_list.cloudfront.origin_access_identities.CloudFrontOriginAccessIdentityList.Items | selectattr('Id', 'equalto', _origin_access_id.cloud_front_origin_access_identity.id) | list | length == 1
+        - cf_oai_list.cloudfront.origin_access_identities | selectattr('Id', 'equalto', _origin_access_id.cloud_front_origin_access_identity.id) | list | length == 1
 
   - name: update distribution to use cache_policy_id and origin_request_policy_id
     cloudfront_distribution:
@@ -770,7 +771,7 @@
         - cf_all_lists.cloudfront.origin_access_identities is defined
         - cf_all_lists.cloudfront.streaming_distributions is defined
         - distribution_id in cf_all_lists.cloudfront.distributions
-        - cf_all_lists.cloudfront.origin_access_identities.CloudFrontOriginAccessIdentityList.Items | selectattr('Id', 'equalto', _origin_access_id.cloud_front_origin_access_identity.id) | list | length == 1
+        - cf_all_lists.cloudfront.origin_access_identities | selectattr('Id', 'equalto', _origin_access_id.cloud_front_origin_access_identity.id) | list | length == 1
 
   always:
   # TEARDOWN STARTS HERE
@@ -780,6 +781,22 @@
       state: absent
       force: true
     ignore_errors: true
+
+  - name: wait for distributions to finish deploying before cleanup
+    cloudfront_distribution_info:
+      distribution: true
+      distribution_id: "{{ item }}"
+    register: _dist_status
+    until: >-
+      item not in _dist_status.cloudfront or
+      _dist_status.cloudfront[item].Distribution.Status == 'Deployed'
+    retries: 60
+    delay: 10
+    ignore_errors: true
+    loop:
+      - '{{ cf_second_distribution.id | default("") }}'
+      - '{{ cf_distribution.id | default("") }}'
+    when: item != ""
 
   - name: clean up cloudfront distribution
     cloudfront_distribution:

--- a/tests/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/tests/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -25,6 +25,69 @@
   - set_fact:
       distribution_id: '{{ cf_distribution.id }}'
 
+  # cloudfront_distribution_info tests - test early to fail fast
+  - name: get distribution info by distribution_id
+    cloudfront_distribution_info:
+      distribution: true
+      distribution_id: "{{ distribution_id }}"
+    register: cf_info_by_id
+
+  - name: ensure distribution info was returned
+    assert:
+      that:
+        - not cf_info_by_id.changed
+        - cf_info_by_id.cloudfront is defined
+        - distribution_id in cf_info_by_id.cloudfront
+        - cf_info_by_id.cloudfront[distribution_id].Distribution.Id == distribution_id
+        - cf_info_by_id.cloudfront[distribution_id].Distribution.Status is defined
+        - cf_info_by_id.cloudfront.result is defined
+        - cf_info_by_id.cloudfront.result.Distribution.Id == distribution_id
+
+  - name: get distribution config by distribution_id
+    cloudfront_distribution_info:
+      distribution_config: true
+      distribution_id: "{{ distribution_id }}"
+    register: cf_config_by_id
+
+  - name: ensure distribution config was returned
+    assert:
+      that:
+        - not cf_config_by_id.changed
+        - cf_config_by_id.cloudfront is defined
+        - distribution_id in cf_config_by_id.cloudfront
+        - cf_config_by_id.cloudfront[distribution_id].DistributionConfig is defined
+        - cf_config_by_id.cloudfront[distribution_id].DistributionConfig.Origins is defined
+        - cf_config_by_id.cloudfront.result is defined
+        - cf_config_by_id.cloudfront.result.DistributionConfig is defined
+
+  - name: list all distributions
+    cloudfront_distribution_info:
+      list_distributions: true
+    register: cf_list
+
+  - name: ensure distribution list contains our distribution
+    assert:
+      that:
+        - not cf_list.changed
+        - cf_list.cloudfront is defined
+        - cf_list.cloudfront.distributions is defined
+        - distribution_id in cf_list.cloudfront.distributions
+        - cf_list.cloudfront.distributions[distribution_id].Id == distribution_id
+
+  - name: get summary of all cloudfront resources
+    cloudfront_distribution_info:
+      summary: true
+    register: cf_summary
+
+  - name: ensure summary was returned
+    assert:
+      that:
+        - not cf_summary.changed
+        - cf_summary.cloudfront is defined
+        - cf_summary.cloudfront.summary is defined
+        - cf_summary.cloudfront.summary.distributions is defined
+        - cf_summary.cloudfront.summary.distributions | selectattr('Id', 'equalto', distribution_id) | list | length == 1
+
   - name: ensure that default value of 'enabled' is 'true'
     assert:
       that:
@@ -635,6 +698,48 @@
         - result.origins['quantity'] > 0
         - result.origins['elements'] | selectattr('s3_origin_config', 'defined') | map(attribute='s3_origin_config') | selectattr('origin_access_identity', 'eq', origin_access_identity) | list | length == 1
 
+  - name: get origin access identity info
+    cloudfront_distribution_info:
+      origin_access_identity: true
+      origin_access_identity_id: "{{ _origin_access_id.cloud_front_origin_access_identity.id }}"
+    register: cf_oai_info
+
+  - name: ensure origin access identity info was returned
+    assert:
+      that:
+        - not cf_oai_info.changed
+        - cf_oai_info.cloudfront is defined
+        - cf_oai_info.cloudfront.origin_access_identity is defined
+        - cf_oai_info.cloudfront.origin_access_identity.CloudFrontOriginAccessIdentity.Id == _origin_access_id.cloud_front_origin_access_identity.id
+        - cf_oai_info.cloudfront.origin_access_identity.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig.Comment == "this is a sample origin access identity"
+
+  - name: get origin access identity config
+    cloudfront_distribution_info:
+      origin_access_identity_config: true
+      origin_access_identity_id: "{{ _origin_access_id.cloud_front_origin_access_identity.id }}"
+    register: cf_oai_config
+
+  - name: ensure origin access identity config was returned
+    assert:
+      that:
+        - not cf_oai_config.changed
+        - cf_oai_config.cloudfront is defined
+        - cf_oai_config.cloudfront.origin_access_identity_configuration is defined
+        - cf_oai_config.cloudfront.origin_access_identity_configuration.Comment == "this is a sample origin access identity"
+
+  - name: list origin access identities
+    cloudfront_distribution_info:
+      list_origin_access_identities: true
+    register: cf_oai_list
+
+  - name: ensure origin access identity list contains our OAI
+    assert:
+      that:
+        - not cf_oai_list.changed
+        - cf_oai_list.cloudfront is defined
+        - cf_oai_list.cloudfront.origin_access_identities is defined
+        - cf_oai_list.cloudfront.origin_access_identities.CloudFrontOriginAccessIdentityList.Items | selectattr('Id', 'equalto', _origin_access_id.cloud_front_origin_access_identity.id) | list | length == 1
+
   - name: update distribution to use cache_policy_id and origin_request_policy_id
     cloudfront_distribution:
       distribution_id: "{{ distribution_id }}"
@@ -650,6 +755,22 @@
         - update_distribution_with_cache_policies.changed
         - update_distribution_with_cache_policies.default_cache_behavior.cache_policy_id == '658327ea-f89d-4fab-a63d-7e88639e58f6'
         - update_distribution_with_cache_policies.default_cache_behavior.origin_request_policy_id == '88a5eaf4-2fd4-4709-b370-b4c650ea3fcf'
+
+  - name: get all lists using all_lists parameter
+    cloudfront_distribution_info:
+      all_lists: true
+    register: cf_all_lists
+
+  - name: ensure all lists were returned
+    assert:
+      that:
+        - not cf_all_lists.changed
+        - cf_all_lists.cloudfront is defined
+        - cf_all_lists.cloudfront.distributions is defined
+        - cf_all_lists.cloudfront.origin_access_identities is defined
+        - cf_all_lists.cloudfront.streaming_distributions is defined
+        - distribution_id in cf_all_lists.cloudfront.distributions
+        - cf_all_lists.cloudfront.origin_access_identities.CloudFrontOriginAccessIdentityList.Items | selectattr('Id', 'equalto', _origin_access_id.cloud_front_origin_access_identity.id) | list | length == 1
 
   always:
   # TEARDOWN STARTS HERE


### PR DESCRIPTION
##### SUMMARY

Added comprehensive integration tests for cloudfront_distribution_info module:
- Get distribution info by distribution_id
- Get distribution config by distribution_id
- List all distributions
- Get summary of all CloudFront resources
- Get origin access identity info
- Get origin access identity config
- List origin access identities
- Get all lists using all_lists parameter

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

cloudfront_distribution_info

##### ADDITIONAL INFORMATION

Avoid regressions of #1915 
