### PR TITLE
ACA-6402 Modify autoscaling_policy module to enforce floats for StepScaling bounds

### DIFF
--- a/changelogs/fragments/2355-float-stepscaling-bounds.yml
+++ b/changelogs/fragments/2355-float-stepscaling-bounds.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - autoscaling_policy - allow float type for step_adjustments lower_bound and upper_bound parameters (https://github.com/ansible-collections/community.aws/issues/2355)

--- a/changelogs/fragments/2355-float-stepscaling-bounds.yml
+++ b/changelogs/fragments/2355-float-stepscaling-bounds.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - autoscaling_policy - allow float type for step_adjustments lower_bound and upper_bound parameters (https://github.com/ansible-collections/community.aws/issues/2355)
+  - autoscaling_policy - allow float type for ``step_adjustments`` ``lower_bound`` and ``upper_bound`` parameters (https://github.com/ansible-collections/community.aws/issues/2355)

--- a/plugins/modules/autoscaling_policy.py
+++ b/plugins/modules/autoscaling_policy.py
@@ -94,12 +94,12 @@ options:
     elements: dict
     suboptions:
       lower_bound:
-        type: int
+        type: float
         description:
           - The lower bound for the difference between the alarm threshold and
             the CloudWatch metric.
       upper_bound:
-        type: int
+        type: float
         description:
           - The upper bound for the difference between the alarm threshold and
             the CloudWatch metric.
@@ -549,7 +549,9 @@ def delete_scaling_policy(connection, module):
 
 def main():
     step_adjustment_spec = dict(
-        lower_bound=dict(type="int"), upper_bound=dict(type="int"), scaling_adjustment=dict(type="int", required=True)
+        lower_bound=dict(type="float"),
+        upper_bound=dict(type="float"),
+        scaling_adjustment=dict(type="int", required=True),
     )
 
     predefined_metric_spec = dict(

--- a/tests/integration/targets/autoscaling_policy/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_policy/tasks/main.yml
@@ -153,6 +153,52 @@
           - result.changed
           - result.adjustment_type == "PercentChangeInCapacity"
 
+    - name: Update Step Scaling policy with float bounds
+      autoscaling_policy:
+        name: "{{ resource_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        policy_type: StepScaling
+        metric_aggregation: Maximum
+        step_adjustments:
+        - upper_bound: 10.5
+          scaling_adjustment: 50
+        - lower_bound: 10.5
+          upper_bound: 30.75
+          scaling_adjustment: 75
+        - lower_bound: 30.75
+          scaling_adjustment: 100
+        adjustment_type: "PercentChangeInCapacity"
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == resource_prefix ~ '_stepscaling_policy'
+          - result.changed
+
+    - name: Update Step Scaling policy with float bounds (idempotency)
+      autoscaling_policy:
+        name: "{{ resource_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        policy_type: StepScaling
+        metric_aggregation: Maximum
+        step_adjustments:
+        - upper_bound: 10.5
+          scaling_adjustment: 50
+        - lower_bound: 10.5
+          upper_bound: 30.75
+          scaling_adjustment: 75
+        - lower_bound: 30.75
+          scaling_adjustment: 100
+        adjustment_type: "PercentChangeInCapacity"
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == resource_prefix ~ '_stepscaling_policy'
+          - not result.changed
+
     - name: Remove Step Scaling policy
       autoscaling_policy:
         name: "{{ resource_prefix }}_stepscaling_policy"


### PR DESCRIPTION
##### SUMMARY
This pull request fixes a bug in the `autoscaling_policy` module by allowing the `lower_bound` and `upper_bound` parameters in `step_adjustments` to accept float values instead of just integers. This change ensures more flexibility and accuracy when configuring autoscaling policies.

Bugfix for step scaling bounds:

* Updated the `autoscaling_policy` module to allow `lower_bound` and `upper_bound` in `step_adjustments` to be floats, both in the module argument specification and in the main function definition. [[1]](diffhunk://#diff-2fba284ead6077c6eda697053cd916af1d0f0527632b6d69898c1671acf79d87L97-R102) [[2]](diffhunk://#diff-2fba284ead6077c6eda697053cd916af1d0f0527632b6d69898c1671acf79d87L552-R552)
* Added a changelog entry documenting that `lower_bound` and `upper_bound` now accept float types.

Fixes #2355.

##### ISSUE TYPE
- Bugfix Pull Request