### PR TITLE
test(directconnect_link_aggregation_group): use module_utils.botocore for imports

### DIFF
--- a/tests/unit/plugins/modules/test_directconnect_link_aggregation_group.py
+++ b/tests/unit/plugins/modules/test_directconnect_link_aggregation_group.py
@@ -16,8 +16,8 @@ import os
 import pytest
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import get_aws_connection_info
 
 from ansible_collections.community.aws.plugins.modules import directconnect_link_aggregation_group as lag_module
 


### PR DESCRIPTION
##### SUMMARY

Update unit test to use `module_utils.botocore` instead of deprecated `module_utils.ec2` for boto3_conn and get_aws_connection_info imports.

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

directconnect_link_aggregation_group

##### ADDITIONAL INFORMATION
