### PR TITLE
ci: add Dependabot for GitHub Actions and pin actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+---
+# Dependabot configuration for GitHub Actions updates
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Monitor GitHub Actions for version updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Group all GitHub Actions updates into a single PR to reduce noise
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Keep commit messages conventional and concise
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    # Limit number of open PRs
+    open-pull-requests-limit: 5
+    # Add labels for easy identification
+    labels:
+      - "dependencies"
+      - "github_actions"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Retrieve pull request base ref
         id: retrieve-pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.source_dir }}"
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.source_dir }}"
           fetch-depth: 0
@@ -89,20 +89,20 @@ jobs:
     name: "${{ matrix.job-id }}"
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.source_dir }}"
           ref: ${{ needs.retrieve-pr-info.outputs.head_ref }}
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.source_dir }}"
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout the amazon.aws collection need to run tests.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ansible-collections/amazon.aws
           ref: ${{ needs.retrieve-pr-info.outputs.base_ref }}


### PR DESCRIPTION
##### SUMMARY
Add Dependabot configuration to automatically monitor and update GitHub Actions dependencies.
Pin all tag-based action references to commit SHAs for supply chain security.

##### ISSUE TYPE
CI/CD Pull Request

##### COMPONENT NAME
.github/dependabot.yml, .github/workflows/integration.yml

##### ADDITIONAL INFORMATION
Changes:
- Add `.github/dependabot.yml` with weekly update schedule
- Configure grouped updates to reduce PR noise
- Pin `actions/checkout@v6` to commit SHA `df4cb1c069e1874edd31b4311f1884172cec0e10`
- Pin `actions/github-script@v7` to commit SHA `f28e40c7f34bde8b3046d885e986cb6290c5673b`
- Set appropriate labels for dependency PRs

This improves supply chain security by pinning GitHub Actions to specific commits while allowing Dependabot to automatically suggest updates.

Assisted-by: Claude Sonnet 4.5